### PR TITLE
feat(api-v3): make GameClockDateTime serializable

### DIFF
--- a/source/scripting_v3/GTA.Chrono/GameClockDateTime.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDateTime.cs
@@ -34,6 +34,7 @@ namespace GTA.Chrono
 	/// altering an existing date.
 	/// </para>
 	/// </remarks>
+	[Serializable]
 	public readonly struct GameClockDateTime : IEquatable<GameClockDateTime>, IComparable<GameClockDateTime>, IComparable, Datelike<GameClockDateTime>, Timelike<GameClockDateTime>
 	{
 		private readonly GameClockDate _date;


### PR DESCRIPTION
As System.DateTime is serializable, it would be nice to also allow GameClockDateTime to be serializable.

As a note, when System.DateOnly and System.TimeOnly were introduced in .NET 6, [they were explicitly not made serializable](https://github.com/dotnet/runtime/issues/49036#issuecomment-789453258). As such I did not add this tag to GameClockDate or GameClockTime.