### PR TITLE
Fix obsolete typo

### DIFF
--- a/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs
@@ -1391,7 +1391,7 @@ namespace GTA
 
 				return lightState1;
 			}
-			[Obsolete("The geter of Vehicle.AreLightsOn is obsolete. Use Vehicle.SetScriptedLightSetting instead.")]
+			[Obsolete("The setter of Vehicle.AreLightsOn is obsolete. Use Vehicle.SetScriptedLightSetting instead.")]
 			set => Function.Call(Hash.SET_VEHICLE_LIGHTS, Handle, value ? 3 : 4);
 		}
 


### PR DESCRIPTION
Fixes obsolete message to correctly state that the setter for AreLightsOn is obsolete, not the getter.