### PR TITLE
fix(core): use dedicated thread for CLR to avoid CLR crashing for false stack overflow on initial startup

### DIFF
--- a/source/core/Console.cs
+++ b/source/core/Console.cs
@@ -1098,7 +1098,7 @@ namespace SHVDN
 			float w = (float)(width) / BaseWidth;
 			float h = (float)(height) / BaseHeight;
 
-			NativeFunc.InvokeInternal(0x3A618A217E5154F0ul /* DRAW_RECT */,
+			NativeFunc.Invoke(0x3A618A217E5154F0ul /* DRAW_RECT */,
 				(x / BaseWidth) + w * 0.5f,
 				(y / BaseHeight) + h * 0.5f,
 				w, h,
@@ -1107,32 +1107,32 @@ namespace SHVDN
 
 		private static unsafe void DrawText(float x, float y, string text, Color color)
 		{
-			NativeFunc.InvokeInternal(0x66E0276CC5F6B9DA /* SET_TEXT_FONT */, 0); // Chalet London :>
-			NativeFunc.InvokeInternal(0x07C837F9A01C34C9 /* SET_TEXT_SCALE */, 0.35f, 0.35f);
-			NativeFunc.InvokeInternal(0xBE6B23FFA53FB442 /* SET_TEXT_COLOUR */, color.R, color.G, color.B, color.A);
-			NativeFunc.InvokeInternal(0x25FBB336DF1804CB /* BEGIN_TEXT_COMMAND_DISPLAY_TEXT */, NativeMemory.CellEmailBcon);
+			NativeFunc.Invoke(0x66E0276CC5F6B9DA /* SET_TEXT_FONT */, 0); // Chalet London :>
+			NativeFunc.Invoke(0x07C837F9A01C34C9 /* SET_TEXT_SCALE */, 0.35f, 0.35f);
+			NativeFunc.Invoke(0xBE6B23FFA53FB442 /* SET_TEXT_COLOUR */, color.R, color.G, color.B, color.A);
+			NativeFunc.Invoke(0x25FBB336DF1804CB /* BEGIN_TEXT_COMMAND_DISPLAY_TEXT */, NativeMemory.CellEmailBcon);
 			NativeFunc.PushLongString(text, 99);
-			NativeFunc.InvokeInternal(0xCD015E5BB0D96A57 /* END_TEXT_COMMAND_DISPLAY_TEXT */, (x / BaseWidth), (y / BaseHeight));
+			NativeFunc.Invoke(0xCD015E5BB0D96A57 /* END_TEXT_COMMAND_DISPLAY_TEXT */, (x / BaseWidth), (y / BaseHeight));
 		}
 
 		private static unsafe void DisableControlsThisFrame()
 		{
-			NativeFunc.InvokeInternal(0x5F4B6931816E599B /* DISABLE_ALL_CONTROL_ACTIONS */, 0);
+			NativeFunc.Invoke(0x5F4B6931816E599B /* DISABLE_ALL_CONTROL_ACTIONS */, 0);
 
 			// LookLeftRight .. LookRightOnly
 			for (ulong i = 1; i <= 6; i++)
 			{
-				NativeFunc.InvokeInternal(0x351220255D64C155 /* ENABLE_CONTROL_ACTION */, 0, i, 0);
+				NativeFunc.Invoke(0x351220255D64C155 /* ENABLE_CONTROL_ACTION */, 0, i, 0);
 			}
 		}
 
 		private static unsafe float GetTextLength(string text)
 		{
-			NativeFunc.InvokeInternal(0x66E0276CC5F6B9DA /* SET_TEXT_FONT */, 0);
-			NativeFunc.InvokeInternal(0x07C837F9A01C34C9 /* SET_TEXT_SCALE */, 0.35f, 0.35f);
-			NativeFunc.InvokeInternal(0x54CE8AC98E120CAB /* BEGIN_TEXT_COMMAND_GET_SCREEN_WIDTH_OF_DISPLAY_TEXT */, NativeMemory.CellEmailBcon);
+			NativeFunc.Invoke(0x66E0276CC5F6B9DA /* SET_TEXT_FONT */, 0);
+			NativeFunc.Invoke(0x07C837F9A01C34C9 /* SET_TEXT_SCALE */, 0.35f, 0.35f);
+			NativeFunc.Invoke(0x54CE8AC98E120CAB /* BEGIN_TEXT_COMMAND_GET_SCREEN_WIDTH_OF_DISPLAY_TEXT */, NativeMemory.CellEmailBcon);
 			NativeFunc.PushLongString(text, 98); // 99 byte string chunks don't process properly in END_TEXT_COMMAND_GET_SCREEN_WIDTH_OF_DISPLAY_TEXT
-			return *(float*)NativeFunc.InvokeInternal(0x85F061DA64ED2F67 /* END_TEXT_COMMAND_GET_SCREEN_WIDTH_OF_DISPLAY_TEXT */, true);
+			return *(float*)NativeFunc.Invoke(0x85F061DA64ED2F67 /* END_TEXT_COMMAND_GET_SCREEN_WIDTH_OF_DISPLAY_TEXT */, true);
 		}
 
 		private static float GetMarginLength()

--- a/source/core/DllMain.cpp
+++ b/source/core/DllMain.cpp
@@ -322,7 +322,7 @@ HANDLE hClrWaitEvent;
 HANDLE hClrContinueEvent;
 
 // proper synchronization with event objects would cause a deadlock or timeout (for executing longer than 2 seconds)
-// in DllMain, so use a bool variable to tell procedures to the asi wants to get freed
+// in DllMain, so use a bool variable to tell procedures that the asi wants to get freed
 bool sClrThreadRequestedToExit = false;
 
 static DWORD CLRThreadProc(LPVOID lparam)

--- a/source/core/NativeFunc.cs
+++ b/source/core/NativeFunc.cs
@@ -87,7 +87,7 @@ namespace SHVDN
 			IntPtr strUtf8 = domain.PinString(str);
 
 			ulong strArg = (ulong)strUtf8.ToInt64();
-			domain.ExecuteTask(new NativeTaskPtrArgs
+			domain.ExecuteTaskWithGameThreadTlsContext(new NativeTaskPtrArgs
 			{
 				_hash = 0x6C188BE134E074AA /* ADD_TEXT_COMPONENT_SUBSTRING_PLAYER_NAME */,
 				_argumentPtr = &strArg,
@@ -251,7 +251,7 @@ namespace SHVDN
 			}
 
 			var task = new NativeTaskPtrArgs { _hash = hash, _argumentPtr = argPtr, _argumentCount = argCount };
-			domain.ExecuteTask(task);
+			domain.ExecuteTaskWithGameThreadTlsContext(task);
 
 			return task._result;
 		}
@@ -270,7 +270,7 @@ namespace SHVDN
 			}
 
 			var task = new NativeTask { _hash = hash, _arguments = args };
-			domain.ExecuteTask(task);
+			domain.ExecuteTaskWithGameThreadTlsContext(task);
 
 			return task._result;
 		}

--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -2147,7 +2147,7 @@ namespace SHVDN
 			var setEntityAngularVelocityDelegate = (delegate* unmanaged[Stdcall]<IntPtr, float*, void>)(vFuncAddr);
 
 			var task = new SetEntityAngularVelocityTask(entityAddress, setEntityAngularVelocityDelegate, x, y, z);
-			ScriptDomain.CurrentDomain.ExecuteTask(task);
+			ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
 		}
 
 
@@ -2766,13 +2766,13 @@ namespace SHVDN
 		public static void PunctureTire(IntPtr wheelAddress, float damage, IntPtr vehicleAddress)
 		{
 			var task = new VehicleWheelPunctureTask(wheelAddress, vehicleAddress, false, damage);
-			ScriptDomain.CurrentDomain.ExecuteTask(task);
+			ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
 		}
 
 		public static void BurstTireOnRim(IntPtr wheelAddress, IntPtr vehicleAddress)
 		{
 			var task = new VehicleWheelPunctureTask(wheelAddress, vehicleAddress, true);
-			ScriptDomain.CurrentDomain.ExecuteTask(task);
+			ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
 		}
 
 		// the function BurstVehicleTireOnRimNew(Old)Func calls must be called in the main thread or the game will crash
@@ -4043,7 +4043,7 @@ namespace SHVDN
 			var vehiclePool = new IntPtr(*(VehiclePool**)(*NativeMemory.s_vehiclePoolAddress));
 
 			var task = new FwScriptGuidPoolTask(FwScriptGuidPoolTask.PoolType.Vehicle, vehiclePool, modelHashes);
-			ScriptDomain.CurrentDomain.ExecuteTask(task);
+			ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
 
 			return task._resultHandles;
 		}
@@ -4057,7 +4057,7 @@ namespace SHVDN
 			var vehiclePool = new IntPtr(*(VehiclePool**)(*NativeMemory.s_vehiclePoolAddress));
 
 			var task = new FwScriptGuidPoolTask(FwScriptGuidPoolTask.PoolType.Vehicle, vehiclePool, position, radius * radius, modelHashes);
-			ScriptDomain.CurrentDomain.ExecuteTask(task);
+			ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
 
 			return task._resultHandles;
 		}
@@ -4078,7 +4078,7 @@ namespace SHVDN
 			}
 
 			var task = new FwScriptGuidPoolTask(FwScriptGuidPoolTask.PoolType.Projectile, new IntPtr(NativeMemory.s_projectilePoolAddress));
-			ScriptDomain.CurrentDomain.ExecuteTask(task);
+			ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
 
 			return task._resultHandles;
 		}
@@ -4090,7 +4090,7 @@ namespace SHVDN
 			}
 
 			var task = new FwScriptGuidPoolTask(FwScriptGuidPoolTask.PoolType.Projectile, new IntPtr(NativeMemory.s_projectilePoolAddress), position, radius * radius);
-			ScriptDomain.CurrentDomain.ExecuteTask(task);
+			ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
 
 			return task._resultHandles;
 		}
@@ -4105,7 +4105,7 @@ namespace SHVDN
 			}
 
 			var task = new FwScriptGuidPoolTask(FwScriptGuidPoolTask.PoolType.Generic, genericPool);
-			ScriptDomain.CurrentDomain.ExecuteTask(task);
+			ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
 
 			return task._resultHandles;
 		}
@@ -4119,7 +4119,7 @@ namespace SHVDN
 			}
 
 			var task = new FwScriptGuidPoolTask(FwScriptGuidPoolTask.PoolType.Generic, genericPool, modelHashes);
-			ScriptDomain.CurrentDomain.ExecuteTask(task);
+			ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
 
 			return task._resultHandles;
 		}
@@ -4133,7 +4133,7 @@ namespace SHVDN
 			}
 
 			var task = new FwScriptGuidPoolTask(FwScriptGuidPoolTask.PoolType.Generic, genericPool, position, radius * radius, modelHashes);
-			ScriptDomain.CurrentDomain.ExecuteTask(task);
+			ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
 
 			return task._resultHandles;
 		}
@@ -4467,7 +4467,7 @@ namespace SHVDN
 			}
 
 			var task = new ActivateSpecialAbilityTask(specialAbilityAddr);
-			ScriptDomain.CurrentDomain.ExecuteTask(task);
+			ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
 		}
 		public static IntPtr GetPrimarySpecialAbilityStructAddress(int playerIndex)
 		{
@@ -5535,7 +5535,7 @@ namespace SHVDN
 		{
 			var task = new GetAllCScriptResourceHandlesTask(CScriptResourceTypeNameIndex.Checkpoint);
 
-			ScriptDomain.CurrentDomain.ExecuteTask(task);
+			ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
 
 			return task._returnHandles;
 		}
@@ -5544,7 +5544,7 @@ namespace SHVDN
 		{
 			var task = new GetCScriptResourceAddressTask(handle, s_checkpointPoolAddress, 0x60);
 
-			ScriptDomain.CurrentDomain.ExecuteTask(task);
+			ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
 
 			return task._returnAddress;
 		}
@@ -5563,7 +5563,7 @@ namespace SHVDN
 
 			var task = new GetCScriptResourceByIndexTask(CScriptResourceTypeNameIndex.ScaleformMovie, handle);
 
-			ScriptDomain.CurrentDomain.ExecuteTask(task);
+			ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
 
 			return task._result != null;
 		}
@@ -5673,7 +5673,7 @@ namespace SHVDN
 		public static void ExplodeProjectile(IntPtr projectileAddress)
 		{
 			var task = new ExplodeProjectileTask(projectileAddress);
-			ScriptDomain.CurrentDomain.ExecuteTask(task);
+			ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
 		}
 
 		internal sealed class ExplodeProjectileTask : IScriptTask
@@ -5762,7 +5762,7 @@ namespace SHVDN
 		{
 			var task = new GetEntityHandleTask(address);
 
-			ScriptDomain.CurrentDomain.ExecuteTask(task);
+			ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
 
 			return task._returnEntityHandle;
 		}
@@ -6496,7 +6496,7 @@ namespace SHVDN
 			}
 
 			var task = new DetachFragmentPartByIndexTask(fragInst, fragmentGroupIndex);
-			ScriptDomain.CurrentDomain.ExecuteTask(task);
+			ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
 
 			return task._wasNewFragInstCreated;
 		}
@@ -6785,7 +6785,7 @@ namespace SHVDN
 		public static void SendNmMessage(int targetHandle, string messageName, Dictionary<string, (int value, Type type)> boolIntFloatParameters, Dictionary<string, object> stringVector3ArrayParameters)
 		{
 			var task = new NmMessageTask(targetHandle, messageName, boolIntFloatParameters, stringVector3ArrayParameters);
-			ScriptDomain.CurrentDomain.ExecuteTask(task);
+			ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
 		}
 
 		#endregion

--- a/source/core/ScriptDomain.cs
+++ b/source/core/ScriptDomain.cs
@@ -32,6 +32,9 @@ namespace SHVDN
 		[DllImport("Kernel32.dll")]
 		internal static extern bool IsDebuggerPresent();
 
+		[DllImport("kernel32.dll")]
+		private static extern uint GetCurrentThreadId();
+
 		private int _executingThreadId = Thread.CurrentThread.ManagedThreadId;
 		private Script _executingScript = null;
 		private List<IntPtr> _pinnedStrings = new();
@@ -45,14 +48,24 @@ namespace SHVDN
 
 		private unsafe delegate* unmanaged[Cdecl]<IntPtr> _getTlsContext;
 		private unsafe delegate* unmanaged[Cdecl]<IntPtr, void> _setTlsContext;
-		private IntPtr _tlsContextOfMainThread;
 
-		internal unsafe void InitTlsContext(IntPtr getTlsContextFunc, IntPtr setTlsContextFunc)
+		private IntPtr _tlsContextOfMainThread;
+		private uint _gameMainThreadIdUnmanaged;
+
+		internal unsafe void InitTlsFunctionPointers(IntPtr getTlsContextFunc, IntPtr setTlsContextFunc)
 		{
 			_getTlsContext = (delegate* unmanaged[Cdecl]<IntPtr>)getTlsContextFunc;
 			_setTlsContext = (delegate* unmanaged[Cdecl]<IntPtr, void>)setTlsContextFunc;
+		}
 
-			_tlsContextOfMainThread = _getTlsContext();
+		internal unsafe void SetTlsContextOfGameMainThread(IntPtr tlsAddr)
+		{
+			_tlsContextOfMainThread = tlsAddr;
+		}
+
+		internal unsafe void SetGameMainThreadId(uint threadId)
+		{
+			_gameMainThreadIdUnmanaged = threadId;
 		}
 
 		/// <summary>
@@ -662,44 +675,51 @@ namespace SHVDN
 		}
 
 		/// <summary>
-		/// Execute a script task in this script domain.
+		/// Execute a script task in this script domain with the tls context of the main thread of the exe.
+		/// You must use this method when you call native functions or functions that may access some
+		/// resources of the tls context of the main thread, such as a <c>rage::sysMemAllocator</c>.
 		/// </summary>
 		/// <param name="task">The task to execute.</param>
-		/// <param name="forceMainThread">Specifies whether to force to execute the task on the main thread.</param>
-		public void ExecuteTask(IScriptTask task, bool forceMainThread = false)
+		public void ExecuteTaskWithGameThreadTlsContext(IScriptTask task)
 		{
-			if (Thread.CurrentThread.ManagedThreadId == _executingThreadId)
+			if (_gameMainThreadIdUnmanaged == GetCurrentThreadId())
 			{
-				// Request came from the main thread, so can just execute it right away
+				// Request came from the main thread of the exe, so can just execute it right away
 				task.Run();
 			}
 			else
 			{
-				// Request came from the script thread
-				if (!forceMainThread)
+				unsafe
 				{
-					unsafe
-					{
-						if (_getTlsContext != null && _setTlsContext != null)
-						{
-							IntPtr tlsContextOfScriptThread = _getTlsContext();
-							_setTlsContext(_tlsContextOfMainThread);
+					IntPtr tlsContextOfScriptThread = _getTlsContext();
+					_setTlsContext(_tlsContextOfMainThread);
 
-							try
-							{
-								task.Run();
-							}
-							finally
-							{
-								// Need to revert TLS context to the real one of the script thread
-								_setTlsContext(tlsContextOfScriptThread);
-							}
-							return;
-						}
+					try
+					{
+						task.Run();
+					}
+					finally
+					{
+						// Need to revert TLS context to the real one of the script thread
+						_setTlsContext(tlsContextOfScriptThread);
 					}
 				}
+			}
+		}
 
-				// Need to pass the task to the domain thread and execute it there as a fallback
+		/// <summary>
+		/// Execute a script task in this script domain.
+		/// </summary>
+		/// <param name="task">The task to execute.</param>
+		public void ExecuteTaskInScriptDomainThread(IScriptTask task)
+		{
+			if (Thread.CurrentThread.ManagedThreadId == _executingThreadId)
+			{
+				// Request came from the script domain thread, so can just execute it right away
+				task.Run();
+			}
+			else
+			{
 				_taskQueue.Enqueue(task);
 				SignalAndWait(_executingScript._waitEvent, _executingScript._continueEvent);
 			}

--- a/source/core/ScriptDomain.cs
+++ b/source/core/ScriptDomain.cs
@@ -597,9 +597,9 @@ namespace SHVDN
 
 					unsafe
 					{
-						NativeFunc.InvokeInternal(0x202709F4C58A0424 /* BEGIN_TEXT_COMMAND_THEFEED_POST */, NativeMemory.CellEmailBcon);
+						NativeFunc.Invoke(0x202709F4C58A0424 /* BEGIN_TEXT_COMMAND_THEFEED_POST */, NativeMemory.CellEmailBcon);
 						NativeFunc.PushLongString($"~o~WARNING~s~: {scriptCountUsingDeprecatedApi} scripts are using the v2 API, which is deprecated and not actively supported. See the console outputs or the log file for more details.");
-						NativeFunc.InvokeInternal(0x2ED7843F8F801023 /* END_TEXT_COMMAND_THEFEED_POST_TICKER */, true, false);
+						NativeFunc.Invoke(0x2ED7843F8F801023 /* END_TEXT_COMMAND_THEFEED_POST_TICKER */, true, false);
 					}
 				}
 

--- a/source/scripting_v3/GTA/Shvdn/Script/Script.cs
+++ b/source/scripting_v3/GTA/Shvdn/Script/Script.cs
@@ -291,7 +291,7 @@ namespace GTA
 		public static T InstantiateScript<T>() where T : Script
 		{
 			var task = new InstantiateScriptTask { _type = typeof(T) };
-			SHVDN.ScriptDomain.CurrentDomain.ExecuteTask(task, true);
+			SHVDN.ScriptDomain.CurrentDomain.ExecuteTaskInScriptDomainThread(task);
 
 			if (task._script == null)
 			{


### PR DESCRIPTION
Fixes #976

Basic idea is taken from #1181, and the credit goes to @Sardelka9515. I add some cleanup code to avoid the exe being blocked from exiting (works as well as da63afd).

I tested this PR, and at least SHVDN will be reloaded after a new session is created and SHVDN won't block the exe from exiting when you tell the game to close the game. c4b243c and later commits would behave pretty much the same as 1f001b2 except for stability, thread synchronization that is necessary for runtime stability, and a little performance penalty difference.