### PR TITLE
feat(api-v3): add Matrix.FastInverse() and Matrix.Inverse()

### DIFF
--- a/source/scripting_v3/GTA.Math/Matrix.cs
+++ b/source/scripting_v3/GTA.Math/Matrix.cs
@@ -439,6 +439,68 @@ namespace GTA.Math
         }
 
         /// <summary>
+        /// Returns the invertse matrix.
+        /// result.
+        /// </summary>
+        public readonly Matrix Inverse()
+        {
+            Matrix res = this;
+            res.Invert();
+            return res;
+        }
+
+        /// <summary>
+        /// Fast inverts the matrix. All the scale must be uniform to calculate the approximately correct result.
+        /// </summary>
+        /// <inheritdoc cref="FastInverse()" path="/remarks"/>
+        public void FastInvert()
+        {
+            this = FastInverse();
+        }
+
+        /// <summary>
+        /// Returns the fast invertse matrix of this matrix. All the scales must be uniform to calculate
+        /// the approximately correct result.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// </para>
+        /// Affine translation will be set to none, which is the same as that of <see cref="Identity"/>.
+        /// <para>
+        /// Idential to how <c>rage::Matrix44::FastInverse(rage::Matrix44 *this, rage::Matrix44 const &amp;m)</c>
+        /// calculates, where the prameter <c>m</c> is the source matrix and the prameter <c>this</c> is the
+        /// destination matrix.
+        /// </para>
+        /// </remarks>
+        public readonly Matrix FastInverse()
+        {
+            // Transpose rotation part
+            Matrix res = default;
+            res.M11 = M11;
+            res.M21 = M12;
+            res.M31 = M13;
+            res.M12 = M21;
+            res.M22 = M22;
+            res.M32 = M23;
+            res.M13 = M31;
+            res.M23 = M32;
+            res.M33 = M33;
+
+            // Set translation to: `transpose([original rotation]) * (-[original translation])`
+            res.M41 = ((M13 * M43) + (M11 * M41) + (M12 * M42)) * -1f;
+            res.M42 = ((M23 * M43) + (M21 * M41) + (M22 * M42)) * -1f;
+            res.M43 = ((M33 * M43) + (M31 * M41) + (M32 * M42)) * -1f;
+
+            // Set affine translation to none
+            res.M14 = 0f;
+            res.M24 = 0f;
+            res.M34 = 0f;
+            res.M44 = 1f;
+
+            return res;
+        }
+
+        /// <summary>
         /// Apply the transformation matrix to a point in world space
         /// </summary>
         /// <param name="point">The original vertex location</param>

--- a/source/scripting_v3/GTA.Math/Matrix.cs
+++ b/source/scripting_v3/GTA.Math/Matrix.cs
@@ -450,7 +450,9 @@ namespace GTA.Math
         }
 
         /// <summary>
-        /// Fast inverts the matrix. All the scale must be uniform to calculate the approximately correct result.
+        /// Fast inverts the matrix.
+        /// All the scales must be uniform and the matrix must be orthogonal to calculate the approximately
+        /// correct result.
         /// </summary>
         /// <inheritdoc cref="FastInverse()" path="/remarks"/>
         public void FastInvert()
@@ -459,13 +461,15 @@ namespace GTA.Math
         }
 
         /// <summary>
-        /// Returns the fast invertse matrix of this matrix. All the scales must be uniform to calculate
-        /// the approximately correct result.
+        /// Returns the fast invertse matrix of this matrix.
+        /// All the scales must be uniform and the matrix must be orthogonal to calculate the approximately
+        /// correct result.
         /// </summary>
         /// <remarks>
         /// <para>
         /// </para>
         /// Affine translation will be set to none, which is the same as that of <see cref="Identity"/>.
+        /// The result will be a bit inaccurate than <see cref="Inverse()"/>.
         /// <para>
         /// Idential to how <c>rage::Matrix44::FastInverse(rage::Matrix44 *this, rage::Matrix44 const &amp;m)</c>
         /// calculates, where the prameter <c>m</c> is the source matrix and the prameter <c>this</c> is the

--- a/source/scripting_v3_tests/MatrixTests.cs
+++ b/source/scripting_v3_tests/MatrixTests.cs
@@ -1,0 +1,98 @@
+//
+// Copyright (C) 2023 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+using Xunit;
+using GTA.Math;
+using System;
+using GTA;
+
+namespace ScriptHookVDotNet_APIv3_Tests.Math
+{
+    public class MatrixTests
+    {
+        public static TheoryData<Matrix, Matrix> FastInverse_Data =>
+            new TheoryData<Matrix, Matrix>
+            {
+                {
+                   new Matrix()
+                   {
+                       M11 = 1f, M12 = 0f, M13 = 0f, M14 = 0f,
+                       M21 = 0f, M22 = 0f, M23 = 1f, M24 = 0f,
+                       M31 = 0f, M32 = -1f, M33 = 0f, M34 = 0f,
+                       M41 = 10f, M42 = 0f, M43 = 0f, M44 = 1f
+                   },
+                   new Matrix()
+                   {
+                       M11 = 1f, M12 = 0f, M13 = 0f, M14 = 0f,
+                       M21 = 0f, M22 = 0f, M23 = -1f, M24 = 0f,
+                       M31 = 0f, M32 = 1f, M33 = 0f, M34 = 0f,
+                       M41 = -10f, M42 = 0f, M43 = 0f, M44 = 1f
+                   }
+                },
+            };
+
+        public static TheoryData<Matrix> Inverse_And_Fast_Inverse_Comparison_Data =>
+            new TheoryData<Matrix>
+            {
+                {
+                   new Matrix()
+                   {
+                       M11 = 1f, M12 = 0f, M13 = 0f, M14 = 0f,
+                       M21 = 0f, M22 = 0f, M23 = 1f, M24 = 0f,
+                       M31 = 0f, M32 = -1f, M33 = 0f, M34 = 0f,
+                       M41 = 10f, M42 = 0f, M43 = 0f, M44 = 1f
+                   }
+                },
+            };
+
+        [Theory]
+        [MemberData(nameof(FastInverse_Data))]
+        public void FastInverse_returns_approx_inversed_value(Matrix mat, Matrix expected)
+        {
+            Matrix actual = mat.FastInverse();
+            EqualsApprox(actual, expected, 1e-5f);
+        }
+
+        [Theory]
+        [MemberData(nameof(FastInverse_Data))]
+        public void FastInvert_returns_approx_inversed_value(Matrix mat, Matrix expected)
+        {
+            Matrix actual = mat;
+            actual.FastInvert();
+            EqualsApprox(actual, expected, 1e-5f);
+        }
+
+        [Theory]
+        [MemberData(nameof(Inverse_And_Fast_Inverse_Comparison_Data))]
+        public void FastInverse_returns_approx_the_same_value_as_regular_inverse_matrix_if_no_scale_or_affine_transform_is_applied(Matrix mat)
+        {
+            Matrix fastInverse = mat.FastInverse();
+            Matrix regularInverse = mat.Inverse();
+
+            EqualsApprox(fastInverse, regularInverse, 1e-5f);
+        }
+
+        private static void EqualsApprox(Matrix left, Matrix right, float tolerance)
+        {
+            Assert.True(System.Math.Abs(left.M11 - right.M11) <= tolerance &&
+                        System.Math.Abs(left.M12 - right.M12) <= tolerance &&
+                        System.Math.Abs(left.M13 - right.M13) <= tolerance &&
+                        System.Math.Abs(left.M14 - right.M14) <= tolerance &&
+                        System.Math.Abs(left.M21 - right.M21) <= tolerance &&
+                        System.Math.Abs(left.M22 - right.M22) <= tolerance &&
+                        System.Math.Abs(left.M23 - right.M23) <= tolerance &&
+                        System.Math.Abs(left.M24 - right.M24) <= tolerance &&
+                        System.Math.Abs(left.M31 - right.M31) <= tolerance &&
+                        System.Math.Abs(left.M32 - right.M32) <= tolerance &&
+                        System.Math.Abs(left.M33 - right.M33) <= tolerance &&
+                        System.Math.Abs(left.M34 - right.M34) <= tolerance &&
+                        System.Math.Abs(left.M41 - right.M41) <= tolerance &&
+                        System.Math.Abs(left.M42 - right.M42) <= tolerance &&
+                        System.Math.Abs(left.M43 - right.M43) <= tolerance &&
+                        System.Math.Abs(left.M44 - right.M44) <= tolerance,
+                $"Assert failed. left: {left.ToString()}, right: {right.ToString()}");
+        }
+    }
+}


### PR DESCRIPTION
The equivalent feature of FastInverse of rage::Matrix34 and rage::Matrix44 comes through! I didn't think you can calculate the inverse of a matrix a lot cheaper than the regular one if no scaling or affine translation is applied until I saw the disassembled code of `rage::Matrix34::FastInverse` and `rage::Matrix44::FastInverse`, though 😛