### PR TITLE
feat(core): add full key binding support for activate/deactivate console and instant reload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,8 @@ jobs:
         && del bin\Release\ScriptHookVDotNet*.metagen `
         && type README.md | more /P > bin\Release\README.txt `
         && type LICENSE.txt | more /P > bin\Release\LICENSE.txt `
-        && echo ReloadKey=None > bin\Release\ScriptHookVDotNet.ini `
-        && echo ConsoleKey=F4 >> bin\Release\ScriptHookVDotNet.ini `
+        && echo ReloadKeyBinding=None > bin\Release\ScriptHookVDotNet.ini `
+        && echo ConsoleKeyBinding=F4 >> bin\Release\ScriptHookVDotNet.ini `
         && echo ScriptTimeoutThreshold=5000 >> bin\Release\ScriptHookVDotNet.ini `
         && echo WarnOfDeprecatedScriptsWithTicker=true >> bin\Release\ScriptHookVDotNet.ini
     - name: Upload artifact

--- a/source/core/Console.cs
+++ b/source/core/Console.cs
@@ -210,6 +210,14 @@ namespace SHVDN
 		/// Writes an info message to the console.
 		/// </summary>
 		/// <param name="msg">The composite format string.</param>
+		public void PrintInfo(string msg)
+		{
+			AddLines("[~b~INFO~w~] ", msg.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries));
+		}
+		/// <summary>
+		/// Writes an info message to the console.
+		/// </summary>
+		/// <param name="msg">The composite format string.</param>
 		/// <param name="args">The formatting arguments.</param>
 		public void PrintInfo(string msg, params object[] args)
 		{
@@ -224,6 +232,14 @@ namespace SHVDN
 		/// Writes an error message to the console.
 		/// </summary>
 		/// <param name="msg">The composite format string.</param>
+		public void PrintError(string msg)
+		{
+			AddLines("[~r~ERROR~w~] ", msg.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries));
+		}
+		/// <summary>
+		/// Writes an error message to the console.
+		/// </summary>
+		/// <param name="msg">The composite format string.</param>
 		/// <param name="args">The formatting arguments.</param>
 		public void PrintError(string msg, params object[] args)
 		{
@@ -233,6 +249,14 @@ namespace SHVDN
 			}
 
 			AddLines("[~r~ERROR~w~] ", msg.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries));
+		}
+		/// <summary>
+		/// Writes a warning message to the console.
+		/// </summary>
+		/// <param name="msg">The composite format string.</param>
+		public void PrintWarning(string msg)
+		{
+			AddLines("[~o~WARNING~w~] ", msg.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries));
 		}
 		/// <summary>
 		/// Writes a warning message to the console.

--- a/source/core/DllMain.cpp
+++ b/source/core/DllMain.cpp
@@ -486,12 +486,14 @@ static bool AreAllKeysPressed(array<WinForms::Keys>^ keys)
 			{
 				return false;
 			}
+			break;
 		case WinForms::Keys::Control:
 			if ((ScriptHookVDotNet::_modKeyState & static_cast<ModifierKeyState>(WinForms::Keys::Control))
 				== ModifierKeyState::None)
 			{
 				return false;
 			}
+			break;
 		case WinForms::Keys::Alt:
 			if ((ScriptHookVDotNet::_modKeyState & static_cast<ModifierKeyState>(WinForms::Keys::Alt))
 				== ModifierKeyState::None)

--- a/source/core/DllMain.cpp
+++ b/source/core/DllMain.cpp
@@ -144,8 +144,8 @@ public:
 internal:
 	static SHVDN::Console ^console = nullptr;
 	static SHVDN::ScriptDomain ^domain = SHVDN::ScriptDomain::CurrentDomain;
-	static array<WinForms::Keys>^ reloadKeys = { WinForms::Keys::None };
-	static array<WinForms::Keys>^ consoleKeys = { WinForms::Keys::F4 };
+	static array<WinForms::Keys>^ reloadKeyBinding = { WinForms::Keys::None };
+	static array<WinForms::Keys>^ consoleKeyBinding = { WinForms::Keys::F4 };
 	static unsigned int scriptTimeoutThreshold = 5000;
 	static bool shouldWarnOfScriptsBuiltAgainstDeprecatedApiWithTicker = true;
 	static Object^ unloadLock = gcnew Object();
@@ -405,7 +405,7 @@ static void ScriptHookVDotNet_ManagedInit()
 
 			ValueTuple<array<WinForms::Keys>^, InvalidKeysFoundError^> keyCombinationResult;
 
-			if (String::Equals(keyStr, "ReloadKey", StringComparison::OrdinalIgnoreCase)) {
+			if (String::Equals(keyStr, "ReloadKeyBinding", StringComparison::OrdinalIgnoreCase)) {
 				keyCombinationResult = ParseKeyBinding(valueStr);
 				InvalidKeysFoundError^ invalidKeysError = keyCombinationResult.Item2;
 				if (invalidKeysError != nullptr)
@@ -414,10 +414,10 @@ static void ScriptHookVDotNet_ManagedInit()
 				}
 				else
 				{
-					ScriptHookVDotNet::reloadKeys = keyCombinationResult.Item1;
+					ScriptHookVDotNet::reloadKeyBinding = keyCombinationResult.Item1;
 				}
 			}
-			else if (String::Equals(keyStr, "ConsoleKey", StringComparison::OrdinalIgnoreCase))
+			else if (String::Equals(keyStr, "ConsoleKeyBinding", StringComparison::OrdinalIgnoreCase))
 			{
 				keyCombinationResult = ParseKeyBinding(valueStr);
 				InvalidKeysFoundError^ invalidKeysError = keyCombinationResult.Item2;
@@ -427,7 +427,7 @@ static void ScriptHookVDotNet_ManagedInit()
 				}
 				else
 				{
-					ScriptHookVDotNet::consoleKeys = keyCombinationResult.Item1;
+					ScriptHookVDotNet::consoleKeyBinding = keyCombinationResult.Item1;
 				}
 			}
 			else if (String::Equals(keyStr, "ScriptTimeoutThreshold", StringComparison::OrdinalIgnoreCase))
@@ -578,13 +578,13 @@ static void ScriptHookVDotNet_ManagedKeyboardMessage(unsigned long keycode, bool
 	SHVDN::Console^ console = ScriptHookVDotNet::console;
 	if (console != nullptr)
 	{
-		if (keydown && AreAllKeysPressed(ScriptHookVDotNet::reloadKeys))
+		if (keydown && AreAllKeysPressed(ScriptHookVDotNet::reloadKeyBinding))
 		{
 			// Force a reload
 			ScriptHookVDotNet::Reload();
 			return;
 		}
-		if (keydown && AreAllKeysPressed(ScriptHookVDotNet::consoleKeys))
+		if (keydown && AreAllKeysPressed(ScriptHookVDotNet::consoleKeyBinding))
 		{
 			// Toggle open state
 			console->IsOpen = !console->IsOpen;

--- a/source/core/DllMain.cpp
+++ b/source/core/DllMain.cpp
@@ -50,6 +50,15 @@ using namespace System::Collections::Generic;
 using namespace System::Reflection;
 namespace WinForms = System::Windows::Forms;
 
+[FlagsAttribute]
+private enum class ModifierKeyState
+{
+	None = 0,
+	Shift = 0x10000,
+	Control = 0x20000,
+	Alt = 0x40000,
+};
+
 public ref class ScriptHookVDotNet // This is not a static class, so that console scripts can inherit from it for ConsoleInput class
 {
 public:
@@ -135,16 +144,171 @@ public:
 internal:
 	static SHVDN::Console ^console = nullptr;
 	static SHVDN::ScriptDomain ^domain = SHVDN::ScriptDomain::CurrentDomain;
-	static WinForms::Keys reloadKey = WinForms::Keys::None;
-	static WinForms::Keys consoleKey = WinForms::Keys::F4;
+	static array<WinForms::Keys>^ reloadKeys = { WinForms::Keys::None };
+	static array<WinForms::Keys>^ consoleKeys = { WinForms::Keys::F4 };
 	static unsigned int scriptTimeoutThreshold = 5000;
 	static bool shouldWarnOfScriptsBuiltAgainstDeprecatedApiWithTicker = true;
 	static Object^ unloadLock = gcnew Object();
+	static array<bool>^ _keyboardStatePool = gcnew array<bool>(256);
+	static ModifierKeyState _modKeyState = ModifierKeyState::None;
+
 	static void SetConsole()
 	{
 		console = (SHVDN::Console ^)AppDomain::CurrentDomain->GetData("Console");
 	}
+
+	static void UpdatePrimaryKeyboardStateCache(unsigned char keyCode, bool down)
+	{
+		_keyboardStatePool[keyCode] = down;
+	}
+	static void UpdateKeyboardModifierStateCache(bool shift, bool ctrl, bool alt)
+	{
+		ModifierKeyState newState = (shift ? ModifierKeyState::Shift : ModifierKeyState::None);
+		newState = (ctrl ? newState | ModifierKeyState::Control : newState);
+		newState = (alt ? newState | ModifierKeyState::Alt : newState);
+
+		_modKeyState = newState;
+	}
 };
+
+ref class InvalidKeysFoundError sealed
+{
+internal:
+	value class PositionAndUnparsedStrInfo
+	{
+	private:
+		int _position;
+		String^ _unparsedStr;
+
+	public:
+		PositionAndUnparsedStrInfo(int position, String^ unparsedStr)
+		{
+			_position = position;
+			_unparsedStr = unparsedStr;
+		}
+
+		property int Position
+		{
+			int get() {
+				return _position;
+			}
+		}
+		property String^ UnparsedString
+		{
+			String^ get()
+			{
+				return _unparsedStr;
+			}
+		}
+	};
+
+	array<InvalidKeysFoundError::PositionAndUnparsedStrInfo>^ _unparsedStrInfo;
+
+	InvalidKeysFoundError(array<InvalidKeysFoundError::PositionAndUnparsedStrInfo>^ input)
+	{
+		_unparsedStrInfo = gcnew array<InvalidKeysFoundError::PositionAndUnparsedStrInfo>(input->Length);
+		input->CopyTo(_unparsedStrInfo, 0);
+	}
+
+	array<InvalidKeysFoundError::PositionAndUnparsedStrInfo>^ GetUnparsedStrSequence()
+	{
+		auto newArray = gcnew array<InvalidKeysFoundError::PositionAndUnparsedStrInfo>(_unparsedStrInfo->Length);
+		_unparsedStrInfo->CopyTo(newArray, 0);
+		return newArray;
+	}
+};
+
+ref class InvalidKeysFoundErrorBuilder sealed
+{
+private:
+	List<InvalidKeysFoundError::PositionAndUnparsedStrInfo>^ _invalidKeys;
+
+public:
+	InvalidKeysFoundErrorBuilder()
+	{
+		_invalidKeys = gcnew List<InvalidKeysFoundError::PositionAndUnparsedStrInfo>();
+	}
+
+	void Add(int position, String^ unparsedStr)
+	{
+		auto posAndKeyInfo = InvalidKeysFoundError::PositionAndUnparsedStrInfo(position, unparsedStr);
+		_invalidKeys->Add(posAndKeyInfo);
+	}
+
+	InvalidKeysFoundError^ Build()
+	{
+		return gcnew InvalidKeysFoundError(_invalidKeys->ToArray());
+	}
+};
+
+// This is for internel use, so use a System.Array for faster iteration
+static ValueTuple<array<WinForms::Keys>^, InvalidKeysFoundError^> ParseKeyBinding(String^ input)
+{
+	InvalidKeysFoundErrorBuilder^ errorBuilder = nullptr;
+
+	array<String^>^ inputSubstrings = input->Split('+');
+	List<WinForms::Keys>^ resultKeyBinding = gcnew List<WinForms::Keys>(inputSubstrings->Length);
+
+	for (int i = 0; i < inputSubstrings->Length; i++)
+	{
+		String^ keyStr = inputSubstrings[i]->Trim();
+
+		WinForms::Keys parsedKey;
+		if (Enum::TryParse(keyStr, true, parsedKey))
+		{
+			resultKeyBinding->Add(parsedKey);
+		}
+		else
+		{
+			if (errorBuilder == nullptr)
+			{
+				errorBuilder = gcnew InvalidKeysFoundErrorBuilder();
+			}
+
+			errorBuilder->Add(i, keyStr);
+		}
+	}
+
+	InvalidKeysFoundError^ error = (errorBuilder != nullptr ? errorBuilder->Build() : nullptr);
+	return ValueTuple<array<WinForms::Keys>^, InvalidKeysFoundError^>(resultKeyBinding->ToArray(), error);
+}
+
+static void LogKeyBindingParseError(String^ rawInput, InvalidKeysFoundError^ invalidKeysFoundError)
+{
+	SHVDN::Log::WriteToConsole(SHVDN::Log::Level::Error,
+		String::Format(
+			"Failed to parse a key binding from the string \"{0}\". See {1} for details.",
+			rawInput,
+			SHVDN::Log::FileName
+		)
+	);
+
+	Text::StringBuilder^ errorLineBuilder = gcnew Text::StringBuilder();
+	bool hasAlreadyFoundFirstUnparsedString = false;
+	for each (auto unparsedInfo in invalidKeysFoundError->GetUnparsedStrSequence())
+	{
+		if (hasAlreadyFoundFirstUnparsedString)
+		{
+			errorLineBuilder->Append(Environment::NewLine);
+		}
+		else
+		{
+			hasAlreadyFoundFirstUnparsedString = true;
+		}
+		errorLineBuilder->Append(
+			String::Format("    Found \"{0}\" at index {1}.", unparsedInfo.UnparsedString, unparsedInfo.Position)
+		);
+	}
+
+	SHVDN::Log::WriteToFile(SHVDN::Log::Level::Error,
+		String::Format(
+			"Failed to parse a key binding from the string \"{0}\":{1}{2}",
+			rawInput,
+			Environment::NewLine,
+			errorLineBuilder->ToString()
+		)
+	);
+}
 
 static void ScriptHookVDotNet_ManagedInit()
 {
@@ -195,10 +359,33 @@ static void ScriptHookVDotNet_ManagedInit()
 			String^ keyStr = data[0]->Trim();
 			String^ valueStr = data[1]->Trim();
 
-			if (String::Equals(keyStr, "ReloadKey", StringComparison::OrdinalIgnoreCase))
-				Enum::TryParse(valueStr, true, ScriptHookVDotNet::reloadKey);
+			ValueTuple<array<WinForms::Keys>^, InvalidKeysFoundError^> keyCombinationResult;
+
+			if (String::Equals(keyStr, "ReloadKey", StringComparison::OrdinalIgnoreCase)) {
+				keyCombinationResult = ParseKeyBinding(valueStr);
+				InvalidKeysFoundError^ invalidKeysError = keyCombinationResult.Item2;
+				if (invalidKeysError != nullptr)
+				{
+					LogKeyBindingParseError(valueStr, invalidKeysError);
+				}
+				else
+				{
+					ScriptHookVDotNet::reloadKeys = keyCombinationResult.Item1;
+				}
+			}
 			else if (String::Equals(keyStr, "ConsoleKey", StringComparison::OrdinalIgnoreCase))
-				Enum::TryParse(valueStr, true, ScriptHookVDotNet::consoleKey);
+			{
+				keyCombinationResult = ParseKeyBinding(valueStr);
+				InvalidKeysFoundError^ invalidKeysError = keyCombinationResult.Item2;
+				if (invalidKeysError != nullptr)
+				{
+					LogKeyBindingParseError(valueStr, invalidKeysError);
+				}
+				else
+				{
+					ScriptHookVDotNet::consoleKeys = keyCombinationResult.Item1;
+				}
+			}
 			else if (String::Equals(keyStr, "ScriptTimeoutThreshold", StringComparison::OrdinalIgnoreCase))
 			{
 				unsigned int outVal;
@@ -287,11 +474,50 @@ static void ScriptHookVDotNet_ManagedTick()
 		scriptDomain->DoTick();
 }
 
+static bool AreAllKeysPressed(array<WinForms::Keys>^ keys)
+{
+	for each (WinForms::Keys key in keys)
+	{
+		switch (key)
+		{
+		case WinForms::Keys::Shift:
+			if ((ScriptHookVDotNet::_modKeyState & static_cast<ModifierKeyState>(WinForms::Keys::Shift))
+				== ModifierKeyState::None)
+			{
+				return false;
+			}
+		case WinForms::Keys::Control:
+			if ((ScriptHookVDotNet::_modKeyState & static_cast<ModifierKeyState>(WinForms::Keys::Control))
+				== ModifierKeyState::None)
+			{
+				return false;
+			}
+		case WinForms::Keys::Alt:
+			if ((ScriptHookVDotNet::_modKeyState & static_cast<ModifierKeyState>(WinForms::Keys::Alt))
+				== ModifierKeyState::None)
+			{
+				return false;
+			}
+			break;
+		default:
+			if (!ScriptHookVDotNet::_keyboardStatePool[(int)key])
+			{
+				return false;
+			}
+		}
+	}
+
+	return true;
+}
+
 static void ScriptHookVDotNet_ManagedKeyboardMessage(unsigned long keycode, bool keydown, bool ctrl, bool shift, bool alt)
 {
 	// Filter out invalid key codes
 	if (keycode <= 0 || keycode >= 256)
 		return;
+
+	ScriptHookVDotNet::UpdatePrimaryKeyboardStateCache(static_cast<unsigned char>(keycode), keydown);
+	ScriptHookVDotNet::UpdateKeyboardModifierStateCache(shift, ctrl, alt);
 
 	// Convert message into a key event
 	auto keys = safe_cast<WinForms::Keys>(keycode);
@@ -304,13 +530,13 @@ static void ScriptHookVDotNet_ManagedKeyboardMessage(unsigned long keycode, bool
 	SHVDN::Console^ console = ScriptHookVDotNet::console;
 	if (console != nullptr)
 	{
-		if (keydown && keys == ScriptHookVDotNet::reloadKey)
+		if (keydown && AreAllKeysPressed(ScriptHookVDotNet::reloadKeys))
 		{
 			// Force a reload
 			ScriptHookVDotNet::Reload();
 			return;
 		}
-		if (keydown && keys == ScriptHookVDotNet::consoleKey)
+		if (keydown && AreAllKeysPressed(ScriptHookVDotNet::consoleKeys))
 		{
 			// Toggle open state
 			console->IsOpen = !console->IsOpen;

--- a/source/core/Log.cs
+++ b/source/core/Log.cs
@@ -20,6 +20,9 @@ namespace SHVDN
 
 		private static string FilePath => Path.ChangeExtension(typeof(ScriptDomain).Assembly.Location, ".log");
 
+		internal static string FileName
+			=> Path.GetFileName(Path.ChangeExtension(typeof(ScriptDomain).Assembly.Location, ".log"));
+
 		public static void Clear()
 		{
 			try
@@ -38,7 +41,7 @@ namespace SHVDN
 			WriteToConsole(level, message);
 		}
 
-		private static void WriteToFile(Level level, params string[] message)
+		internal static void WriteToFile(Level level, params string[] message)
 		{
 			try
 			{
@@ -79,7 +82,7 @@ namespace SHVDN
 			}
 		}
 
-		private static void WriteToConsole(Level level, params string[] message)
+		internal static void WriteToConsole(Level level, params string[] message)
 		{
 			var console = AppDomain.CurrentDomain.GetData("Console") as Console;
 

--- a/source/core/Log.cs
+++ b/source/core/Log.cs
@@ -20,8 +20,7 @@ namespace SHVDN
 
 		private static string FilePath => Path.ChangeExtension(typeof(ScriptDomain).Assembly.Location, ".log");
 
-		internal static string FileName
-			=> Path.GetFileName(Path.ChangeExtension(typeof(ScriptDomain).Assembly.Location, ".log"));
+		internal static string FileName => Path.GetFileName(FilePath);
 
 		public static void Clear()
 		{


### PR DESCRIPTION
## Summary
Now you can use multiple keys to activate/deactivate the console and the instant reload, such as `ReloadKey = Control + Alt + K`. Use the plus sign as key separators. Don't worry, SHVDN also handles whitespaces around the equal sign between the key and value before this PR is made, which is different from how `ScriptHookVDotNet.ini` was parsed in v3.6.0.
When fails to parse a key binding, logs the error like `Found "Contol" at index 0` (Control is the mistyped one instead of Control) and fallbacks to the default key binding.

With a lot of scripts installed, only supporting single key for key bindsings may suffer people for empty key. I saw one person suffering how SHVDN only supported single key for key bindings of the console and the instant reload. A lot of scripts that uses KeyDown only support single key for a key binding, didn't surprise me much when I saw the case…

I'm not separating parser stuff into a dedicated file, I expect to separate other loader stuff when we separate the loader ASI script and ScriptDomain modules into different module files.