### PR TITLE
feat(api-v3): add new chrono constructors

### DIFF
--- a/source/scripting_v3/GTA.Chrono/GameClockDate.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDate.cs
@@ -51,6 +51,9 @@ namespace GTA.Chrono
 			_ordFlags = ordFlags;
 		}
 
+		public GameClockDate(int year, int month, int day) : this()
+			=> FromYmd(year, month, day);
+
 		private static OrdFlags OrdFlagsForMaxDate = new(365, YearFlags.FromYear(int.MaxValue));
 		private static OrdFlags OrdFlagsForMinDate = new(1, YearFlags.FromYear(int.MinValue));
 

--- a/source/scripting_v3/GTA.Chrono/GameClockDateTime.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDateTime.cs
@@ -45,6 +45,12 @@ namespace GTA.Chrono
 			_time = time;
 		}
 
+		public GameClockDateTime(int year, int month, int day, int hour, int minute, int second) : this()
+		{
+			_date = new GameClockDate(year, month, day);
+			_time = new GameClockTime(hour, minute, second);
+		}
+
 		/// <summary>
 		/// Gets the largest possible value of <see cref="GameClockDateTime"/>.
 		/// </summary>

--- a/source/scripting_v3/GTA.Chrono/GameClockTime.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockTime.cs
@@ -28,6 +28,9 @@ namespace GTA.Chrono
 			_secs = secs;
 		}
 
+		public GameClockTime(int hour, int minute, int second) : this()
+			=> FromHms(hour, minute, second);
+
 		/// <summary>
 		/// Gets the largest possible value of <see cref="GameClockDate"/>.
 		/// </summary>


### PR DESCRIPTION
This adds new constructors to GameClockTime, GameClockDate, and GameClockDateTime which accept int values just as System.DateTime had. In this way, a user can more easily migrate from System.DateTime if they were previously creating new System.DateTime objects using int values in the constructor.