### PR TITLE
Add new GetSafePositionForPed

### DIFF
--- a/source/scripting_v3/GTA/GetSafePositionFlags.cs
+++ b/source/scripting_v3/GTA/GetSafePositionFlags.cs
@@ -1,0 +1,64 @@
+//
+// Copyright (C) 2023 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+using System;
+
+namespace GTA
+{
+	/// <summary>
+	/// An enumeration of the flags to be passed in to <see cref="World.GetSafePositionForPed(Math.Vector3, out Math.Vector3, GetSafePositionFlags)"/>
+	/// to govern which navmesh polygons it considers.
+	/// </summary>
+	/// <remarks>
+	/// The test function that is used for this enum can be found with <c>"75 07 32 C0 E9 88 00 00 00 F6 C1 04 74 0A 8B 42 24"</c> (which is called via a function pointer).
+	/// The test function uses the same struct layout as YnvPoly class in CodeWalker.
+	/// <see href="https://github.com/dexyfex/CodeWalker/blob/9d76f2c6c42b580e67aabf293e3c57be5edbb190/CodeWalker.Core/GameFiles/FileTypes/YnvFile.cs#L756"/>
+	/// </remarks>
+	[Flags]
+	public enum GetSafePositionFlags
+	{
+		Default = 0,
+		/// <summary>
+		/// Only navmesh polygons marked as pavement.
+		/// </summary>
+		/// <remarks>
+		/// The pavement flag is named <c>B02_IsFootpath</c> in CodeWalker30_dev44.
+		/// </remarks>
+		OnlyPavement = 1,
+		/// <summary>
+		/// Only navmesh polygons not marked as "isolated".
+		/// </summary>
+		/// <remarks>
+		/// The isolated flag is named <c>B15_InteractionUnk</c> in CodeWalker30_dev44.
+		/// </remarks>
+		NotIsolated = 2,
+		/// <summary>
+		/// No navmesh polygons created from interiors.
+		/// </summary>
+		/// <remarks>
+		/// The interior flag is named <c>B14_IsInterior</c> in CodeWalker30_dev44.
+		/// </remarks>
+		NotInterior = 4,
+		/// <summary>
+		/// Removes explosions in the vicinity of the <see cref="Player"/>.
+		/// </summary>
+		/// <remarks>
+		/// The isolated flag is named <c>B07_IsWater</c> in CodeWalker30_dev44.
+		/// </remarks>
+		NotWater = 8,
+		/// <summary>
+		/// Only navmesh polygons marked as "network spawn candidate".
+		/// </summary>
+		/// <remarks>
+		/// The isolated flag is named <c>B17_IsFlatGround</c> in CodeWalker30_dev44.
+		/// Despite the name in the said CodeWalker build, some slope navmesh polygons has the "network spawn candidate" flag.
+		/// </remarks>
+		OnlyNetworkSpawn = 16,
+		/// <summary>
+		/// Specify whether to use a flood-fill from the starting position, as opposed to scanning all polygons within the search volume.
+		/// </summary>
+		UseFloodFill = 128,
+	}
+}

--- a/source/scripting_v3/GTA/World.cs
+++ b/source/scripting_v3/GTA/World.cs
@@ -2001,12 +2001,40 @@ namespace GTA
 			return resultArg;
 		}
 
+
+		/// <summary>
+		/// Checks to see if it can find a safe bit of ground to place a <see cref="Ped"/>.
+		/// </summary>
+		/// <param name="position">The position to check around.</param>
+		/// <param name="safePosition">If successful, will be filled with the position to check around.</param>
+		/// <param name="flags">The flags to determine how the method searches for positions.</param>
+		/// <returns>
+		/// <see langword="true"/> if successfully found a safe bit of ground to place a <see cref="Ped"/>; otherwise, <see langword="false"/>.
+		/// </returns>
+		/// <remarks>
+		/// Use this carefully since it can have a considerable performance hit, having to stall the game whilst it queries navmesh polygons.
+		/// </remarks>
+		public static bool GetSafePositionForPed(Vector3 position, out Vector3 safePosition, GetSafePositionFlags flags = GetSafePositionFlags.Default)
+		{
+			NativeVector3 outPos;
+			unsafe
+			{
+				// the 4th position sets the internal initial bitflag value to 3 instead of 2 if set,
+				// making it like the 1nd bit flag of 6th parameter is always set
+				bool foundSafePos = Function.Call<bool>(Hash.GET_SAFE_COORD_FOR_PED, position.X, position.Y, position.Z, false, &outPos, flags);
+				safePosition = outPos;
+				return foundSafePos;
+			}
+		}
+
 		/// <summary>
 		/// Gets the nearest safe coordinate to position a <see cref="Ped"/>.
 		/// </summary>
 		/// <param name="position">The position to check around.</param>
 		/// <param name="sidewalk">if set to <see langword="true" /> Only find positions on the sidewalk.</param>
 		/// <param name="flags">The flags.</param>
+		[Obsolete("World.GetSafeCoordForPed is obsolete since there is no way to check if the method is failed while GET_SAFE_COORD_FOR_PED provides one." +
+			"Use GetSafePositionForPed instead.")]
 		public static Vector3 GetSafeCoordForPed(Vector3 position, bool sidewalk = true, int flags = 0)
 		{
 			NativeVector3 outPos;


### PR DESCRIPTION
Now you can check if the method failed to find an appropriate navmesh without having to call via `Function.Call` manually.

I even searched the exe to find out how the flags filters the navmeshes.