### PR TITLE
feat(api-v3): Add cinematic camera director class

### DIFF
--- a/source/scripting_v3/GTA/Camera/CinematicCameraDirector.cs
+++ b/source/scripting_v3/GTA/Camera/CinematicCameraDirector.cs
@@ -32,7 +32,7 @@ namespace GTA
 		public static bool IsFirstPersonVehicleCamRendering => Function.Call<bool>(Hash.IS_CINEMATIC_FIRST_PERSON_VEHICLE_INTERIOR_CAM_RENDERING);
 
 		/// <summary>
-		/// Gets a value indicating whether the vehicle nose cam is rendering.
+		/// Gets a value indicating whether the vehicle bonnet cam is rendering.
 		/// For example, this will return true if using the weapon cam on the Hydra.
 		/// Only available in v1.0.372.2 or later versions.
 		/// </summary>

--- a/source/scripting_v3/GTA/Camera/CinematicCameraDirector.cs
+++ b/source/scripting_v3/GTA/Camera/CinematicCameraDirector.cs
@@ -70,20 +70,20 @@ namespace GTA
 		public static bool IsIdleCamRendering => Function.Call<bool>(Hash.IS_CINEMATIC_IDLE_CAM_RENDERING);
 
 		/// <summary>
-		/// Gets a value indicating whether a player-controlled cinematic camera is active.
+		/// Gets a value indicating whether the cinematic camera mode switch is active.
 		/// Only available in v1.0.1493.0 or later game versions.
 		/// </summary>
 		/// <value>
-		/// <see langword="true" /> if the <see cref="CinematicCameraDirector"/> is a player-controlled cinematic camera; otherwise, <see langword="false" />.
+		/// <see langword="true" /> if the <see cref="CinematicCameraDirector"/> mode switch is active; otherwise, <see langword="false" />.
 		/// </value>
 		/// <exception cref="GameVersionNotSupportedException">
 		/// Thrown if called in game versions earlier than v1.0.1493.0.
 		/// </exception>
-		public static bool IsPlayerCamActive
+		public static bool IsCinematicModeActive
 		{
 			get
 			{
-				GameVersionNotSupportedException.ThrowIfNotSupported(GameVersion.v1_0_1493_0_Steam, nameof(CinematicCameraDirector), nameof(IsPlayerCamActive));
+				GameVersionNotSupportedException.ThrowIfNotSupported(GameVersion.v1_0_1493_0_Steam, nameof(CinematicCameraDirector), nameof(IsCinematicModeActive));
 
 				return Function.Call<bool>(Hash.IS_CINEMATIC_CAM_INPUT_ACTIVE);
 			}

--- a/source/scripting_v3/GTA/Camera/CinematicCameraDirector.cs
+++ b/source/scripting_v3/GTA/Camera/CinematicCameraDirector.cs
@@ -24,12 +24,12 @@ namespace GTA
 		public static void InvalidateVehicleIdleCam() => Function.Call(Hash.INVALIDATE_CINEMATIC_VEHICLE_IDLE_MODE);
 
 		/// <summary>
-		/// Gets a value indicating whether a first person vehicle camera is active.
+		/// Gets a value indicating whether a first person vehicle interior camera is active.
 		/// </summary>
 		/// <value>
 		/// <see langword="true" /> if the <see cref="CinematicCameraDirector"/> is a first person vehicle camera; otherwise, <see langword="false" />.
 		/// </value>
-		public static bool IsFirstPersonVehicleCamRendering => Function.Call<bool>(Hash.IS_CINEMATIC_FIRST_PERSON_VEHICLE_INTERIOR_CAM_RENDERING);
+		public static bool IsFirstPersonVehicleInteriorCamRendering => Function.Call<bool>(Hash.IS_CINEMATIC_FIRST_PERSON_VEHICLE_INTERIOR_CAM_RENDERING);
 
 		/// <summary>
 		/// Gets a value indicating whether the vehicle bonnet cam is rendering.
@@ -37,7 +37,7 @@ namespace GTA
 		/// Only available in v1.0.372.2 or later versions.
 		/// </summary>
 		/// <value>
-		/// <see langword="true" /> if the <see cref="CinematicCameraDirector"/> is a vehicle nose camera; otherwise, <see langword="false" />.
+		/// <see langword="true" /> if the <see cref="CinematicCameraDirector"/> is a vehicle bonnet camera; otherwise, <see langword="false" />.
 		/// </value>
 		/// <exception cref="GameVersionNotSupportedException">
 		/// Thrown if called in game versions earlier than v1.0.372.2.
@@ -102,9 +102,9 @@ namespace GTA
 		/// <summary>
 		/// Stops shaking the <see cref="CinematicCameraDirector"/>'s active camera.
 		/// </summary>
-		public static void StopShaking()
+		public static void StopShaking(bool stopImmediately = false)
 		{
-			Function.Call(Hash.STOP_CINEMATIC_CAM_SHAKING, true);
+			Function.Call(Hash.STOP_CINEMATIC_CAM_SHAKING, stopImmediately);
 		}
 
 		/// <summary>

--- a/source/scripting_v3/GTA/Camera/CinematicCameraDirector.cs
+++ b/source/scripting_v3/GTA/Camera/CinematicCameraDirector.cs
@@ -1,0 +1,126 @@
+//
+// Copyright (C) 2015 crosire & kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+using GTA.Native;
+
+namespace GTA
+{
+	/// <summary>
+	/// Represents the cinematic camera director.
+	/// The cinematic director is responsible for idle, vehicle cinematic, vehicle first person, and nose cameras.
+	/// </summary>
+	public static class CinematicCameraDirector
+	{
+		/// <summary>
+		/// Invalidates the cinematic idle camera, restarting the associated idle counter.
+		/// </summary>
+		public static void InvalidateIdleCam() => Function.Call(Hash.INVALIDATE_IDLE_CAM);
+
+		/// <summary>
+		/// Invalidates the vehicle cinematic idle camera, restarting the associated idle counter.
+		/// </summary>
+		public static void InvalidateVehicleIdleCam() => Function.Call(Hash.INVALIDATE_CINEMATIC_VEHICLE_IDLE_MODE);
+
+		/// <summary>
+		/// Gets a value indicating whether a first person vehicle camera is active.
+		/// </summary>
+		/// <value>
+		/// <see langword="true" /> if the <see cref="CinematicCameraDirector"/> is a first person vehicle camera; otherwise, <see langword="false" />.
+		/// </value>
+		public static bool IsFirstPersonVehicleCamRendering => Function.Call<bool>(Hash.IS_CINEMATIC_FIRST_PERSON_VEHICLE_INTERIOR_CAM_RENDERING);
+
+		/// <summary>
+		/// Gets a value indicating whether the vehicle nose cam is rendering.
+		/// For example, this will return true if using the weapon cam on the Hydra.
+		/// Only available in v1.0.372.2 or later versions.
+		/// </summary>
+		/// <value>
+		/// <see langword="true" /> if the <see cref="CinematicCameraDirector"/> is a vehicle nose camera; otherwise, <see langword="false" />.
+		/// </value>
+		/// <exception cref="GameVersionNotSupportedException">
+		/// Thrown if called in game versions earlier than v1.0.372.2.
+		/// </exception>
+		public static bool IsVehicleBonnetCamRendering
+		{
+			get
+			{
+				GameVersionNotSupportedException.ThrowIfNotSupported(GameVersion.v1_0_372_2_Steam, nameof(CinematicCameraDirector), nameof(IsVehicleBonnetCamRendering));
+
+				return Function.Call<bool>(Hash.IS_BONNET_CINEMATIC_CAM_RENDERING);
+			}
+		}
+
+		/// <summary>
+		/// Gets a value indicating whether any cinematic camera is rendering.
+		/// Note that this will also return true if in first-person view while inside a vehicle.
+		/// </summary>
+		/// <value>
+		/// <see langword="true" /> if the <see cref="CinematicCameraDirector"/> is a cinematic camera; otherwise, <see langword="false" />.
+		/// </value>
+		public static bool IsAnyCamRendering => Function.Call<bool>(Hash.IS_CINEMATIC_CAM_RENDERING);
+
+		/// <summary>
+		/// Gets a value indicating whether an idle cinematic camera is rendering.
+		/// </summary>
+		/// <value>
+		/// <see langword="true" /> if the <see cref="CinematicCameraDirector"/> is an idle cinematic camera; otherwise, <see langword="false" />.
+		/// </value>
+		public static bool IsIdleCamRendering => Function.Call<bool>(Hash.IS_CINEMATIC_IDLE_CAM_RENDERING);
+
+		/// <summary>
+		/// Gets a value indicating whether a player-controlled cinematic camera is active.
+		/// Only available in v1.0.1493.0 or later game versions.
+		/// </summary>
+		/// <value>
+		/// <see langword="true" /> if the <see cref="CinematicCameraDirector"/> is a player-controlled cinematic camera; otherwise, <see langword="false" />.
+		/// </value>
+		/// <exception cref="GameVersionNotSupportedException">
+		/// Thrown if called in game versions earlier than v1.0.1493.0.
+		/// </exception>
+		public static bool IsPlayerCamActive
+		{
+			get
+			{
+				GameVersionNotSupportedException.ThrowIfNotSupported(GameVersion.v1_0_1493_0_Steam, nameof(CinematicCameraDirector), nameof(IsPlayerCamActive));
+
+				return Function.Call<bool>(Hash.IS_CINEMATIC_CAM_INPUT_ACTIVE);
+			}
+		}
+
+		/// <summary>
+		/// Shakes the <see cref="CinematicCameraDirector"/>'s active camera.
+		/// </summary>
+		/// <param name="shakeType">Type of the shake to apply.</param>
+		/// <param name="amplitude">The amplitude of the shaking.</param>
+		public static void Shake(CameraShake shakeType, float amplitude)
+		{
+			Function.Call(Hash.SHAKE_CINEMATIC_CAM, Camera.s_shakeNames[(int)shakeType], amplitude);
+		}
+
+		/// <summary>
+		/// Stops shaking the <see cref="CinematicCameraDirector"/>'s active camera.
+		/// </summary>
+		public static void StopShaking()
+		{
+			Function.Call(Hash.STOP_CINEMATIC_CAM_SHAKING, true);
+		}
+
+		/// <summary>
+		/// Gets a value indicating whether the <see cref="CinematicCameraDirector"/>'s active camera is shaking.
+		/// </summary>
+		/// <value>
+		/// <see langword="true" /> if the <see cref="CinematicCameraDirector"/>'s active camera is shaking; otherwise, <see langword="false" />.
+		/// </value>
+		public static bool IsShaking => Function.Call<bool>(Hash.IS_CINEMATIC_CAM_SHAKING);
+
+		/// <summary>
+		/// Sets the overall amplitude scaling for an active cinematic camera shake.
+		/// </summary>
+		public static float ShakeAmplitude
+		{
+			set => Function.Call(Hash.SET_CINEMATIC_CAM_SHAKE_AMPLITUDE, value);
+		}
+	}
+}

--- a/source/scripting_v3/GTA/Camera/CinematicCameraDirector.cs
+++ b/source/scripting_v3/GTA/Camera/CinematicCameraDirector.cs
@@ -102,6 +102,7 @@ namespace GTA
 		/// <summary>
 		/// Stops shaking the <see cref="CinematicCameraDirector"/>'s active camera.
 		/// </summary>
+		/// <param name="stopImmediately">Whether to stop shaking immediately; defaults to <see langword="false"/></param>
 		public static void StopShaking(bool stopImmediately = false)
 		{
 			Function.Call(Hash.STOP_CINEMATIC_CAM_SHAKING, stopImmediately);

--- a/source/scripting_v3/GTA/Camera/GameplayCamera.cs
+++ b/source/scripting_v3/GTA/Camera/GameplayCamera.cs
@@ -460,9 +460,9 @@ namespace GTA
 		/// <summary>
 		/// Stops shaking the <see cref="GameplayCamera"/>.
 		/// </summary>
-		public static void StopShaking()
+		public static void StopShaking(bool stopImmediately = false)
 		{
-			Function.Call(Hash.STOP_GAMEPLAY_CAM_SHAKING, true);
+			Function.Call(Hash.STOP_GAMEPLAY_CAM_SHAKING, stopImmediately);
 		}
 
 		/// <summary>

--- a/source/scripting_v3/GTA/Camera/GameplayCamera.cs
+++ b/source/scripting_v3/GTA/Camera/GameplayCamera.cs
@@ -445,12 +445,48 @@ namespace GTA
 		public static bool IsFirstPersonAimCamActive => Function.Call<bool>(Hash.IS_FIRST_PERSON_AIM_CAM_ACTIVE);
 
 		/// <summary>
-		/// Gets a value indicating whether the cinematic camera is active.
+		/// Gets a value indicating whether a first person vehicle camera is active.
 		/// </summary>
 		/// <value>
-		/// <see langword="true" /> if the <see cref="GameplayCamera"/> is the cinematic camera; otherwise, <see langword="false" />.
+		/// <see langword="true" /> if the <see cref="GameplayCamera"/> is a first person vehicle camera; otherwise, <see langword="false" />.
 		/// </value>
-		public static bool IsCinematicCamActive => Function.Call<bool>(Hash.IS_CINEMATIC_CAM_INPUT_ACTIVE);
+		public static bool IsFirstPersonVehicleCamActive => Function.Call<bool>(Hash.IS_CINEMATIC_FIRST_PERSON_VEHICLE_INTERIOR_CAM_RENDERING);
+
+		/// <summary>
+		/// Gets a value indicating whether any cinematic camera is active.
+		/// Note that this will also return true if in first-person view while inside a vehicle.
+		/// </summary>
+		/// <value>
+		/// <see langword="true" /> if the <see cref="GameplayCamera"/> is a cinematic camera; otherwise, <see langword="false" />.
+		/// </value>
+		public static bool IsAnyCinematicCamActive => Function.Call<bool>(Hash.IS_CINEMATIC_CAM_RENDERING);
+
+		/// <summary>
+		/// Gets a value indicating whether an idle cinematic camera is active.
+		/// </summary>
+		/// <value>
+		/// <see langword="true" /> if the <see cref="GameplayCamera"/> is a idle cinematic camera; otherwise, <see langword="false" />.
+		/// </value>
+		public static bool IsIdleCinematicCamActive => Function.Call<bool>(Hash.IS_CINEMATIC_IDLE_CAM_RENDERING);
+
+		/// <summary>
+		/// Gets a value indicating whether a player-controlled cinematic camera is active.
+		/// Only available in v1.0.1493.0 or later game versions.
+		/// </summary>
+		/// <value>
+		/// <see langword="true" /> if the <see cref="GameplayCamera"/> is a player-controlled cinematic camera; otherwise, <see langword="false" />.
+		/// </value>
+		public static bool IsCinematicCamInputActive
+		{
+			get
+			{
+				if (Game.Version < GameVersion.v1_0_1493_0_Steam)
+				{
+					GameVersionNotSupportedException.ThrowIfNotSupported(GameVersion.v1_0_1493_0_Steam, nameof(GameplayCamera), nameof(IsCinematicCamInputActive));
+				}
+				return Function.Call<bool>(Hash.IS_CINEMATIC_CAM_INPUT_ACTIVE);
+			}
+		}
 
 		/// <summary>
 		/// Gets a value indicating whether the active gameplay camera is looking behind.

--- a/source/scripting_v3/GTA/Camera/GameplayCamera.cs
+++ b/source/scripting_v3/GTA/Camera/GameplayCamera.cs
@@ -460,6 +460,7 @@ namespace GTA
 		/// <summary>
 		/// Stops shaking the <see cref="GameplayCamera"/>.
 		/// </summary>
+		/// <param name="stopImmediately">Whether to stop shaking immediately; defaults to <see langword="false"/></param>
 		public static void StopShaking(bool stopImmediately = false)
 		{
 			Function.Call(Hash.STOP_GAMEPLAY_CAM_SHAKING, stopImmediately);

--- a/source/scripting_v3/GTA/Camera/GameplayCamera.cs
+++ b/source/scripting_v3/GTA/Camera/GameplayCamera.cs
@@ -454,7 +454,7 @@ namespace GTA
 
 		/// <summary>
 		/// Gets a value indicating whether any cinematic camera is active.
-		/// Note that this will also return true if in first-person view while inside a vehicle.
+		/// Note that this will also return true if in first person view while inside a vehicle.
 		/// </summary>
 		/// <value>
 		/// <see langword="true" /> if the <see cref="GameplayCamera"/> is a cinematic camera; otherwise, <see langword="false" />.
@@ -465,7 +465,7 @@ namespace GTA
 		/// Gets a value indicating whether an idle cinematic camera is active.
 		/// </summary>
 		/// <value>
-		/// <see langword="true" /> if the <see cref="GameplayCamera"/> is a idle cinematic camera; otherwise, <see langword="false" />.
+		/// <see langword="true" /> if the <see cref="GameplayCamera"/> is an idle cinematic camera; otherwise, <see langword="false" />.
 		/// </value>
 		public static bool IsIdleCinematicCamActive => Function.Call<bool>(Hash.IS_CINEMATIC_IDLE_CAM_RENDERING);
 
@@ -477,7 +477,7 @@ namespace GTA
 		/// <see langword="true" /> if the <see cref="GameplayCamera"/> is a player-controlled cinematic camera; otherwise, <see langword="false" />.
 		/// </value>
 		/// <exception cref="GameVersionNotSupportedException">
-		/// Thrown if called in the game versions earlier than v1.0.1493.0.
+		/// Thrown if called in game versions earlier than v1.0.1493.0.
 		/// </exception>
 		public static bool IsCinematicCamInputActive
 		{

--- a/source/scripting_v3/GTA/Camera/GameplayCamera.cs
+++ b/source/scripting_v3/GTA/Camera/GameplayCamera.cs
@@ -384,11 +384,6 @@ namespace GTA
 		#endregion
 
 		/// <summary>
-		/// Invalidates the cinematic idle camera, restarting the associated idle counter.
-		/// </summary>
-		public static void InvalidateIdleCamera() => Function.Call(Hash.INVALIDATE_IDLE_CAM);
-
-		/// <summary>
 		/// Gets or sets the first-person ped aim zoom factor associated with equipped sniper scoped weapon,
 		/// or the mobile phone camera, if active.
 		/// </summary>
@@ -443,53 +438,6 @@ namespace GTA
 		/// <see langword="true" /> if a first person ped aim camera is active; otherwise, <see langword="false" />.
 		/// </value>
 		public static bool IsFirstPersonAimCamActive => Function.Call<bool>(Hash.IS_FIRST_PERSON_AIM_CAM_ACTIVE);
-
-		/// <summary>
-		/// Gets a value indicating whether a first person vehicle camera is active.
-		/// </summary>
-		/// <value>
-		/// <see langword="true" /> if the <see cref="GameplayCamera"/> is a first person vehicle camera; otherwise, <see langword="false" />.
-		/// </value>
-		public static bool IsFirstPersonVehicleCamActive => Function.Call<bool>(Hash.IS_CINEMATIC_FIRST_PERSON_VEHICLE_INTERIOR_CAM_RENDERING);
-
-		/// <summary>
-		/// Gets a value indicating whether any cinematic camera is active.
-		/// Note that this will also return true if in first person view while inside a vehicle.
-		/// </summary>
-		/// <value>
-		/// <see langword="true" /> if the <see cref="GameplayCamera"/> is a cinematic camera; otherwise, <see langword="false" />.
-		/// </value>
-		public static bool IsAnyCinematicCamActive => Function.Call<bool>(Hash.IS_CINEMATIC_CAM_RENDERING);
-
-		/// <summary>
-		/// Gets a value indicating whether an idle cinematic camera is active.
-		/// </summary>
-		/// <value>
-		/// <see langword="true" /> if the <see cref="GameplayCamera"/> is an idle cinematic camera; otherwise, <see langword="false" />.
-		/// </value>
-		public static bool IsIdleCinematicCamActive => Function.Call<bool>(Hash.IS_CINEMATIC_IDLE_CAM_RENDERING);
-
-		/// <summary>
-		/// Gets a value indicating whether a player-controlled cinematic camera is active.
-		/// Only available in v1.0.1493.0 or later game versions.
-		/// </summary>
-		/// <value>
-		/// <see langword="true" /> if the <see cref="GameplayCamera"/> is a player-controlled cinematic camera; otherwise, <see langword="false" />.
-		/// </value>
-		/// <exception cref="GameVersionNotSupportedException">
-		/// Thrown if called in game versions earlier than v1.0.1493.0.
-		/// </exception>
-		public static bool IsCinematicCamInputActive
-		{
-			get
-			{
-				if (Game.Version < GameVersion.v1_0_1493_0_Steam)
-				{
-					GameVersionNotSupportedException.ThrowIfNotSupported(GameVersion.v1_0_1493_0_Steam, nameof(GameplayCamera), nameof(IsCinematicCamInputActive));
-				}
-				return Function.Call<bool>(Hash.IS_CINEMATIC_CAM_INPUT_ACTIVE);
-			}
-		}
 
 		/// <summary>
 		/// Gets a value indicating whether the active gameplay camera is looking behind.

--- a/source/scripting_v3/GTA/Camera/GameplayCamera.cs
+++ b/source/scripting_v3/GTA/Camera/GameplayCamera.cs
@@ -445,6 +445,14 @@ namespace GTA
 		public static bool IsFirstPersonAimCamActive => Function.Call<bool>(Hash.IS_FIRST_PERSON_AIM_CAM_ACTIVE);
 
 		/// <summary>
+		/// Gets a value indicating whether the cinematic camera is active.
+		/// </summary>
+		/// <value>
+		/// <see langword="true" /> if the <see cref="GameplayCamera"/> is the cinematic camera; otherwise, <see langword="false" />.
+		/// </value>
+		public static bool IsCinematicCamActive => Function.Call<bool>(Hash.IS_CINEMATIC_CAM_INPUT_ACTIVE);
+
+		/// <summary>
 		/// Gets a value indicating whether the active gameplay camera is looking behind.
 		/// </summary>
 		/// <value>

--- a/source/scripting_v3/GTA/Camera/GameplayCamera.cs
+++ b/source/scripting_v3/GTA/Camera/GameplayCamera.cs
@@ -476,6 +476,9 @@ namespace GTA
 		/// <value>
 		/// <see langword="true" /> if the <see cref="GameplayCamera"/> is a player-controlled cinematic camera; otherwise, <see langword="false" />.
 		/// </value>
+		/// <exception cref="GameVersionNotSupportedException">
+		/// Thrown if called in the game versions earlier than v1.0.1493.0.
+		/// </exception>
 		public static bool IsCinematicCamInputActive
 		{
 			get


### PR DESCRIPTION
This adds a ~~check to the GameplayCamera class~~ Cinematic Camera Director class to check whether the cinematic camera is currently active or not, which is especially useful when performing checks against current view mode in vehicles since the cinematic camera will not override the FollowPed or FollowVehicle cam mode return value.