### PR TITLE
feat(api-v3): Screen.MainWindowResolution and Screen.PhysicalAspectRatio

### DIFF
--- a/ScriptHookVDotNet.vcxproj
+++ b/ScriptHookVDotNet.vcxproj
@@ -123,6 +123,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>

--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -317,7 +317,7 @@ namespace SHVDN
 
 				s_unkScreenFunc = (delegate* unmanaged[Stdcall]<IntPtr, IntPtr>)((long*)(*(int*)(address + 0x30) + address + 0x34));
 				s_isUsingMultiScreenFunc = (delegate* unmanaged[Stdcall]<IntPtr, bool>)((long*)(*(int*)(address + 0x38) + address + 0x3C));
-				s_getAppropriateScreenInfoFunc = (delegate* unmanaged[Stdcall]<IntPtr, ScreenInfo*>)((long*)(*(int*)(address + 0x50) + address + 0x54));
+				s_getMainScreenInfoFunc = (delegate* unmanaged[Stdcall]<IntPtr, ScreenInfo*>)((long*)(*(int*)(address + 0x50) + address + 0x54));
 			}
 
 			// Find euphoria functions
@@ -3103,14 +3103,15 @@ namespace SHVDN
 		[StructLayout(LayoutKind.Explicit, Size = 0x30)]
 		internal struct ScreenInfo
 		{
+			// these fields should be in pixel coordinates
 			[FieldOffset(0x14)]
-			internal uint nonMainScreenWidth;
+			internal uint left;
 			[FieldOffset(0x18)]
-			internal uint physicalWidth;
+			internal uint right;
 			[FieldOffset(0x1C)]
-			internal uint nonMainScreenHeight;
+			internal uint top;
 			[FieldOffset(0x20)]
-			internal uint physicalHeight;
+			internal uint bottom;
 		}
 
 		private static int* s_physicalScrenWidthAddr;
@@ -3124,7 +3125,7 @@ namespace SHVDN
 		/// Returns only either 0 or 1.
 		/// </remarks>
 		private static delegate* unmanaged[Stdcall]<IntPtr, bool> s_isUsingMultiScreenFunc;
-		private static delegate* unmanaged[Stdcall]<IntPtr, ScreenInfo*> s_getAppropriateScreenInfoFunc;
+		private static delegate* unmanaged[Stdcall]<IntPtr, ScreenInfo*> s_getMainScreenInfoFunc;
 
 		internal sealed class GetMainWindowResoltionTask : IScriptTask
 		{
@@ -3141,11 +3142,11 @@ namespace SHVDN
 				{
 					// A lot of functions call this function twice for some reason, so we call it twice for safely
 					generalScreenInfoAddr = s_unkScreenFunc(s_screenInfoAddr);
-					ScreenInfo* screenInfoAddr = s_getAppropriateScreenInfoFunc(generalScreenInfoAddr);
+					ScreenInfo* screenInfoAddr = s_getMainScreenInfoFunc(generalScreenInfoAddr);
 
 					resolutionResult = new Size(
-						(int)(screenInfoAddr->physicalWidth - screenInfoAddr->nonMainScreenWidth),
-						(int)(screenInfoAddr->physicalHeight - screenInfoAddr->nonMainScreenHeight)
+						(int)(screenInfoAddr->right - screenInfoAddr->left),
+						(int)(screenInfoAddr->bottom - screenInfoAddr->top)
 						);
 				}
 			}

--- a/source/scripting_v3/GTA.UI/Screen.cs
+++ b/source/scripting_v3/GTA.UI/Screen.cs
@@ -112,7 +112,8 @@ namespace GTA.UI
 		public const float Height = 720f;
 
 		/// <summary>
-		/// Gets the actual screen resolution the game is being rendered at
+		/// Gets the actual/physical screen resolution the game is being rendered at.
+		/// In 3x1 modes, non-main windows are also considered.
 		/// </summary>
 		public static Size Resolution
 		{
@@ -128,9 +129,26 @@ namespace GTA.UI
 			}
 		}
 		/// <summary>
+		/// Gets the main window screen resolution the game is being rendered at.
+		/// In 3x1 modes, non-main windows are not considered.
+		/// </summary>
+		public static Size MainWindowResolution => SHVDN.NativeMemory.GetMainWindowResolution();
+		/// <summary>
 		/// Gets the current screen aspect ratio of the main window.
 		/// </summary>
-		public static float AspectRatio => Function.Call<float>(Hash.GET_ASPECT_RATIO, 0);
+		/// <remarks>
+		/// Takes into account custom overrides from the settings menu, so this property will return an appropriate
+		/// constant value if the aspect ratio is overridden.
+		/// </remarks>
+		public static float AspectRatio => Function.Call<float>(Hash.GET_ASPECT_RATIO, false);
+		/// <summary>
+		/// Gets the physical aspect ratio of the game window (Useful for 3x1 modes).
+		/// </summary>
+		/// <remarks>
+		/// Takes into account custom overrides from the settings menu, so this property will return an appropriate
+		/// constant value if the aspect ratio is overridden.
+		/// </remarks>
+		public static float PhysicalAspectRatio => Function.Call<float>(Hash.GET_ASPECT_RATIO, true);
 		/// <summary>
 		/// Gets the screen width scaled against a 720pixel height base.
 		/// </summary>


### PR DESCRIPTION
~~`Screen.MainWindowResolution` needs testing by someone else so we can make sure that it returns the resolution for the main screen when using multiple ones. Unfortunately I don't have multiple screens for my gaming PC and can't really afford to buy some software or device that can use my MacBook or iPad as extra displays right now, either.~~ You can test with width and height arguments for command lines even without multiple screens in borderless windowed mode, such as `-width 1812 -height 306`. Kudos to @alexguirre for informing me of the fact that you can test in ultrawide screen mode in single monitor (in [5Mods Discord](https://discord.com/channels/318621297057988608/318626093013925889/1151190627845947452))!

`((float)Width / (float)Height)` of `Screen.MainWindowResolution` should EXACTLY match `Screen.AspectRatio` if Aspect Ratio of the setting menu is set to Auto and `Screen.MainWindowResolution` is correctly implemented. `GET_ASPECT_RATIO` calculates in the same way when false is passed as the parameter.