### PR TITLE
feat(api-v3): ClipSet struct and methods that requires clipset to Ped

### DIFF
--- a/source/scripting_v3/GTA/ClipSet.cs
+++ b/source/scripting_v3/GTA/ClipSet.cs
@@ -1,0 +1,122 @@
+//
+// Copyright (C) 2015 crosire & kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+using GTA.Native;
+using System;
+
+namespace GTA
+{
+	/// <summary>
+	/// Represents a dictionary struct for a clip/animation set, which should represent a key name for <c>fwClipSet</c>.
+	/// Clip/Animation sets are defined in <c>clip_sets.ymt</c> (compiled file of <c>clip_sets.pso.meta</c> according to
+	/// the official scripting headers) or <c>clip_sets.xml</c> files.
+	/// Note that clip/animation sets are different from clip/animation dictionaries, which is created from <c>ycd</c> files.
+	/// </summary>
+	public readonly struct ClipSet : IEquatable<ClipSet>, IStreamingResource
+	{
+		public ClipSet(string name) : this()
+		{
+			Name = name;
+		}
+
+		/// <summary>
+		/// Gets the name.
+		/// </summary>
+		public string Name
+		{
+			get;
+		}
+
+		/// <summary>
+		/// Gets a value indicating whether this <see cref="ClipSet"/> is loaded
+		/// so the animations of this <see cref="ClipSet"/> are ready to use.
+		/// </summary>
+		public bool IsLoaded => Function.Call<bool>(Hash.HAS_CLIP_SET_LOADED, Name);
+
+		/// <summary>
+		/// Attempts to load this <see cref="ClipSet"/> into memory.
+		/// </summary>
+		public void Request()
+		{
+			Function.Call(Hash.REQUEST_CLIP_SET, Name);
+		}
+		/// <summary>
+		/// Attempts to load this <see cref="ClipSet"/> into memory for a given period of time.
+		/// </summary>
+		/// <param name="timeout">The time (in milliseconds) before giving up trying to load this <see cref="ClipSet"/>.</param>
+		/// <returns><see langword="true" /> if this <see cref="ClipSet"/> is loaded; otherwise, <see langword="false" />.</returns>
+		public bool Request(int timeout)
+		{
+			Request();
+
+			int startTime = Environment.TickCount;
+			int maxElapsedTime = timeout >= 0 ? timeout : int.MaxValue;
+
+			while (!IsLoaded)
+			{
+				Script.Yield();
+				Request();
+
+				if (Environment.TickCount - startTime >= maxElapsedTime)
+				{
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		/// <summary>
+		/// Tells the game we have finished using this <see cref="ClipSet"/> and it can be freed from memory.
+		/// </summary>
+		public void MarkAsNoLongerNeeded()
+		{
+			Function.Call(Hash.REMOVE_CLIP_SET, Name);
+		}
+
+		public bool Equals(ClipSet animationDictionary)
+		{
+			return Name == animationDictionary.Name;
+		}
+		public override bool Equals(object obj)
+		{
+			if (obj is ClipSet model)
+			{
+				return Equals(model);
+			}
+
+			return false;
+		}
+
+		public static bool operator ==(ClipSet left, ClipSet right)
+		{
+			return left.Equals(right);
+		}
+		public static bool operator !=(ClipSet left, ClipSet right)
+		{
+			return !left.Equals(right);
+		}
+
+		public static implicit operator InputArgument(ClipSet value)
+		{
+			return new InputArgument(value.Name);
+		}
+		public static implicit operator ClipSet(string value)
+		{
+			return new ClipSet(value);
+		}
+		public static explicit operator string(ClipSet value)
+		{
+			return value.Name;
+		}
+
+		public override int GetHashCode()
+		{
+			return Name.GetHashCode();
+		}
+
+		public override string ToString() => Name.ToString();
+	}
+}

--- a/source/scripting_v3/GTA/ClipSet.cs
+++ b/source/scripting_v3/GTA/ClipSet.cs
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2015 crosire & kagikn & contributors
+// Copyright (C) 2023 kagikn & contributors
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
@@ -76,9 +76,9 @@ namespace GTA
 			Function.Call(Hash.REMOVE_CLIP_SET, Name);
 		}
 
-		public bool Equals(ClipSet animationDictionary)
+		public bool Equals(ClipSet other)
 		{
-			return Name == animationDictionary.Name;
+			return Name == other.Name;
 		}
 		public override bool Equals(object obj)
 		{

--- a/source/scripting_v3/GTA/Entities/Peds/Ped.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Ped.cs
@@ -2223,7 +2223,7 @@ namespace GTA
 		}
 
 		/// <summary>
-		/// Sets the clip/animation set this <see cref="Ped"/> should use or <see langword="null"/>
+		/// Sets the movement clip/animation set this <see cref="Ped"/> should use or <see langword="null"/>
 		/// to reset to the default value defined in <c>peds.meta</c> under <c>&lt;MovementClipSet&gt;</c>.
 		/// </summary>
 		/// <remarks>
@@ -2237,6 +2237,7 @@ namespace GTA
 		/// dictionary will result in the setter failure.
 		/// </para>
 		/// </remarks>
+		[Obsolete("Ped.MovementAnimationSet is obsolete. Use Ped.SetMovementClipSet or Ped.ResetMovementClipSet instead.")]
 		public string MovementAnimationSet
 		{
 			set
@@ -2265,6 +2266,60 @@ namespace GTA
 				}
 			}
 		}
+
+		/// <summary>
+		/// Sets the movement clipset this <see cref="Ped"/> should use.
+		/// Do not forget to stream in/load the clipset you want to load, or the method silently will fail.
+		/// </summary>
+		/// <remarks>
+		/// Unlike any methods that requires some resource to be loaded before the main operation and that are present in v3.6.0,
+		/// this method does not load the clipset automatically. Load the clipset you want to load beforehand.
+		/// </remarks>
+		public void SetMovementClipSet(ClipSet clipSet, float blendDuration = 0.25f)
+			=> Function.Call(Hash.SET_PED_MOVEMENT_CLIPSET, Handle, clipSet, blendDuration);
+
+		/// <summary>
+		/// Resets the movement clipset to the default value defined in <c>peds.meta</c> under <c>&lt;MovementClipSet&gt;</c>.
+		/// Do not forget to unstream the clipset if no longer needed.
+		/// </summary>
+		public void ResetMovementClipSet(float blendDuration = 0.25f)
+			=> Function.Call(Hash.RESET_PED_MOVEMENT_CLIPSET, Handle, blendDuration);
+
+		/// <summary>
+		/// Sets the strafe clipset this <see cref="Ped"/> should use.
+		/// Do not forget to stream in/load the clipset you want to load, or the method silently will fail.
+		/// </summary>
+		/// <remarks>
+		/// Unlike any methods that requires some resource to be loaded before the main operation and that are present in v3.6.0,
+		/// this method does not load the clipset automatically. Load the clipset you want to load beforehand.
+		/// </remarks>
+		public void SetStrafeClipSet(ClipSet clipSet)
+			=> Function.Call(Hash.SET_PED_STRAFE_CLIPSET, Handle, clipSet);
+
+		/// <summary>
+		/// Resets the strafe clipset to the default value defined in <c>peds.meta</c> under <c>&lt;StrafeClipSet&gt;</c>.
+		/// Do not forget to unstream the clipset if no longer needed.
+		/// </summary>
+		public void ResetStrafeClipSet()
+			=> Function.Call(Hash.RESET_PED_STRAFE_CLIPSET, Handle);
+
+		/// <summary>
+		/// Sets the weapon movement clipset this <see cref="Ped"/> should use.
+		/// Do not forget to stream in/load the clipset you want to load, or the method silently will fail.
+		/// </summary>
+		/// <remarks>
+		/// Unlike any methods that requires some resource to be loaded before the main operation and that are present in v3.6.0,
+		/// this method does not load the clipset automatically. Load the clipset you want to load beforehand.
+		/// </remarks>
+		public void SetWeaponMovementClipSet(ClipSet clipSet)
+			=> Function.Call(Hash.SET_PED_WEAPON_MOVEMENT_CLIPSET, Handle, clipSet);
+
+		/// <summary>
+		/// Resets the weapon movement clipset to the default value defined in <c>peds.meta</c> under <c>&lt;StrafeClipSet&gt;</c>.
+		/// Do not forget to unstream the clipset if no longer needed.
+		/// </summary>
+		public void ResetWeaponMovementClipSet()
+			=> Function.Call(Hash.RESET_PED_WEAPON_MOVEMENT_CLIPSET, Handle);
 
 		#endregion
 


### PR DESCRIPTION
Again, less confusing interfaces are added in this PR.

Why I named the wrapper strict that represents `ClipSet` and not `AnimationSet` that sounds more familiar in modding community and RPH adopts? Because I saw the hash of `fwClipSetManager`, which is 0x56872C54, in both GTA5 and RDR3 exes…

I skip considering providing less confusing alternatives for Weapon classes and vehicle mods classes until v3.7.0 is released, their refactoring would cost much more time.