### PR TITLE
feat(api-v3): add test probe(ish) features

### DIFF
--- a/source/scripting_v3/GTA/GetGroundHeightMode.cs
+++ b/source/scripting_v3/GTA/GetGroundHeightMode.cs
@@ -1,0 +1,25 @@
+//
+// Copyright (C) 2023 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+namespace GTA
+{
+	public enum GetGroundHeightMode
+	{
+		/// <summary>
+		/// Does not consider water as ground.
+		/// </summary>
+		Normal,
+		/// <summary>
+		/// Consider water as ground and takes the waves into account.
+		/// Does not make any difference from <see cref="Normal"/> in earlier game versions such as v1.0.372.2.
+		/// </summary>
+		ConsiderWaterAsGround,
+		/// <summary>
+		/// Consider water as ground but does not take the waves into account.
+		/// Does not make any difference from <see cref="Normal"/> in earlier game versions such as v1.0.372.2.
+		/// </summary>
+		ConsiderWaterAsGroundNoWaves,
+	}
+}


### PR DESCRIPTION
## Summary
- Add new `GetGroundHeight` overloads that returns a bool if the test is sucessful
- Add methods to get approx height and floor where you can use to fetch the approx height/floor at distance place
- Add `GetWaterHeight` and `GetWaterHeightNoWaves`
- Mark old 2 GetGroundHeight overloads as obsolete

With new methods, you can find building collisions with test result info, approx height/floor that can be used for distant place, and water position with well documented info.

