### PR TITLE
feat(api-v3): RagdollBlockingFlags, Ped.SetRagdollBlockingFlags, and Ped.ClearRagdollBlockingFlags

### DIFF
--- a/source/scripting_v3/GTA/Entities/Peds/Ped.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Ped.cs
@@ -1063,6 +1063,20 @@ namespace GTA
 			Function.Call(Hash.SET_PED_TO_RAGDOLL, Handle, 1, 1, 1, false, false, false);
 		}
 
+		/// <summary>
+		/// Blocks ragdoll reactions from various forms of damage.
+		/// </summary>
+		public void SetRagdollBlockingFlags(RagdollBlockingFlags flags = RagdollBlockingFlags.BulletImpact)
+		{
+			Function.Call(Hash.SET_RAGDOLL_BLOCKING_FLAGS, Handle, (int)flags);
+		}
+		/// <summary>
+		/// Re-enables ragdoll reactions from various forms of damage.
+		/// </summary>
+		public void ClearRagdollBlockingFlags(RagdollBlockingFlags flags = RagdollBlockingFlags.BulletImpact)
+		{
+			Function.Call(Hash.CLEAR_RAGDOLL_BLOCKING_FLAGS, Handle, (int)flags);
+		}
 
 		/// <summary>
 		/// Gets or sets whether this <see cref="Ped"/> is ragdolling.

--- a/source/scripting_v3/GTA/Entities/Peds/RagdollBlockingFlags.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/RagdollBlockingFlags.cs
@@ -1,0 +1,59 @@
+//
+// Copyright (C) 2023 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+using System;
+
+namespace GTA
+{
+	/// <summary>
+	/// An enumeration of possible flags used to disable ragdoll behaviors from various sources.
+	/// </summary>
+	[Flags]
+	public enum RagdollBlockingFlags
+	{
+		BulletImpact = 1,
+		VehicleImpact = 2,
+		Fire = 4,
+		Electrocution = 8,
+		/// <summary>
+		/// Blocks ragdoll activation from any impact with a <see cref="Ped"/> (player characters running into
+		/// the <see cref="Ped"/>, or active ragdolls colliding with them).
+		/// </summary>
+		PlayerImpact = 16,
+		Explosion = 32,
+		ImpactObject = 64,
+		Melee = 128,
+		RubberBullet = 256,
+		Falling = 512,
+		WaterJet = 1024,
+		Drowning = 2048,
+		/// <summary>
+		/// Allows blocking of ragdoll activation for dead <see cref="Ped"/>s.
+		/// By default, dead <see cref="Ped"/>s' ragdolls are allowed to activate regardless of how these flags
+		/// have been set.
+		/// </summary>
+		AllowBlockDeadPed = 4096,
+		/// <summary>
+		/// Blocks ragdoll activation from an animated player running into the character (but not from collisions
+		/// with other ragdolls).
+		/// </summary>
+		PlayerBump = 8192,
+		/// <summary>
+		/// Blocks ragdoll activation from a ragdolling player colliding with the character (but not from animated
+		/// player bumps or collisions with active non-player ragdolls).
+		/// </summary>
+		PlayerRagdollBump = 16384,
+		/// <summary>
+		/// Blocks ragdoll activation from a ragdolling non-player colliding with the character (but not from any
+		/// collisions with players, ragdolling or otherwise).
+		/// </summary>
+		PedRagdollBump = 32768,
+		/// <summary>
+		/// Blocks ragdoll activation from grabbing a <see cref="Vehicle"/> door whilst it pulls away.
+		/// </summary>
+		VehicleGrab = 65536,
+		SmokeGrenade = 131072,
+	}
+}


### PR DESCRIPTION
I was being tired of weird game crashes that were probably not caused by some factor other than our codebase, and simple feature addition.

I was being paranoid since launcher.log reported my GTA5.exe crashed for 0xc0000374 (STATUS_HEAP_CORRUPTION). It seems that it wasn't because SHVDN did something wrong but because old NVIDIA driver 535.98 caused that, though. At least SHVDN always crashed before calling `nativeInit` of SHV when said crash happened. I haven't encountered those weird crashes since I updated my NVIDIA driver to 536.67 (I've launched the exe more than 20 times since I updated the driver, the exe was crashed every 8 or 10 times when I used NVIDIA driver 535.98).
I don't think #1286 wasn't needed though, since VEH can catch STATUS_HEAP_CORRUPTION exceptions and one of .NET runtime may throw a false stack overflow exception instead. Also, any .NET exception created in our script domain might have turned into a false stack overflow exception without that PR if what LMS said in #976 is correct in how .NET exceptions are handled.