### PR TITLE
feat(api-v3): ScriptVehicleWheelIndex, tire wear rate properties, and methods for hydraulic suspention raise factor

### DIFF
--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -790,8 +790,14 @@ namespace SHVDN
 				address = FindPatternNaive("\x45\x84\xF6\x74\x08\xF3\x0F\x59\x0D\x00\x00\x00\x00\xF3\x0F\x10\x83", "xxxxxxxxx????xxxx");
 				if (address != null)
 				{
-					VehicleTireWearMultiplierOffset = *(int*)(address + 0x22);
-					// Note: The values for SET_TYRE_WEAR_RATE_SCALE and SET_TYRE_MAXIMUM_GRIP_DIFFERENCE_DUE_TO_WEAR_RATE are not present in b1868
+					VehicleTireWearRateOffset = *(int*)(address + 0x22);
+
+					// The values for SET_TYRE_WEAR_RATE_SCALE and SET_TYRE_MAXIMUM_GRIP_DIFFERENCE_DUE_TO_WEAR_RATE are not present in b1868
+					if (gameVersion >= 59)
+					{
+						VehicleWheelMaxGripDiffDueToWearRateOffset = VehicleTireWearRateOffset + 4;
+						VehicleTireWearRateScaleOffset = VehicleTireWearRateOffset + 8;
+					}
 				}
 			}
 
@@ -2703,7 +2709,13 @@ namespace SHVDN
 
 		public static int VehicleTireHealthOffset { get; }
 
-		public static int VehicleTireWearMultiplierOffset { get; }
+		public static int VehicleTireWearRateOffset { get; }
+		/// <summary>
+		/// This value only affects how fast a vehicle tire health decreases, which is different from
+		/// <see cref="VehicleTireWearRateOffset"/>.
+		/// </summary>
+		public static int VehicleWheelMaxGripDiffDueToWearRateOffset { get; }
+		public static int VehicleTireWearRateScaleOffset { get; }
 
 		// the on fire offset is the same as this offset
 		public static int VehicleWheelTouchingFlagsOffset { get; }

--- a/source/scripting_v3/GTA/Entities/Vehicles/ScriptVehicleWheelIndex.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/ScriptVehicleWheelIndex.cs
@@ -1,0 +1,34 @@
+//
+// Copyright (C) 2023 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+namespace GTA
+{
+	public enum ScriptVehicleWheelIndex
+	{
+		/// <summary>
+		/// The invalid value for <see cref="VehicleWheel.ScriptIndex"/>.
+		/// Do not directly use this value for native functions.
+		/// </summary>
+		Invalid = -1,
+		CarFrontLeft,
+		CarFrontRight,
+		CarMidLeft,
+		CarMidRight,
+		CarRearLeft,
+		CarRearRight,
+		/// <remarks>
+		/// Internally specifies the same wheel index as <see cref="CarFrontLeft"/>.
+		/// <see cref="VehicleWheel.ScriptIndex"/> will never return this value when you get a <see cref="VehicleWheel"/>
+		/// via <see cref="VehicleWheelCollection.this[VehicleWheelBoneId]"/> and will return <see cref="CarFrontLeft"/> instead.
+		/// </remarks>
+		BikeFront,
+		/// <remarks>
+		/// Internally specifies the same wheel index as <see cref="CarRearLeft"/>.
+		/// <see cref="VehicleWheel.ScriptIndex"/> will never return this value when you get a <see cref="VehicleWheel"/>
+		/// via <see cref="VehicleWheelCollection.this[VehicleWheelBoneId]"/> and will return <see cref="CarRearLeft"/> instead.
+		/// </remarks>
+		BikeRear
+	}
+}

--- a/source/scripting_v3/GTA/Entities/Vehicles/VehicleWheel.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/VehicleWheel.cs
@@ -466,6 +466,12 @@ namespace GTA
 		/// Will throw <see cref="GameVersionNotSupportedException"/> if the setter is called in earlier versions (the getter always returns <see langword="false"/> in earlier versions).
 		/// </para>
 		/// </summary>
+		/// <remarks>
+		/// This property represents the wear rate property <c>SET_TYRE_WEAR_RATE</c> is supposed to change,
+		/// but Script Hook V does never call it and instead calls <c>SET_TYRE_WEAR_RATE_SCALE</c> in versions that
+		/// support up to v1.0.2944.0 or some earlier game version (you can actually call <c>SET_TYRE_WEAR_RATE</c>
+		/// in RAGE Plugin Hook and FiveM, and you can call <c>GET_TYRE_WEAR_RATE</c> in SHV scripts).
+		/// </remarks>
 		/// <exception cref="GameVersionNotSupportedException">
 		/// Thrown when called on a game version prior to v1.0.1868.0.
 		/// </exception>
@@ -506,6 +512,8 @@ namespace GTA
 		/// <summary>
 		/// <para>
 		/// Gets or sets the difference in tire grip.
+		/// The more this value is, the more traction the wheel loses of traction produced from <see cref="WearMultiplier"/>.
+		/// Should be between a wear rate of 1 and 0.
 		/// </para>
 		/// <para>
 		/// Only supported in v1.0.2060.0 and later versions.
@@ -515,7 +523,7 @@ namespace GTA
 		/// <exception cref="GameVersionNotSupportedException">
 		/// Thrown when called on a game version prior to v1.0.2060.0.
 		/// </exception>
-		public float MaxDifferenceDueToWearRate
+		public float MaxGripDifferenceDueToWearRate
 		{
 			get
 			{
@@ -555,6 +563,10 @@ namespace GTA
 		/// Will throw <see cref="GameVersionNotSupportedException"/> if the setter is called in earlier versions (the getter always returns <see langword="false"/> in earlier versions).
 		/// </para>
 		/// </summary>
+		/// <remarks>
+		/// This property represents the wear rate scale property, which <c>SET_TYRE_WEAR_RATE_SCALE</c> is supposed to
+		/// change, not the the wear rate property, which <c>SET_TYRE_WEAR_RATE</c> is supposed to change.
+		/// </remarks>
 		/// <exception cref="GameVersionNotSupportedException">
 		/// Thrown when called on a game version prior to v1.0.2060.0.
 		/// </exception>

--- a/source/scripting_v3/GTA/Entities/Vehicles/VehicleWheelCollection.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/VehicleWheelCollection.cs
@@ -15,44 +15,12 @@ namespace GTA
 		// Vehicles have up to 10 wheels
 		const int MAX_WHEEL_COUNT = 10;
 		readonly VehicleWheel[] _vehicleWheels = new VehicleWheel[MAX_WHEEL_COUNT];
-		VehicleWheel[] _vehicleWheelsForIndex6And7;
 		VehicleWheel _nullWheel;
 		#endregion
 
 		internal VehicleWheelCollection(Vehicle owner)
 		{
 			Vehicle = owner;
-		}
-
-		[Obsolete("VehicleWheel indexer overload with int index does not support any of the wheels wheel_lm2, wheel_rm2, wheel_lm3, or wheel_lm3, but provided for legacy scripts compatibility in v3 API. Use VehicleWheel indexer overload with VehicleWheelBoneId enum instead.")]
-		public VehicleWheel this[int index]
-		{
-			get
-			{
-				// Return null wheel instance to avoid scripts that targets to between 3.0 to 3.1 not working due to a exception
-				// The vehicle wheel id array for natives defines only 8 elements, and any other values can result in undefined behavior or even memory access violation
-				if (index < 0 || index > 7)
-				{
-					return _nullWheel ?? (_nullWheel = new VehicleWheel(Vehicle, -1));
-				}
-
-				if (index < 6)
-				{
-					VehicleWheelBoneId boneId = VehicleWheel.vehicleWheelBoneIndexTableForNatives[index];
-					int boneIndexZeroBased = (int)boneId - 11;
-					return _vehicleWheels[boneIndexZeroBased] ?? (_vehicleWheels[boneIndexZeroBased] = new VehicleWheel(Vehicle, index));
-				}
-				// Use a special array in case some scripts access to index 6 or 7 wheel and read Index property
-				else
-				{
-					if (_vehicleWheelsForIndex6And7 == null)
-					{
-						_vehicleWheelsForIndex6And7 = new VehicleWheel[2];
-					}
-
-					return _vehicleWheelsForIndex6And7[index - 6] ?? (_vehicleWheelsForIndex6And7[index - 6] = new VehicleWheel(Vehicle, index));
-				}
-			}
 		}
 
 		public VehicleWheel this[VehicleWheelBoneId boneId]
@@ -66,6 +34,39 @@ namespace GTA
 
 				int boneIndexZeroBased = (int)boneId - 11;
 				return _vehicleWheels[boneIndexZeroBased] ?? (_vehicleWheels[boneIndexZeroBased] = new VehicleWheel(Vehicle, boneId));
+			}
+		}
+		public VehicleWheel this[ScriptVehicleWheelIndex index]
+		{
+			get
+			{
+				int indexInt = (int)index;
+				if (indexInt < 0 || indexInt > 7)
+				{
+					throw new ArgumentOutOfRangeException(nameof(index));
+				}
+
+				VehicleWheelBoneId boneId = VehicleWheel.vehicleWheelBoneIndexTableForNatives[indexInt];
+				int boneIndexZeroBased = (int)boneId - 11;
+				return _vehicleWheels[boneIndexZeroBased] ?? (_vehicleWheels[boneIndexZeroBased] = new VehicleWheel(Vehicle, index));
+			}
+		}
+
+		[Obsolete("Use VehicleWheelCollection.this[ScriptVehicleWheelIndex] instead.")]
+		public VehicleWheel this[int index]
+		{
+			get
+			{
+				// Return null wheel instance to avoid scripts that targets to between 3.0 to 3.1 not working due to a exception
+				// The vehicle wheel id array for natives defines only 8 elements, and any other values can result in undefined behavior or even memory access violation
+				if (index < 0 || index > 7)
+				{
+					return _nullWheel ?? (_nullWheel = new VehicleWheel(Vehicle, -1));
+				}
+
+				VehicleWheelBoneId boneId = VehicleWheel.vehicleWheelBoneIndexTableForNatives[index];
+				int boneIndexZeroBased = (int)boneId - 11;
+				return _vehicleWheels[boneIndexZeroBased] ?? (_vehicleWheels[boneIndexZeroBased] = new VehicleWheel(Vehicle, index));
 			}
 		}
 


### PR DESCRIPTION
Why `VehicleWheel.SetHydraulicSuspensionRaiseFactor` and `VehicleWheel.GetHydraulicSuspensionRaiseFactor` don't (bother to) support middle wheel 2 and middle wheel 3? Because car hydraulic doesn't make much sense for those wheels.
Why you can't call the correct function for `SET_TYRE_WEAR_RATE` in SHV scripts (and instead that call will result in invocation of `SET_TYRE_WEAR_RATE_SCALE`), while you can call the correct one in RPH or FiveM? Because SHV mapped wrong in versions that support up to v1.0.2944.0 or a older game version (wrongly maps hashes for `SET_TYRE_WEAR_RATE_SCALE`). I reported [the issue](https://gtaforums.com/topic/932648-script-hook-v/?do=findComment&comment=1072185375) btw. Ffs, AB, that incorrect mapping must have bothered some people who create scripts for SHV 😭 (I wasn't one of them really though.)

This PR also adds `ScriptVehicleWheelIndex` for future convenience.