### PR TITLE
feat(api-v3): GTA.Graphics.Scripted2DGfxSettings

### DIFF
--- a/source/scripting_v3/GTA.Graphics/Scripted2DGfxSettings.cs
+++ b/source/scripting_v3/GTA.Graphics/Scripted2DGfxSettings.cs
@@ -1,0 +1,108 @@
+//
+// Copyright (C) 2023 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+using GTA.Native;
+using System.Drawing;
+
+namespace GTA.Graphics
+{
+	/// <summary>
+	/// Represents a static class to access global scripted 2D graphics settings.
+	/// </summary>
+	/// <remarks>
+	/// Changing values that can be accessed by this class will affect all scripts including game ysc scripts
+	/// and external scripts not for SHVDN.
+	/// </remarks>
+	public static class Scripted2DGfxSettings
+	{
+		/// <summary>
+		/// Sets whether to display this scripted gfx when the game pauses where the pause menu is drawn.
+		/// The setting is defaulted to off (<see langword="false"/>).
+		/// </summary>
+		public static bool DrawsBehindPauseMenu
+		{
+			set => Function.Call(Hash.SET_SCRIPT_GFX_DRAW_BEHIND_PAUSEMENU, value);
+		}
+
+		/// <summary>
+		/// Sets scripted graphics draw order.
+		/// The default setting is <see cref="ScriptedGfxDrawOrder.AfterHud"/>.
+		/// </summary>
+		public static ScriptedGfxDrawOrder DrawOrder
+		{
+			set => Function.Call(Hash.SET_SCRIPT_GFX_DRAW_ORDER, (int)value);
+		}
+
+		/// <summary>
+		/// Sets the alignment type to the safezone.
+		/// </summary>
+		/// <param name="alignX">
+		/// The x alignment type.
+		/// The following is the acceptable values that make the game aligns 2D graphic elements differently:
+		/// <see cref="UIAlignment.Left"/>, <see cref="UIAlignment.Right"/>, and <see cref="UIAlignment.Center"/>.
+		/// </param>
+		/// <param name="alignY">
+		///	The y alignment type.
+		/// The following is the acceptable values that make the game aligns 2D graphic elements differently:
+		/// <see cref="UIAlignment.Top"/>, <see cref="UIAlignment.Bottom"/>, and <see cref="UIAlignment.Center"/>.
+		/// </param>
+		public static void SetAlignmentType(UIAlignment alignX, UIAlignment alignY)
+			=> Function.Call(Hash.SET_SCRIPT_GFX_ALIGN_PARAMS, (byte)alignX, (byte)alignY);
+
+		/// <summary>
+		/// Sets the alignment offset and size.
+		/// </summary>
+		/// <param name="offset">
+		/// <para>
+		/// The <see cref="PointF"/> value to offset all x, y coords passed to 2d renderer,
+		/// where 0 is at the top left corner of the screen and 1 is at the bottom right corner of the screen.
+		/// </para>
+		/// <para>
+		/// Set <c>new PointF(0, 0)</c> to revert to the default value.
+		/// The method will not assert that both offset values are within the range of 0 to 1 inclusive.
+		/// </para>
+		/// </param>
+		/// <param name="size">
+		/// <para>
+		/// If you are aligned to the right or bottom of the screen, it assumes the x or y size of everything is this.
+		/// This makes the calculations for positioning multiple UI elements of different sizes easier.
+		/// Set this to the size of the largest element.
+		/// </para>
+		/// <para>
+		/// Set <c>new SizeF(0, 0)</c> to revert to the default value.
+		/// The method will not assert that both size values are within the range of 0 to 1 inclusive.
+		/// </para>
+		/// </param>
+		public static void SetAlignmentOffsetAndSize(PointF offset, SizeF size)
+			=> Function.Call(Hash.SET_SCRIPT_GFX_ALIGN_PARAMS, offset.X, offset.Y, size.Width, size.Height);
+
+		/// <summary>
+		/// Resets all the alignment parameters to unaligned with no offsets.
+		/// </summary>
+		/// <remarks>
+		/// Calling this method has the same effect as calling <see cref="SetAlignmentType"/> with both paramters
+		/// assigned to <see cref="UIAlignment.Ignore"/> and calling <see cref="SetAlignmentOffsetAndSize(PointF, SizeF)"/>
+		/// with the zero offset and the zero size.
+		/// </remarks>
+		public static void ResetAlignment() => Function.Call(Hash.RESET_SCRIPT_GFX_ALIGN);
+
+		/// <summary>
+		/// Get a position on screen given the current alignment setup.
+		/// </summary>
+		/// <param name="offset">
+		/// The input <see cref="PointF"/> value in screen space (not 1280x720 screen pixel space),
+		/// where 0 is at the top left corner of the screen and 1 is at the bottom right corner of the screen.
+		/// </param>
+		public static PointF GetAlignPosition(PointF offset)
+		{
+			unsafe
+			{
+				float newX, newY;
+				Function.Call(Hash.GET_SCRIPT_GFX_ALIGN_POSITION, offset.X, offset.Y, &newX, &newY);
+				return new PointF(newX, newY);
+			}
+		}
+	}
+}

--- a/source/scripting_v3/GTA.Graphics/ScriptedGfxDrawOrder.cs
+++ b/source/scripting_v3/GTA.Graphics/ScriptedGfxDrawOrder.cs
@@ -1,0 +1,25 @@
+//
+// Copyright (C) 2023 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+namespace GTA.Graphics
+{
+	public enum ScriptedGfxDrawOrder
+	{
+		BeforeHudPriorityLow,
+		BeforeHud,
+		BeforeHudPriorityHigh,
+		AfterHudPriorityLow,
+		/// <summary>
+		/// The default value.
+		/// When you draw scripted graphics such as texts, rects, or textures on a render target (texture),
+		/// you need to specify this value.
+		/// </summary>
+		AfterHud,
+		AfterHudPriorityHigh,
+		AfterFadePriorityLow,
+		AfterFade,
+		AfterFadePriorityHigh,
+	}
+}

--- a/source/scripting_v3/GTA.Graphics/UIAlignment.cs
+++ b/source/scripting_v3/GTA.Graphics/UIAlignment.cs
@@ -1,0 +1,65 @@
+//
+// Copyright (C) 2023 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+namespace GTA.Graphics
+{
+	/// <summary>
+	/// An enumeration of all possible values where scripted draw commands align 2d graphic elements in different ways
+	/// and the default value for no special alignment.
+	/// </summary>
+	/// <remarks>
+	/// This enumeration specifies <see cref="byte"/> as the base type as the game internally uses 1-byte values
+	/// for UI alignment types.
+	/// </remarks>
+	public enum UIAlignment : byte
+	{
+		/// <summary>
+		/// The left alignment value, which can be used for the horizonal alignment.
+		/// </summary>
+		/// <remarks>
+		/// Represents 'L' out of the  ASCII characters.
+		/// </remarks>
+		Left = 76,
+		/// <summary>
+		/// The right alignment value, which can be used for the horizonal alignment.
+		/// </summary>
+		/// <remarks>
+		/// Represents 'R' out of the ASCII characters.
+		/// </remarks>
+		Right = 82,
+		/// <summary>
+		/// The top alignment value, which can be used for the vertical alignment.
+		/// </summary>
+		/// <remarks>
+		/// Represents 'T' out of the ASCII characters.
+		/// </remarks>
+		Top = 84,
+		/// <summary>
+		/// The bottom alignment value, which can be used for the vertical alignment.
+		/// </summary>
+		/// <remarks>
+		/// Rrepresents 'B' out of the ASCII characters.
+		/// </remarks>
+		Bottom = 66,
+		/// <summary>
+		/// The center alignment value, which can be used for both horizonal and vertical alignment.
+		/// </summary>
+		/// <remarks>
+		/// Represents 'C' out of the ASCII characters.
+		/// </remarks>
+		Center = 67,
+		/// <summary>
+		/// The canonical value of the ignore value (represents 'I' in ASCII characters),
+		/// where script 2d draw commands skips the UI alignment.
+		/// </summary>
+		/// <remarks>
+		/// Although this value is the initial value for the UI alignment when the game launches,
+		/// script 2d draw commands do some alignment operation only if one of the acceptable values is set
+		/// (you can confirm this by searching the function that can be found with
+		/// <c>"40 80 FE 4C 75 08 F3 0F 10 7C 24 78 EB 2A 40 80 FE 52 75 0C"</c>).
+		/// </remarks>
+		Ignore = 73,
+	}
+}


### PR DESCRIPTION
Related to #1282

You have to use memory patterns/signatures to get scripted 2d gfx draw settings, and that made me choose not to use regular classes (so you can place a instance to UI classes like `ContainerElement`). If some game update breaks memory stuff and that makes a lot of scripts having to wait for a SHVDN update to draw 2d gfx correctly, we would get a lot of complaint about 2d gfx stuff.

We could reset stuff after each draw, but I think that may make script devs have trouble with weird resetting behavior I guess? For your information, text style values will reset after each text draw.