### PR TITLE
feat(api-v3): PickupObject and Pickup.Object

### DIFF
--- a/source/scripting_v3/GTA/Pickup/Pickup.cs
+++ b/source/scripting_v3/GTA/Pickup/Pickup.cs
@@ -8,6 +8,9 @@ using GTA.Native;
 
 namespace GTA
 {
+	/// <summary>
+	/// Represents a pickup placement, not pickup object.
+	/// </summary>
 	public sealed class Pickup : PoolObject
 	{
 		public Pickup(int handle) : base(handle)
@@ -15,17 +18,31 @@ namespace GTA
 		}
 
 		/// <summary>
-		/// The position of this <see cref="Pickup"/>.
+		/// The position of this <see cref="Pickup"/> placement.
 		/// </summary>
 		public Vector3 Position => Function.Call<Vector3>(Hash.GET_PICKUP_COORDS, Handle);
 
 		/// <summary>
-		/// Gets if this <see cref="Pickup"/> has been collected.
+		/// Gets if this <see cref="Pickup"/> placement has been collected.
 		/// </summary>
 		public bool IsCollected => Function.Call<bool>(Hash.HAS_PICKUP_BEEN_COLLECTED, Handle);
 
 		/// <summary>
-		/// Determines if the object of this <see cref="Pickup"/> exists.
+		/// Gets the <see cref="PickupObject"/> of this <see cref="Pickup"/> placement.
+		/// </summary>
+		/// <returns></returns>
+		public PickupObject Object
+		{
+			get
+			{
+				// GET_PICKUP_OBJECT returns -1 (not 0) if the pickup placement has no object or is invalid
+				int objHandle = Function.Call<int>(Hash.GET_PICKUP_OBJECT, Handle);
+				return objHandle == -1 ? new PickupObject(objHandle) : null;
+			}
+		}
+
+		/// <summary>
+		/// Determines if the object of this <see cref="Pickup"/> placement exists.
 		/// </summary>
 		/// <returns></returns>
 		public bool ObjectExists()
@@ -34,7 +51,7 @@ namespace GTA
 		}
 
 		/// <summary>
-		/// Destroys this <see cref="Pickup"/>.
+		/// Destroys this <see cref="Pickup"/> placement.
 		/// </summary>
 		public override void Delete()
 		{
@@ -42,7 +59,7 @@ namespace GTA
 		}
 
 		/// <summary>
-		/// Determines if this <see cref="Pickup"/> exists.
+		/// Determines if this <see cref="Pickup"/> placement exists.
 		/// </summary>
 		/// <returns><see langword="true" /> if this <see cref="Pickup"/> exists; otherwise, <see langword="false" />.</returns>
 		public override bool Exists()
@@ -51,7 +68,7 @@ namespace GTA
 		}
 
 		/// <summary>
-		/// Determines if an <see cref="object"/> refers to the same pickup as this <see cref="Pickup"/>.
+		/// Determines if an <see cref="object"/> refers to the same pickup placement as this <see cref="Pickup"/>.
 		/// </summary>
 		/// <param name="obj">The <see cref="object"/> to check.</param>
 		/// <returns><see langword="true" /> if the <paramref name="obj"/> is the same pickup as this <see cref="Pickup"/>; otherwise, <see langword="false" />.</returns>
@@ -66,17 +83,17 @@ namespace GTA
 		}
 
 		/// <summary>
-		/// Determines if two <see cref="Pickup"/>s refer to the same pickup.
+		/// Determines if two <see cref="Pickup"/>s refer to the same pickup placement.
 		/// </summary>
 		/// <param name="left">The left <see cref="Pickup"/>.</param>
 		/// <param name="right">The right <see cref="Pickup"/>.</param>
-		/// <returns><see langword="true" /> if <paramref name="left"/> is the same pickup as <paramref name="right"/>; otherwise, <see langword="false" />.</returns>
+		/// <returns><see langword="true" /> if <paramref name="left"/> is the same pickup placement as <paramref name="right"/>; otherwise, <see langword="false" />.</returns>
 		public static bool operator ==(Pickup left, Pickup right)
 		{
 			return left?.Equals(right) ?? right is null;
 		}
 		/// <summary>
-		/// Determines if two <see cref="Pickup"/>s don't refer to the same pickup.
+		/// Determines if two <see cref="Pickup"/>s don't refer to the same pickup placement.
 		/// </summary>
 		/// <param name="left">The left <see cref="Pickup"/>.</param>
 		/// <param name="right">The right <see cref="Pickup"/>.</param>

--- a/source/scripting_v3/GTA/Pickup/PickupObject.cs
+++ b/source/scripting_v3/GTA/Pickup/PickupObject.cs
@@ -1,0 +1,46 @@
+//
+// Copyright (C) 2023 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+using System;
+
+namespace GTA
+{
+	/// <summary>
+	/// Represents a pickup object, which is for a <c>CPickup</c>.
+	/// </summary>
+	public sealed class PickupObject : Prop
+	{
+		internal PickupObject(int handle) : base(handle)
+		{
+		}
+
+		/// <summary>
+		/// Get a <see cref="PickupObject"/> instance by its handle.
+		/// </summary>
+		/// <param name="handle"></param>
+		/// <returns>
+		/// A <see cref="PickupObject"/> if the handle is for pickup object; otherwise, <see langword="null"/>.
+		/// </returns>
+		public static new PickupObject FromHandle(int handle)
+		{
+			IntPtr address = SHVDN.NativeMemory.GetEntityAddress(handle);
+			if (address == IntPtr.Zero)
+			{
+				return null;
+			}
+
+			// We have to use some of Rockstar's RTTI info to ensure if this CObject is CPickup
+			// Native functions that take a pickup object handle verify this in the same way
+			// (fetches an address from the associated handle then tests if the class id hash
+			// is the same as 0xAD2BCC1A (the joaat hash of the name "CPickup")
+			const uint CPickupNameHash = 0xAD2BCC1A;
+			if (SHVDN.NativeMemory.GetRageClassId(address) != CPickupNameHash)
+			{
+				return null;
+			}
+
+			return new PickupObject(handle);
+		}
+	}
+}

--- a/source/scripting_v3/GTA/World.cs
+++ b/source/scripting_v3/GTA/World.cs
@@ -603,31 +603,52 @@ namespace GTA
 		}
 
 		/// <summary>
-		/// Gets the closest <see cref="Prop"/> to a given position in the World associated with a <see cref="Pickup"/>.
+		/// Gets the closest <see cref="PickupObject"/> to a given position in the World associated with a <see cref="Pickup"/>.
 		/// </summary>
-		/// <param name="position">The position to find the nearest <see cref="Prop"/>.</param>
-		/// <param name="radius">The maximum distance from the <paramref name="position"/> to detect <see cref="Prop"/>s.</param>
-		/// <remarks>Returns <see langword="null" /> if no <see cref="Prop"/> was in the given region.</remarks>
+		/// <param name="position">The position to find the nearest <see cref="PickupObject"/>.</param>
+		/// <param name="radius">The maximum distance from the <paramref name="position"/> to detect <see cref="PickupObject"/>s.</param>
+		/// <remarks>
+		/// <para>
+		/// Returns <see langword="null" /> if no <see cref="PickupObject"/> was in the given region.
+		/// </para>
+		/// <para>
+		/// Although this method returns a <see cref="PickupObject"/> instance, it specifies the base class
+		/// <see cref="Prop"/> type as the return type for compatibility for scripts built against v3.6.0 or earlier
+		/// versions of SHVDN. If you need to use the return value as <see cref="PickupObject"/>, you can cast it
+		/// into <see cref="PickupObject"/>.
+		/// </para>
+		/// </remarks>
 		public static Prop GetClosestPickupObject(Vector3 position, float radius)
 		{
 			return GetClosest(position, GetNearbyPickupObjects(position, radius));
 		}
-
 		/// <summary>
-		/// Gets an <c>array</c> of all <see cref="Prop"/>s in the World associated with a <see cref="Pickup"/>.
+		/// Gets an <c>array</c> of all <see cref="PickupObject"/>s in the World associated with a <see cref="Pickup"/>.
 		/// </summary>
+		/// <remarks>
+		/// Although this method returns an array of <see cref="PickupObject"/> instances, it specifies an array of
+		/// the base class <see cref="Prop"/> type as the return type for compatibility for scripts built against
+		/// v3.6.0 or earlier versions of SHVDN. If you need to use the return value as an array of
+		/// <see cref="PickupObject"/>, you can cast it into an array of <see cref="PickupObject"/>.
+		/// </remarks>
 		public static Prop[] GetAllPickupObjects()
 		{
-			return Array.ConvertAll(SHVDN.NativeMemory.GetPickupObjectHandles(), handle => new Prop(handle));
+			return Array.ConvertAll(SHVDN.NativeMemory.GetPickupObjectHandles(), handle => new PickupObject(handle));
 		}
 		/// <summary>
-		/// Gets an <c>array</c> of all <see cref="Prop"/>s in a given region in the World associated with a <see cref="Pickup"/>.
+		/// Gets an <c>array</c> of all <see cref="PickupObject"/>s in a given region in the World associated with a <see cref="Pickup"/>.
 		/// </summary>
 		/// <param name="position">The position to check the <see cref="Entity"/> against.</param>
 		/// <param name="radius">The maximum distance from the <paramref name="position"/> to detect <see cref="Prop"/>s.</param>
+		/// <remarks>
+		/// Although this method returns an array of <see cref="PickupObject"/> instances, it specifies an array of
+		/// the base class <see cref="Prop"/> type as the return type for compatibility for scripts built against
+		/// v3.6.0 or earlier versions of SHVDN. If you need to use the return value as an array of
+		/// <see cref="PickupObject"/>, you can cast it into an array of <see cref="PickupObject"/>.
+		/// </remarks>
 		public static Prop[] GetNearbyPickupObjects(Vector3 position, float radius)
 		{
-			return Array.ConvertAll(SHVDN.NativeMemory.GetPickupObjectHandles(position.ToInternalFVector3(), radius), handle => new Prop(handle));
+			return Array.ConvertAll(SHVDN.NativeMemory.GetPickupObjectHandles(position.ToInternalFVector3(), radius), handle => new PickupObject(handle));
 		}
 		/// <summary>
 		/// Gets the closest <see cref="Projectile"/> to a given position in the World.


### PR DESCRIPTION
Fuck, I wish if an class for `CPickup` was introduced before `World.Get*` methods for pickup objects were added. Unfortunately we can't change the (static) return type of them in the v3 API, that would be a breaking change.