### PR TITLE
Add support for loading multiple ScriptDomains

### DIFF
--- a/source/core/DllMain.cpp
+++ b/source/core/DllMain.cpp
@@ -122,6 +122,47 @@ public:
 			console->PrintInfo(IO::Path::GetFileName(script->Filename) + " ~h~" + script->Name + (script->IsRunning ? (script->IsPaused ? " ~o~[paused]" : " ~g~[running]") : " ~r~[aborted]"));
 	}
 
+	[SHVDN::ConsoleCommand("List all loaded domains")]
+	static void ListDomains()
+	{
+		console->PrintInfo("~c~--- Loaded Domains ---");
+		console->PrintInfo("[ROOT] " + domain->Name + " -> " + domain->ScriptPath);
+		ListSubDomains(domain);
+	}
+
+	static void ListSubDomains(SHVDN::ScriptDomain ^d)
+	{
+		for each (auto sub in d->SubDomains) {
+			console->PrintInfo(sub->Name + " -> " + sub->ScriptPath);
+			ListSubDomains(sub);
+		}
+	}
+
+	[SHVDN::ConsoleCommand("Load a sub domain into root ScriptDomain")]
+	static void LoadSubDomain(String ^scriptDirectory)
+	{
+		domain->LoadSubDomain(scriptDirectory);
+	}
+
+
+	[SHVDN::ConsoleCommand("Unload a sub domain from root ScriptDomain")]
+	static void UnloadSubDomain(String ^name)
+	{
+		try {
+			for each (auto sub in domain->SubDomains) {
+				if (sub->Name == name)
+				{
+					domain->UnloadSubDomain(sub);
+					return;
+				}
+			}
+			throw gcnew KeyNotFoundException("Specified domain was not found");
+		}
+		catch (Exception^ ex) {
+			console->PrintError("Failed to unload domain: " + ex->ToString());
+		}
+	}
+
 internal:
 	static SHVDN::Console ^console = nullptr;
 	static SHVDN::ScriptDomain ^domain = SHVDN::ScriptDomain::CurrentDomain;


### PR DESCRIPTION
Implemented as tree-like domain chain, parent domain will dispatch events to child/sub domains. Still sketchy, but should provide a way to load/unload individual domains with the console. 

To avoid repeated memory scanning, I think a shared dictionary can be used to cache the pattern and corresponding offset.

Any feedback/suggestion will be appreciated