### PR TITLE
Add ScriptSoundId class and forget variants of sound methods to Audio class

### DIFF
--- a/source/scripting_v3/GTA/Audio.cs
+++ b/source/scripting_v3/GTA/Audio.cs
@@ -3,6 +3,7 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
 using GTA.Math;
 using GTA.Native;
 
@@ -37,11 +38,87 @@ namespace GTA
 		#region Sounds
 
 		/// <summary>
+		/// Gets a <see cref="ScriptSoundId"/> instance of a triggered sound.
+		/// This method returns a new <see cref="ScriptSoundId"/>, which is used for keeping track of sounds after they've been triggered -
+		/// use this if you need to control a sound after it's been started, for instance to stop a looping sound, or to change a sound's pitch midway through playback.
+		/// </summary>
+		/// <returns></returns>
+		/// <remarks>
+		/// <para>
+		/// SoundIds can be reused, without needing to release them and grab a new one. If a sound's finished playing,
+		/// you can reuse its SoundId to kick off another one. If the sound's not finished playing,
+		/// it'll be stopped first (fading out or whatever is set up in RAVE by the sound designer), and the new one kicked off; usually it is safer to just get a new SoundId. 
+		/// </para>
+		/// <para>
+		/// The <see cref="ScriptSoundId"/> is always an integer greater than or equal to zero; if a playback function has a SoundId field but the sound doesn't need to be altered after 
+		/// triggering then call the forget method variants in <see cref="Audio"/> class, rather than getting a <see cref="ScriptSoundId"/>.
+		/// </para>
+		/// <para>
+		/// Scripted sound id can be reserved up to 100 in the <c>audScriptAudioEntity</c> instance.
+		/// The limit is shared among all scripts.
+		/// </para>
+		/// </remarks>
+		/// <returns>
+		/// A <see cref="ScriptSoundId"/> instance with the assigned id in the range of from 0 to 100 if the method successfully found an empty id/index;
+		/// otherwise, a <see cref="ScriptSoundId"/> instance with the id -1.
+		/// </returns>
+		public static ScriptSoundId GetSoundId() => new (Function.Call<int>(Hash.GET_SOUND_ID));
+
+		/// <summary>
+		/// Plays back a sound with the name <paramref name="soundName"/>, but do not track of sounds.
+		/// If this is used to play a sound for which no pan or speakermask is set by the sound designer, then the sound will play from the map's origin -
+		/// therefore this should only be used to play frontend sounds like menu bleeps or other artificially panned effects.
+		/// </summary>
+		/// <param name="soundName">The sound name to play.</param>
+		/// <param name="setName">The optional sound set name that contains the sound.</param>
+		/// <param name="enableOnReplay"><inheritdoc cref="ScriptSoundId.PlaySoundFrontend(string, string, bool)" path="/param[@name='enableOnReplay']"/></param>.
+		public static void PlaySoundAndForget(string soundName, string setName, bool enableOnReplay = true)
+		{
+			Function.Call(Hash.PLAY_SOUND, -1, soundName, setName, enableOnReplay);
+		}
+		/// <summary>
+		/// Plays back a sound "frontend" - at full volume, panned centrally, but do not track of sounds.
+		/// </summary>
+		/// <param name="soundName">The sound name to play.</param>
+		/// <param name="setName">The optional sound set name that contains the sound.</param>
+		/// <param name="enableOnReplay"><inheritdoc cref="ScriptSoundId.PlaySoundFrontend(string, string, bool)" path="/param[@name='enableOnReplay']"/></param>.
+		/// <remarks>
+		/// If the sound has a Pan or a SpeakerMask set by the sound designer then the it will play using these settings,
+		/// otherwise it will play from dead ahead (0°).
+		/// </remarks>
+		public static void PlaySoundFrontendAndForget(string soundName, string setName, bool enableOnReplay = true)
+		{
+			Function.Call(Hash.PLAY_SOUND_FRONTEND, -1, soundName, setName, enableOnReplay);
+		}
+		/// <summary>
+		/// Plays back a sound from an <see cref="Entity"/>'s location, but do not track of sounds.
+		/// The sound's position will track the <see cref="Entity"/>'s position as it moves.
+		/// </summary>
+		/// <param name="entity">The <see cref="Entity"/> to play the sound from.</param>
+		/// <param name="soundName">The sound name to play.</param>
+		/// <param name="setName">The optional sound set name that contains the sound.</param>
+		public static void PlaySoundFromEntityAndForget(Entity entity, string soundName, string setName = null)
+			=> Function.Call(Hash.PLAY_SOUND_FROM_ENTITY, -1, soundName, entity.Handle, setName, false, 0);
+		/// <summary>
+		/// Plays back a sound from an absolute position, but do not track of sounds.
+		/// </summary>
+		/// <param name="position">The world coordinates to play the sound from.</param>
+		/// <param name="soundName">The sound name to play.</param>
+		/// <param name="setName">The optional sound set name that contains the sound.</param>
+		/// <param name="isExteriorLoc">
+		/// If <see langword="true"/>, the sound will use a portal occlusion environmentGroup.
+		/// Only use this if the sound is playing outside and needs occlusion.
+		/// </param>
+		public static void PlaySoundFromPositionAndForget(Vector3 position, string soundName, string setName = null, bool isExteriorLoc = false)
+			=> Function.Call(Hash.PLAY_SOUND_FROM_COORD, -1, soundName, position.X, position.Y, position.Z, setName, false, 0, isExteriorLoc);
+
+		/// <summary>
 		/// Plays a sound from the game's sound files at the specified <paramref name="entity"/>.
 		/// </summary>
 		/// <param name="entity">The entity to play the sound at.</param>
 		/// <param name="soundFile">The sound file to play.</param>
 		/// <returns>The identifier of the active sound effect instance.</returns>
+		[Obsolete("Audio.PlaySoundAt is obsolete, use ScriptSoundId.PlaySoundFromEntity or Audio.PlaySoundFromEntityAndForget.")]
 		public static int PlaySoundAt(Entity entity, string soundFile)
 		{
 			int id = Function.Call<int>(Hash.GET_SOUND_ID);
@@ -55,6 +132,7 @@ namespace GTA
 		/// <param name="soundFile">The sound file to play.</param>
 		/// <param name="soundSet">The name of the sound inside the file.</param>
 		/// <returns>The identifier of the active sound effect instance.</returns>
+		[Obsolete("Audio.PlaySoundAt is obsolete, use ScriptSoundId.PlaySoundFromEntity or Audio.PlaySoundFromEntityAndForget.")]
 		public static int PlaySoundAt(Entity entity, string soundFile, string soundSet)
 		{
 			int id = Function.Call<int>(Hash.GET_SOUND_ID);
@@ -67,6 +145,7 @@ namespace GTA
 		/// <param name="position">The world coordinates to play the sound at.</param>
 		/// <param name="soundFile">The sound file to play.</param>
 		/// <returns>The identifier of the active sound effect instance.</returns>
+		[Obsolete("Audio.PlaySoundAt is obsolete, use ScriptSoundId.PlaySoundFromPosition or Audio.PlaySoundFromPositionAndForget.")]
 		public static int PlaySoundAt(Vector3 position, string soundFile)
 		{
 			int id = Function.Call<int>(Hash.GET_SOUND_ID);
@@ -80,6 +159,7 @@ namespace GTA
 		/// <param name="soundFile">The sound file to play.</param>
 		/// <param name="soundSet">The name of the sound inside the file.</param>
 		/// <returns>The identifier of the active sound effect instance.</returns>
+		[Obsolete("Audio.PlaySoundAt is obsolete, use ScriptSoundId.PlaySoundFromPosition or Audio.PlaySoundFromPositionAndForget.")]
 		public static int PlaySoundAt(Vector3 position, string soundFile, string soundSet)
 		{
 			int id = Function.Call<int>(Hash.GET_SOUND_ID);
@@ -91,6 +171,7 @@ namespace GTA
 		/// </summary>
 		/// <param name="soundFile">The sound file to play.</param>
 		/// <returns>The identifier of the active sound effect instance.</returns>
+		[Obsolete("Audio.PlaySoundFrontend is obsolete, use ScriptSoundId.PlaySoundFrontend or Audio.PlaySoundFrontendAndForget.")]
 		public static int PlaySoundFrontend(string soundFile)
 		{
 			int id = Function.Call<int>(Hash.GET_SOUND_ID);
@@ -103,6 +184,7 @@ namespace GTA
 		/// <param name="soundFile">The sound file to play.</param>
 		/// <param name="soundSet">The name of the sound inside the file.</param>
 		/// <returns>The identifier of the active sound effect instance.</returns>
+		[Obsolete("Audio.PlaySoundFrontend is obsolete, use ScriptSoundId.PlaySoundFrontend or Audio.PlaySoundFrontendAndForget.")]
 		public static int PlaySoundFrontend(string soundFile, string soundSet)
 		{
 			int id = Function.Call<int>(Hash.GET_SOUND_ID);
@@ -114,6 +196,7 @@ namespace GTA
 		/// Cancels playing the specified sound instance.
 		/// </summary>
 		/// <param name="id">The identifier of the active sound effect instance.</param>
+		[Obsolete("Audio.StopSound is obsolete, use ScriptSoundId.Stop.")]
 		public static void StopSound(int id)
 		{
 			Function.Call(Hash.STOP_SOUND, id);
@@ -122,6 +205,7 @@ namespace GTA
 		/// Releases the specified sound instance. Call this for every sound effect started.
 		/// </summary>
 		/// <param name="id">The identifier of the active sound effect instance.</param>
+		[Obsolete("Audio.ReleaseSound is obsolete, use ScriptSoundId.Release.")]
 		public static void ReleaseSound(int id)
 		{
 			Function.Call(Hash.RELEASE_SOUND_ID, id);
@@ -131,6 +215,7 @@ namespace GTA
 		/// Gets a boolean indicating whether the specified sound instance has completed playing.
 		/// </summary>
 		/// <param name="id">The identifier of the active sound effect instance.</param>
+		[Obsolete("Audio.HasSoundFinished is obsolete, use ScriptSoundId.HasFinished.")]
 		public static bool HasSoundFinished(int id)
 		{
 			return Function.Call<bool>(Hash.HAS_SOUND_FINISHED, id);

--- a/source/scripting_v3/GTA/ScriptSoundId.cs
+++ b/source/scripting_v3/GTA/ScriptSoundId.cs
@@ -1,0 +1,189 @@
+//
+// Copyright (C) 2023 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+using GTA.Math;
+using GTA.Native;
+using System;
+
+namespace GTA
+{
+	/// <summary>
+	/// Represents a script sound id, which is used for script audio sounds processed via the static <c>audScriptAudioEntity</c> instance.
+	/// </summary>
+	public readonly struct ScriptSoundId : IEquatable<ScriptSoundId>
+	{
+		internal ScriptSoundId(int id) : this()
+		{
+			Id = id;
+		}
+
+		/// <summary>
+		/// Gets the script sound id/index.
+		/// </summary>
+		public int Id
+		{
+			get;
+		}
+
+		/// <summary>
+		/// Returns <see langword="true"/> if the sound <see cref="Id"/> is negative,
+		/// which indicates <see cref="Audio.GetSoundId()"/> fails to reserve a new script sound id (with the return value -1).
+		/// </summary>
+		/// <remarks>
+		/// Do not trust this property if the struct is created via something other than <see cref="Audio.GetSoundId()"/>.
+		/// </remarks>
+		public bool IsNullId => Id < 0;
+
+		/// <summary>
+		/// Plays back a sound with the name <paramref name="soundName"/>.
+		/// If this is used to play a sound for which no pan or speakermask is set by the sound designer, then the sound will play from the map's origin -
+		/// therefore this should only be used to play frontend sounds like menu bleeps or other artificially panned effects.
+		/// </summary>
+		/// <param name="soundName">The sound name to play.</param>
+		/// <param name="setName">The optional sound set name that contains the sound.</param>
+		/// <param name="enableOnReplay"><inheritdoc cref="PlaySoundFrontend(string, string, bool)" path="/param[@name='enableOnReplay']"/></param>.
+		public void PlaySound(string soundName, string setName, bool enableOnReplay = true)
+		{
+			Function.Call(Hash.PLAY_SOUND, Id, soundName, setName, enableOnReplay);
+		}
+		/// <summary>
+		/// Plays back a sound "frontend" - at full volume, panned centrally.
+		/// </summary>
+		/// <param name="soundName">The sound name to play.</param>
+		/// <param name="setName">The optional sound set name that contains the sound.</param>
+		/// <param name="enableOnReplay">
+		/// <para>
+		/// The name is taken from the official definition, but the effect is unknown.
+		/// </para>
+		/// <para>
+		/// Will be internally disabled if the hash calculated from <paramref name="soundName"/> (with <see cref="Game.GenerateHash(string)"/>) is one of the values
+		/// <c>[0x5A23F3D5, 0xDF84A53C, 0xFD4C28, 0x832CAA0F, 0x17BD10F1, 0xFA4A5AA0, 0x2B8F97E3, 0x1D46A6A2, 0xF5E3A26A, 0xF35C567B,
+		/// 0x71F56AB4, 0xC55C68A0, 0x54C522AD, 0xD382DF7C, 0x2A508F9C, 0xE8F24AFD, 0x8DDBFC96, 0x28C8633, 0x596B8EBB, 0x8A73028A,
+		/// 0x578FE4D7, 0xE52306DE, 0x10109BEB]</c>.
+		/// </para>
+		/// </param>
+		/// <remarks>
+		/// If the sound has a Pan or a SpeakerMask set by the sound designer then the it will play using these settings,
+		/// otherwise it will play from dead ahead (0°).
+		/// </remarks>
+		public void PlaySoundFrontend(string soundName, string setName, bool enableOnReplay = true)
+		{
+			Function.Call(Hash.PLAY_SOUND_FRONTEND, Id, soundName, setName, enableOnReplay);
+		}
+		/// <summary>
+		/// Plays back a sound from an <see cref="Entity"/>'s location.
+		/// The sound's position will track the <see cref="Entity"/>'s position as it moves.
+		/// </summary>
+		/// <param name="entity">The <see cref="Entity"/> to play the sound from.</param>
+		/// <param name="soundName">The sound name to play.</param>
+		/// <param name="setName">The optional sound set name that contains the sound.</param>
+		public void PlaySoundFromEntity(Entity entity, string soundName, string setName = null)
+			=> Function.Call(Hash.PLAY_SOUND_FROM_ENTITY, Id, soundName, entity.Handle, setName, false, 0);
+		/// <summary>
+		/// Plays back a sound from an absolute position.
+		/// </summary>
+		/// <param name="position">The world coordinates to play the sound from.</param>
+		/// <param name="soundName">The sound name to play.</param>
+		/// <param name="setName">The optional sound set name that contains the sound.</param>
+		/// <param name="isExteriorLoc">
+		/// If <see langword="true"/>, the sound will use a portal occlusion environmentGroup.
+		/// Only use this if the sound is playing outside and needs occlusion.
+		/// </param>
+		public void PlaySoundFromPosition(Vector3 position, string soundName, string setName = null, bool isExteriorLoc = false)
+			=> Function.Call(Hash.PLAY_SOUND_FROM_COORD, Id, soundName, position.X, position.Y, position.Z, setName, false, 0, isExteriorLoc);
+
+		/// <summary>
+		/// <para>
+		/// Sets a variable on a sound.
+		/// </para>
+		/// <para>
+		/// This method allows to communicate with the sound engine in complex ways,
+		///	by passing a floating point value to a specific sound object. This allows some nice effects such as adjusting the pitch of a sample being to be played back,
+		///	or varying a lowpass cutoff. The VariableName parameter must be set up in RAVE (the audio scripting tool) as well as instruction on its usage on a case-by-case
+		///	basis therefore a sound designer must be consulted with before using this command.
+		///	</para>
+		/// </summary>
+		public void UpdatePosition(string variableName, float variableValue)
+			=> Function.Call(Hash.SET_VARIABLE_ON_SOUND, Id, variableName, variableValue);
+		/// <summary>
+		/// Updates a playing sounds absolute position.
+		/// Currently not available in v1.0.617.1 or earlier game versions.
+		/// </summary>
+		/// <param name="position">The new position.</param>
+		public void UpdatePosition(Vector3 position)
+		{
+			if (Game.Version < GameVersion.v1_0_678_1_Steam)
+			{
+				throw new GameVersionNotSupportedException(GameVersion.v1_0_678_1_Steam, nameof(ScriptSoundId), nameof(UpdatePosition));
+			}
+
+			Function.Call(Hash.UPDATE_SOUND_COORD, Id, position.X, position.Y, position.Z);
+		}
+
+		/// <summary>
+		/// Gets a boolean indicating whether the specified sound instance has completed playing.
+		/// </summary>
+		public bool HasFinished()
+		{
+			return Function.Call<bool>(Hash.HAS_SOUND_FINISHED, Id);
+		}
+
+		/// <summary>
+		/// Stops a playing sound.
+		/// Calling this method on this <see cref="ScriptSoundId"/> that has finished playing will have no ill effects in any case
+		/// as long as the <see cref="ScriptSoundId"/> has not been released.
+		/// </summary>
+		public void Stop()
+		{
+			Function.Call(Hash.STOP_SOUND, Id);
+		}
+		/// <summary>
+		/// Releases this <see cref="ScriptSoundId"/>.
+		/// This should be called once a sound has finished being manipulated by the script so that its <see cref="ScriptSoundId"/>
+		/// can be released and re-used.
+		/// </summary>
+		public void Release()
+		{
+			Function.Call(Hash.RELEASE_SOUND_ID, Id);
+		}
+
+		public bool Equals(ScriptSoundId other)
+		{
+			return Id == other.Id;
+		}
+		public override bool Equals(object obj)
+		{
+			if (obj is ScriptSoundId model)
+			{
+				return Equals(model);
+			}
+
+			return false;
+		}
+
+		public static bool operator ==(ScriptSoundId left, ScriptSoundId right)
+		{
+			return left.Equals(right);
+		}
+		public static bool operator !=(ScriptSoundId left, ScriptSoundId right)
+		{
+			return !left.Equals(right);
+		}
+
+		public static implicit operator InputArgument(ScriptSoundId value)
+		{
+			return new InputArgument(value.Id);
+		}
+		public static implicit operator ScriptSoundId(int value)
+		{
+			return new ScriptSoundId(value);
+		}
+
+		public override int GetHashCode()
+		{
+			return Id.GetHashCode();
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Add `ScriptSoundId` which is documented much more than before and forget variants for sound methods.
Easier sound id/index management too.