### PR TITLE
Don't select the weapon if equipNow is set to false and the player has it when calling Give

### DIFF
--- a/source/scripting_v3/GTA/Weapons/WeaponCollection.cs
+++ b/source/scripting_v3/GTA/Weapons/WeaponCollection.cs
@@ -145,7 +145,10 @@ namespace GTA
 
 			if (weapon.IsPresent)
 			{
-				Select(weapon);
+				if (equipNow)
+				{
+					Select(weapon);
+				}
 			}
 			else
 			{


### PR DESCRIPTION
This is a weird thing I found when trying to update one of my projects.

When the player still has the weapon that we are trying to give to him, it will always call Switch without checking the equipNow parameter.

This PR simply just skips the call to Select if equipNow is not set to false.