### PR TITLE
Add Ped.CombatTarget and properties and methods for script task status

### DIFF
--- a/source/scripting_v3/GTA/Entities/Peds/Ped.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Ped.cs
@@ -582,7 +582,7 @@ namespace GTA
 		/// otherwise, <see cref="ScriptTaskStatus.Vacant"/> as it is internally used in the game code outside native functions.
 		/// This parameter is passed uninitialized.
 		/// </param>
-		public void GetScriptTaskNameHashAndStatus(out ScriptTaskNameHash nameHash, out ScriptTaskStatus status)
+		public void GetCurrentScriptTaskNameHashAndStatus(out ScriptTaskNameHash nameHash, out ScriptTaskStatus status)
 		{
 			SHVDN.NativeMemory.GetScriptTaskHashAndStatus(Handle, out uint nameHashUInt, out uint statusUInt);
 			nameHash = (ScriptTaskNameHash)nameHashUInt;

--- a/source/scripting_v3/GTA/Entities/Peds/Ped.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Ped.cs
@@ -560,7 +560,65 @@ namespace GTA
 		/// <summary>
 		/// Gets the script task status of specified scripted task on this <see cref="Ped"/>.
 		/// </summary>
-		public ScriptTaskStatus GetScriptTaskStatus(ScriptTaskNameHash taskNameHash) => Function.Call<ScriptTaskStatus>(Hash.GET_SCRIPT_TASK_STATUS, Handle, (uint)taskNameHash);
+		/// <value>
+		/// The value of the current script task status if the <see cref="Ped"/> exists and has their intelligence instance,
+		/// and then <paramref name="taskNameHash"/> matches the current task name hash or <see cref="ScriptTaskNameHash.Any"/>;
+		/// otherwise, <see cref="ScriptTaskStatus.Finished"/>.
+		/// </value>
+		public ScriptTaskStatus GetScriptTaskStatus(ScriptTaskNameHash taskNameHash)
+			// Although GET_SCRIPT_TASK_STATUS does additional check if the game is multiplier mode and the hash does not match, we won't encounter such case
+			=> Function.Call<ScriptTaskStatus>(Hash.GET_SCRIPT_TASK_STATUS, Handle, (uint)taskNameHash);
+
+		/// <summary>
+		/// Gets the current script task name hash and status on this <see cref="Ped"/>.
+		/// </summary>
+		/// <param name="nameHash">
+		/// When this method returns, contains the value of the current script task name hash, if the <see cref="Ped"/> exists and has their intelligence instance;
+		/// otherwise, <see cref="ScriptTaskNameHash.Invalid"/> as it is internally used in the game code outside native functions.
+		/// This parameter is passed uninitialized.
+		/// </param>
+		/// <param name="status">
+		/// When this method returns, contains the value of the current script task status, if the <see cref="Ped"/> exists and has their intelligence instance;
+		/// otherwise, <see cref="ScriptTaskStatus.Vacant"/> as it is internally used in the game code outside native functions.
+		/// This parameter is passed uninitialized.
+		/// </param>
+		public void GetScriptTaskNameHashAndStatus(out ScriptTaskNameHash nameHash, out ScriptTaskStatus status)
+		{
+			SHVDN.NativeMemory.GetScriptTaskHashAndStatus(Handle, out uint nameHashUInt, out uint statusUInt);
+			nameHash = (ScriptTaskNameHash)nameHashUInt;
+			status = (ScriptTaskStatus)statusUInt;
+		}
+
+		/// <summary>
+		/// Gets the current script task name hash on this <see cref="Ped"/>.
+		/// </summary>
+		/// <value>
+		/// The value of the current script task name hash if the <see cref="Ped"/> exists and has their intelligence instance;
+		/// otherwise, <see cref="ScriptTaskNameHash.Invalid"/> as it is internally used in the game code outside native functions.
+		/// </value>
+		public ScriptTaskStatus CurrentScriptTaskNameHash
+		{
+			get
+			{
+				SHVDN.NativeMemory.GetScriptTaskHashAndStatus(Handle, _, out uint scriptTaskStatus);
+				return (ScriptTaskStatus)scriptTaskStatus;
+			}
+		}
+		/// <summary>
+		/// Gets the current script task status on this <see cref="Ped"/>.
+		/// </summary>
+		/// <value>
+		/// The value of the current script task status if the <see cref="Ped"/> exists and has their intelligence instance;
+		/// otherwise, <see cref="ScriptTaskStatus.Vacant"/> as it is internally used in the game code outside native functions.
+		/// </value>
+		public ScriptTaskStatus CurrentScriptTaskStatus
+		{
+			get
+			{
+				SHVDN.NativeMemory.GetScriptTaskHashAndStatus(Handle, _, out uint scriptTaskStatus);
+				return (ScriptTaskStatus)scriptTaskStatus;
+			}
+		}
 
 		/// <summary>
 		/// Gets Returns the state of any active <see cref="TaskInvoker.FollowNavMeshTo(GTA.Math.Vector3, PedMoveBlendRatio, int, float, FollowNavMeshFlags, float, float, float, float)"/>
@@ -1284,6 +1342,22 @@ namespace GTA
 		/// <see langword="true" /> if this <see cref="Ped"/> was killed by a takedown; otherwise, <see langword="false" />.
 		/// </value>
 		public bool WasKilledByTakedown => Function.Call<bool>(Hash.WAS_PED_KILLED_BY_TAKEDOWN, Handle);
+
+		/// <summary>
+		/// Gets the combat target <see cref="Ped"/> who this <see cref="Ped"/> is in combat with for a <c>CTaskCombat</c> of this <see cref="Ped"/>.
+		/// </summary>
+		/// <remarks>
+		/// Although <c>GET_PED_TARGET_FROM_COMBAT_PED</c> does not present in v1.0.2245.0 or earlier game versions,
+		/// this property supports all game versions.
+		/// </remarks>
+		public Ped CombatTarget
+		{
+			get
+			{
+				var targetEntityHandle = SHVDN.NativeMemory.GetCombatTargetPedHandleFromCombatPed(Handle);
+				return targetEntityHandle != 0 ? new Ped(targetEntityHandle) : null;
+			}
+		}
 
 		public Ped MeleeTarget
 		{

--- a/source/scripting_v3/GTA/Entities/Peds/ScriptTaskNameHash.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/ScriptTaskNameHash.cs
@@ -11,7 +11,14 @@ namespace GTA
 	/// </summary>
 	public enum ScriptTaskNameHash : uint
 	{
+		/// <summary>
+		/// This is the special hash that makes <see cref="Ped.GetScriptTaskStatus(ScriptTaskNameHash)"/> returns the current task status
+		/// regardless of the current script task hash.
+		/// </summary>
 		Any = 0x55966344,
+		/// <summary>
+		/// This value is used when no scripted task is performed.
+		/// </summary>
 		Invalid = 0x811E343C,
 		Pause = 0x03C990EC,
 		StandStill = 0xC572E06A,

--- a/source/scripting_v3/GTA/Entities/Peds/ScriptTaskStatus.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/ScriptTaskStatus.cs
@@ -23,7 +23,14 @@ namespace GTA
 		/// </summary>
 		Dormant = 2,
 		/// <summary>
+		/// The script task has nothing to do.
+		/// <see cref="ScriptTaskNameHash.Invalid"/> basically goes to this status.
+		/// </summary>
+		Vacant = 3,
+		/// <summary>
 		/// The task has been done or not performed yet as a primary task.
+		/// Strictly, <see cref="Ped.GetScriptTaskStatus(ScriptTaskNameHash)"/> returns this value
+		/// if the specified hash does not match the current one and the specified hash is not <see cref="ScriptTaskNameHash.Any"/>.
 		/// </summary>
 		Finished = 7,
 	}


### PR DESCRIPTION
## Summary
Add `Ped.CombatTarget`
Add `Ped.GetCurrentScriptTaskNameHashAndStatus`, `Ped.CurrentScriptTaskNameHash`, and `Ped.CurrentScriptStatus`
Add `ScriptTaskStatus.Vacant`

Did you want `Ped.CombatTarget` so bad?