### PR TITLE
ci: add nightly release workflow

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -75,8 +75,8 @@ jobs:
         uses: actions/create-github-app-token@v1
         id: app-token
         with:
-          app_id: ${{ vars.SHVDN_APP_ID }}
-          private_key: ${{ secrets.SHVDN_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.SHVDN_APP_ID }}
+          private-key: ${{ secrets.SHVDN_APP_PRIVATE_KEY }}
           owner: 'scripthookvdotnet'
           repositories: 'scripthookvdotnet-nightly'
       - name: Push New Tag
@@ -173,8 +173,8 @@ jobs:
         uses: actions/create-github-app-token@v1
         id: app-token
         with:
-          app_id: ${{ vars.SHVDN_APP_ID }}
-          private_key: ${{ secrets.SHVDN_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.SHVDN_APP_ID }}
+          private-key: ${{ secrets.SHVDN_APP_PRIVATE_KEY }}
           owner: 'scripthookvdotnet'
           repositories: 'scripthookvdotnet-nightly'
       - name: Push New Release

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -3,7 +3,7 @@ name: 🌕🏭 Create Nightly Release
 on:
   push:
     branches:
-      - 'main'
+      - main
     tags:
       # create nightly releases for
       - 'v[0-9]+.[0-9]+.[0-9]+'
@@ -24,18 +24,27 @@ permissions:
 
 jobs:
   calc-next-tag-name:
-    name: Calculate New Version Tag
+    name: Get Latest commit hash on Nightly Repo and Calculate New Version Tag
     runs-on: ubuntu-latest
+    outputs:
+      sha_on_main_branch_in_nightly_repo: ${{ steps.calc-next-tag-name.outputs.sha_nightly_repo }}
+      next_version_name: ${{ steps.calc-next-tag-name.outputs.next_version_name }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout Nightly Release Repo
+        uses: actions/checkout@v4
         with:
           repository: ${{ format('{0}/scripthookvdotnet-nightly', github.repository_owner) }}
           path: nightly-repo
           fetch-depth: 0
+      - name: Calculate New Tag
+        id: calc-next-tag-name
+        working-directory: nightly-repo
         env:
-          CUSTOM_VERSION_NAME: ${{ github.event_name != workflow_dispatch && github.event.inputs.tag_name || '' }}
-          PRERELEASE_BUILD_NO: ${{ github.event_name != workflow_dispatch && github.event.inputs.prerelease_build_number || '0' }}
+          CUSTOM_VERSION_NAME: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.semver_name || '' }}
+          PRERELEASE_BUILD_NO: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.prerelease_build_number || '0' }}
         run: |
+          echo "sha_nightly_repo=$(git log -n 1 --pretty=format:"%H")" >> "$GITHUB_OUTPUT"
+
           if [ "$CUSTOM_VERSION_NAME" != "" ]; then
             echo "next_version_name=${CUSTOM_VERSION_NAME}-nightly.${PRERELEASE_BUILD_NO}" >> "$GITHUB_OUTPUT"
             exit 0
@@ -43,48 +52,84 @@ jobs:
           if [[ "$GITHUB_REF" = refs/tags/* ]]; then
             # we've already checked that the ref is a tag with the v prefix
             next_version_name=$(echo "${GITHUB_REF_NAME}-nightly.0" | cut -c2-)
-            echo "next_version_name=$next_version_name" >> "$GITHUB_OUTPUT"
-           exit 0
+            echo "next_version_name=${next_version_name}" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           if latest_tag_name=$(git describe --tags `git rev-list --tags --max-count=1`); then
             next_version_name=$(npx semver "$latest_tag_name" -i prerelease)
-            echo "next_version_name=$next_version_name" >> "$GITHUB_OUTPUT"
+            echo "next_version_name=${next_version_name}" >> "$GITHUB_OUTPUT"
           else
             echo "There's no tags on the nightly repo. Please specify a custom version tag."
             exit 1
           fi
 
   create-new-tag:
-    needs: calc-next-tag-name
     name: Push New Version Tag
+    needs: calc-next-tag-name
     runs-on: ubuntu-latest
-    uses: mathieudutour/github-tag-action@v6.1
-    with:
-      github_token: ${{ secrets.RELEASE_TOKEN_NIGHTLY }}
-      # needs to allow any refs so the action won't skip creating a tag when a tag ref is pushed
-      release_branches: ".*"
-      create_annotated_tag: true
-      custom_tag: ${{ jobs.calc-next-tag-name.outputs.next_version_name }}
+    outputs:
+      tag_name: ${{ steps.tag-output.outputs.result }}
+    steps:
+      - uses: actions/github-script@v7
+        id: tag-output
+        env:
+          SHA_NIGHTLY_REPO: ${{ needs.calc-next-tag-name.outputs.sha_on_main_branch_in_nightly_repo }}
+          TAG_NAME: ${{ needs.calc-next-tag-name.outputs.next_version_name }}
+        with:
+          github-token: ${{ secrets.RELEASE_TOKEN_NIGHTLY }}
+          script: |
+            const owner = process.env.GITHUB_REPOSITORY_OWNER;
+            const repo = 'scripthookvdotnet-nightly';
+            const tag = `v${ process.env.TAG_NAME }`;
+            const message = `${ process.env.GITHUB_REF_NAME }_${tag}`;
+
+            const annotatedTag = await github.rest.git.createTag({
+              owner,
+              repo,
+              tag,
+              message,
+              object: process.env.SHA_NIGHTLY_REPO,
+              type: 'commit',
+            });
+
+            if (annotatedTag.status !== 201) {
+              console.log(`Could not create tag. Received ${annotatedTag.status} from API`);
+              process.exit(1);
+            }
+
+            await github.rest.git.createRef({
+              owner,
+              repo,
+              ref: `refs/tags/${tag}`,
+              sha: annotatedTag.data.sha,
+            });
+
+            return tag;
+          result-encoding: string
 
   create-release-note-body-text:
     name: Create Body Text for Release
     runs-on: ubuntu-latest
-    uses: actions/github-script@v7
-    with:
-      script: |
-        const commitSha = ${{ github.sha }};
+    outputs:
+      body_text: ${{ steps.body-text.outputs.result }}
+    steps:
+      - uses: actions/github-script@v7
+        id: body-text
+        with:
+          script: |
+            const commitSha = '${{ github.sha }}';
 
-        console.log(`Searching for Commit - ${commitSha}`);
+            console.log(`Searching for Commit - ${commitSha}`);
 
-        const { data: commit } = github.rest.repos.getCommit({
-          owner: context.repo.owner,
-          repo: context.repo.repo,
-          ref: commitSha,
-        });
+            const { data: commit } = await github.rest.repos.getCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: commitSha,
+            });
 
-        return `- [${commit.commit.message}](${commit.html_url})\n`;
-      result-encoding: string
+            return `- [${commit.commit.message}](${commit.html_url})\n`;
+          result-encoding: string
 
   build:
     name: Build Solution
@@ -104,22 +149,25 @@ jobs:
         with:
           name: ScriptHookVDotNet
           path: bin/Release
-      - run: ls -R
+      - run: ls -g
         working-directory: bin/Release
       - name: Pack build
+        env:
+          TAG_NAME: ${{ needs.create-new-tag.outputs.tag_name }}
         run: |
-          $artifact_name = "ScriptHookVDotNet-${GITHUB_REF_NAME}"
-          $artifact_file_name = "${artifact_name}.zip"
-          "artifact_name=${artifact_name}" >> $GITHUB_ENV
-          "artifact_filename=${artifact_file_name}" >> $GITHUB_ENV
-          7z a "$artifact_file_name" ${{ github.workspace }}/bin/Release/*
+          artifact_name="ScriptHookVDotNet-${TAG_NAME}"
+          artifact_file_name="${artifact_name}.zip"
+          echo "artifact_name=${artifact_name}" >> $GITHUB_ENV
+          echo "artifact_filename=${artifact_file_name}" >> $GITHUB_ENV
+          zip "$artifact_file_name" ${{ github.workspace }}/bin/Release/*
       - name: Push new release
         uses: ncipollo/release-action@v1.13.0
         with:
           repo: scripthookvdotnet-nightly
           name: ${{ env.artifact_name }}
+          tag: ${{ needs.create-new-tag.outputs.tag_name }}
           token: ${{ secrets.RELEASE_TOKEN_NIGHTLY }}
-          body: ${{ jobs.create-release-note-body-text.outputs.result }}
+          body: ${{ needs.create-release-note-body-text.outputs.body_text }}
           artifacts: |
             ${{ env.artifact_filename }}
           artifactErrorsFailBuild: true

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -71,13 +71,22 @@ jobs:
     outputs:
       tag_name: ${{ steps.tag-output.outputs.result }}
     steps:
-      - uses: actions/github-script@v7
+      - name: Generate Access Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app_id: ${{ vars.SHVDN_APP_ID }}
+          private_key: ${{ secrets.SHVDN_APP_PRIVATE_KEY }}
+          owner: 'scripthookvdotnet'
+          repositories: 'scripthookvdotnet-nightly'
+      - name: Push New Tag
+        uses: actions/github-script@v7
         id: tag-output
         env:
           SHA_NIGHTLY_REPO: ${{ needs.calc-next-tag-name.outputs.sha_on_main_branch_in_nightly_repo }}
           TAG_NAME: ${{ needs.calc-next-tag-name.outputs.next_version_name }}
         with:
-          github-token: ${{ secrets.RELEASE_TOKEN_NIGHTLY }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const owner = process.env.GITHUB_REPOSITORY_OWNER;
             const repo = 'scripthookvdotnet-nightly';
@@ -144,7 +153,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - name: Download artifact from build Workflow
+      - name: Download Artifact from Build Workflow
         uses: actions/download-artifact@v3
         with:
           name: ScriptHookVDotNet
@@ -160,13 +169,21 @@ jobs:
           echo "artifact_name=${artifact_name}" >> $GITHUB_ENV
           echo "artifact_filename=${artifact_file_name}" >> $GITHUB_ENV
           zip "$artifact_file_name" ${{ github.workspace }}/bin/Release/*
-      - name: Push new release
+      - name: Generate Access Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app_id: ${{ vars.SHVDN_APP_ID }}
+          private_key: ${{ secrets.SHVDN_APP_PRIVATE_KEY }}
+          owner: 'scripthookvdotnet'
+          repositories: 'scripthookvdotnet-nightly'
+      - name: Push New Release
         uses: ncipollo/release-action@v1.13.0
         with:
           repo: scripthookvdotnet-nightly
           name: ${{ env.artifact_name }}
           tag: ${{ needs.create-new-tag.outputs.tag_name }}
-          token: ${{ secrets.RELEASE_TOKEN_NIGHTLY }}
+          token: ${{ steps.app-token.outputs.token }}
           body: ${{ needs.create-release-note-body-text.outputs.body_text }}
           artifacts: |
             ${{ env.artifact_filename }}

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -10,9 +10,14 @@ on:
   workflow_dispatch:
     inputs:
       semver_name:
-        description: 'Custom version tag name without v prefix'
+        description: 'Custom semver name without pre-release identifiers'
         required: false
         type: string
+      prerelease_build_number:
+        description: 'Custom pre-release build number'
+        required: false
+        type: string
+        default: '0'
 
 permissions:
   contents: read
@@ -28,15 +33,16 @@ jobs:
           path: nightly-repo
           fetch-depth: 0
         env:
-          CUSTOM_TAG_NAME: ${{ github.event_name != workflow_dispatch && github.event.inputs.tag_name || '' }}
+          CUSTOM_VERSION_NAME: ${{ github.event_name != workflow_dispatch && github.event.inputs.tag_name || '' }}
+          PRERELEASE_BUILD_NO: ${{ github.event_name != workflow_dispatch && github.event.inputs.prerelease_build_number || '0' }}
         run: |
           if [ "$CUSTOM_VERSION_NAME" != "" ]; then
-            echo "next_version_name=$CUSTOM_VERSION_NAME" >> "$GITHUB_OUTPUT"
+            echo "next_version_name=${CUSTOM_VERSION_NAME}-nightly.${PRERELEASE_BUILD_NO}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if [[ "$GITHUB_REF" = refs/tags/* ]]; then
             # we've already checked that the ref is a tag with the v prefix
-            next_version_name=$(echo "$GITHUB_REF_NAME" | cut -c2-)
+            next_version_name=$(echo "${GITHUB_REF_NAME}-nightly.0" | cut -c2-)
             echo "next_version_name=$next_version_name" >> "$GITHUB_OUTPUT"
            exit 0
           fi

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,121 @@
+name: 🌕🏭 Create Nightly Release
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      # create nightly releases for
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      semver_name:
+        description: 'Custom version tag name without v prefix'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  calc-next-tag-name:
+    name: Calculate New Version Tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ format('{0}/scripthookvdotnet-nightly', github.repository_owner) }}
+          path: nightly-repo
+          fetch-depth: 0
+        env:
+          CUSTOM_TAG_NAME: ${{ github.event_name != workflow_dispatch && github.event.inputs.tag_name || '' }}
+        run: |
+          if [ "$CUSTOM_VERSION_NAME" != "" ]; then
+            echo "next_version_name=$CUSTOM_VERSION_NAME" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "$GITHUB_REF" = refs/tags/* ]]; then
+            # we've already checked that the ref is a tag with the v prefix
+            next_version_name=$(echo "$GITHUB_REF_NAME" | cut -c2-)
+            echo "next_version_name=$next_version_name" >> "$GITHUB_OUTPUT"
+           exit 0
+          fi
+
+          if latest_tag_name=$(git describe --tags `git rev-list --tags --max-count=1`); then
+            next_version_name=$(npx semver "$latest_tag_name" -i prerelease)
+            echo "next_version_name=$next_version_name" >> "$GITHUB_OUTPUT"
+          else
+            echo "There's no tags on the nightly repo. Please specify a custom version tag."
+            exit 1
+          fi
+
+  create-new-tag:
+    needs: calc-next-tag-name
+    name: Push New Version Tag
+    runs-on: ubuntu-latest
+    uses: mathieudutour/github-tag-action@v6.1
+    with:
+      github_token: ${{ secrets.RELEASE_TOKEN_NIGHTLY }}
+      # needs to allow any refs so the action won't skip creating a tag when a tag ref is pushed
+      release_branches: ".*"
+      create_annotated_tag: true
+      custom_tag: ${{ jobs.calc-next-tag-name.outputs.next_version_name }}
+
+  create-release-note-body-text:
+    name: Create Body Text for Release
+    runs-on: ubuntu-latest
+    uses: actions/github-script@v7
+    with:
+      script: |
+        const commitSha = ${{ github.sha }};
+
+        console.log(`Searching for Commit - ${commitSha}`);
+
+        const { data: commit } = github.rest.repos.getCommit({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          ref: commitSha,
+        });
+
+        return `- [${commit.commit.message}](${commit.html_url})\n`;
+      result-encoding: string
+
+  build:
+    name: Build Solution
+    uses: ./.github/workflows/build.yml
+    # can't (directly) pass property values of the env var for reusable workflows, so build workflow takes care
+
+  create-release:
+    name: Publish Release
+    needs: [create-new-tag, create-release-note-body-text, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download artifact from build Workflow
+        uses: actions/download-artifact@v3
+        with:
+          name: ScriptHookVDotNet
+          path: bin/Release
+      - run: ls -R
+        working-directory: bin/Release
+      - name: Pack build
+        run: |
+          $artifact_name = "ScriptHookVDotNet-${GITHUB_REF_NAME}"
+          $artifact_file_name = "${artifact_name}.zip"
+          "artifact_name=${artifact_name}" >> $GITHUB_ENV
+          "artifact_filename=${artifact_file_name}" >> $GITHUB_ENV
+          7z a "$artifact_file_name" ${{ github.workspace }}/bin/Release/*
+      - name: Push new release
+        uses: ncipollo/release-action@v1.13.0
+        with:
+          repo: scripthookvdotnet-nightly
+          name: ${{ env.artifact_name }}
+          token: ${{ secrets.RELEASE_TOKEN_NIGHTLY }}
+          body: ${{ jobs.create-release-note-body-text.outputs.result }}
+          artifacts: |
+            ${{ env.artifact_filename }}
+          artifactErrorsFailBuild: true
+          omitBodyDuringUpdate: true
+          omitNameDuringUpdate: true


### PR DESCRIPTION
Resolves #1340

Finally, we can have nightly releases where assets urls are permanent and assets can be downloaded without a GitHub account.

Notice: needs some testing, so I'm going to test in my fork soon.