### PR TITLE
ci: make sure all tests pass before build workflow can complete successfully

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,6 @@ jobs:
           throw "Failed to find the parent path of VSTest.Console."
         }
         Add-Content $env:GITHUB_PATH $vstest_parent_path
-
     - name: Install ScriptHookV SDK
       working-directory: ${{env.SOLUTION_FILE_PATH}}
       run: ./tools/install_sdk.ps1
@@ -65,6 +64,7 @@ jobs:
         vstest.console "source\scripting_v3_tests\bin\x64\Release\net48\ScriptHookVDotNet_APIv3_Tests.dll" /logger:console;verbosity=minimal
     - name: Put misc files for packing
       working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: |
         $robocopy_process = Start-Process "robocopy" -ArgumentList ". bin\Release README.md LICENSE.txt COPYRIGHT.md THIRD-PARTY-NOTICES.md" -PassThru -Wait
         if ($robocopy_process.ExitCode -ne 1) { exit 1 }
         cd bin\Release `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
         {
           throw "Failed to find the parent path of VSTest.Console."
         }
+        echo $vstest_parent_path
         Add-Content $env:GITHUB_PATH $vstest_parent_path
     - name: Install ScriptHookV SDK
       working-directory: ${{env.SOLUTION_FILE_PATH}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,16 @@ jobs:
       with:
         msbuild-architecture: x64
         vs-version: 17.7.6
+    - name: Add VSTest.Console to PATH
+      working-directory: ${{env.SOLUTION_FILE_PATH}}
+      run: |
+        $vstest_parent_path = (.github/workflows/find-vstest-path.ps1)
+        if ($vstest_parent_path -eq "")
+        {
+          throw "Failed to find the parent path of VSTest.Console."
+        }
+        Add-Content $env:GITHUB_PATH $vstest_parent_path
+
     - name: Install ScriptHookV SDK
       working-directory: ${{env.SOLUTION_FILE_PATH}}
       run: ./tools/install_sdk.ps1
@@ -48,6 +58,13 @@ jobs:
       run: |
         msbuild /m /p:configuration=Release /p:platform=x64 ScriptHookVDotNet.sln `
         && del bin\Release\ScriptHookVDotNet*.metagen
+    - name: Run tests
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: |
+        # Set verbosity to `minimal` so only failed tests would print (set to `normal` by default in VSTest.Console)
+        vstest.console "source\scripting_v3_tests\bin\x64\Release\net48\ScriptHookVDotNet_APIv3_Tests.dll" /logger:console;verbosity=minimal
+    - name: Put misc files for packing
+      working-directory: ${{env.GITHUB_WORKSPACE}}
         $robocopy_process = Start-Process "robocopy" -ArgumentList ". bin\Release README.md LICENSE.txt COPYRIGHT.md THIRD-PARTY-NOTICES.md" -PassThru -Wait
         if ($robocopy_process.ExitCode -ne 1) { exit 1 }
         cd bin\Release `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: |
         # Set verbosity to `minimal` so only failed tests would print (set to `normal` by default in VSTest.Console)
-        vstest.console "source\scripting_v3_tests\bin\x64\Release\net48\ScriptHookVDotNet_APIv3_Tests.dll" /logger:console;verbosity=minimal
+        vstest.console "source\scripting_v3_tests\bin\x64\Release\net48\ScriptHookVDotNet_APIv3_Tests.dll" "/logger:console;verbosity=minimal"
     - name: Put misc files for packing
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: |

--- a/.github/workflows/find-vstest-path.ps1
+++ b/.github/workflows/find-vstest-path.ps1
@@ -1,0 +1,8 @@
+$path = (& "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Workload.ManagedDesktop Microsoft.VisualStudio.Workload.Web -requiresAny -property installationPath)
+if (!(test-path $path))
+{
+    return ""
+}
+
+$path = join-path $path 'Common7\IDE\CommonExtensions\Microsoft\TestWindow'
+return $path


### PR DESCRIPTION
We can make sure all tests pass in the CI build now. It would be great if we can add test code in the core module (the ASI one) like how we test structs in `GTA.Chrono`, but integrating C# code into C++/CLI project prevents from testing. So we need to separate most of core code into separate .NET dll first before we can test some code in the core module...