### PR TITLE
feat(api-v3): add `ProjectileRocket`, `ProjectileThrown`, and query methods for them

### DIFF
--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -258,6 +258,15 @@ namespace SHVDN
             IntPtr startAddressToSearch;
 
             // Get relative address and add it to the instruction address.
+
+            address = FindPatternBmh("\x74\x27\x48\x8D\x7E\x18\x48\x8B\x0F\x48\x3B\xCB\x74\x1B", "xxxxxxxxxxxxxx");
+            // Fetch the address of `AddKnownRef` first, as the offset is at like plus 0xA5 in any builds,
+            // while that of `RemoveKnownRef` is at like plus 0x18EB4.
+            s_fwRefAwareBaseImpl__AddKnownRef = (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, void>)(new IntPtr(
+                *(int*)(address + 0x25) + address + 0x29));
+            s_fwRefAwareBaseImpl__RemoveKnownRef = (delegate* unmanaged[Stdcall]<IntPtr, IntPtr, void>)(new IntPtr(
+                *(int*)(address + 0x17) + address + 0x1B));
+
             address = FindPatternBmh("\x74\x21\x48\x8B\x48\x20\x48\x85\xC9\x74\x18\x48\x8B\xD6\xE8", "xxxxxxxxxxxxxxx") - 10;
             s_getPtfxAddressFunc = (delegate* unmanaged[Stdcall]<int, ulong>)(
                 new IntPtr(*(int*)(address) + address + 4));
@@ -693,6 +702,19 @@ namespace SHVDN
             if (address != null)
             {
                 ProjectileRocketTargetOffset = *(int*)(address + 5);
+
+                ProjectileRocketCachedTargetPosOffset = ProjectileRocketTargetOffset - 0x20;
+                ProjectileRocketLaunchDirOffset = ProjectileRocketTargetOffset - 0x10;
+                ProjectileRocketFlightModelInputPitchOffset = ProjectileRocketTargetOffset + 0x8;
+                ProjectileRocketFlightModelInputRollOffset = ProjectileRocketTargetOffset + 0xC;
+                ProjectileRocketFlightModelInputYawOffset = ProjectileRocketTargetOffset + 0x10;
+
+                ProjectileRocketTimeBeforeHomingOffset = ProjectileRocketTargetOffset + 0x18;
+                ProjectileRocketTimeBeforeHomingAngleBreakOffset = ProjectileRocketTargetOffset + 0x1C;
+                ProjectileRocketLauncherSpeedOffset = ProjectileRocketTargetOffset + 0x20;
+                ProjectileRocketTimeSinceLaunchOffset = ProjectileRocketTargetOffset + 0x24;
+                ProjectileRocketFlagsOffset = ProjectileRocketTargetOffset + 0x30;
+                ProjectileRocketCachedDirectionOffset = ProjectileRocketTargetOffset + 0x40;
             }
 
             address = FindPatternBmh("\x39\x70\x10\x75\x17\x40\x84\xED\x74\x09\x33\xD2\xE8", "xxxxxxxxxxxxx");
@@ -1160,6 +1182,85 @@ namespace SHVDN
 
             return deltaX * deltaX + deltaY * deltaY + deltaZ * deltaZ;
         }
+
+        #region -- fwRefAwareBaseImpl Functions --
+
+        private static delegate* unmanaged[Stdcall]<IntPtr, IntPtr, void> s_fwRefAwareBaseImpl__AddKnownRef;
+        private static delegate* unmanaged[Stdcall]<IntPtr, IntPtr, void> s_fwRefAwareBaseImpl__RemoveKnownRef;
+
+        #endregion
+
+        #region -- fwRegdRef Functions --
+
+        internal sealed class ResetFwRegdRefTask : IScriptTask
+        {
+            #region Fields
+            private IntPtr _lhs;
+            private IntPtr _rhs;
+            #endregion
+
+            internal ResetFwRegdRefTask(IntPtr lhs, IntPtr rhs)
+            {
+                _lhs = lhs;
+                _rhs = rhs;
+            }
+
+            public void Run()
+            {
+                AssignToFwRegdRefInternal(_lhs, _rhs);
+            }
+        }
+
+        /// <summary>
+        /// Assigns a `<c>fwRegdRef</c>`.
+        /// </summary>
+        /// <param name="lhs">
+        /// The <c>fwRegdRef</c> address to put the copy to. Must be one of the subclasses of
+        /// `<c>fwRefAwareBaseImpl</c>`.
+        /// </param>
+        /// <param name="rhs">The other <c>fwRegdRef</c> to copy reference.</param>
+        public static void AssignToFwRegdRef(IntPtr lhs, IntPtr rhs)
+        {
+            var task = new ResetFwRegdRefTask(lhs, rhs);
+            ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
+        }
+
+        /// <summary>
+        /// Assigns a `<c>fwRegdRef</c>`.
+        /// </summary>
+        /// <param name="lhs">
+        /// The <c>fwRegdRef</c> address to put the copy to. Must be one of the subclasses of
+        /// `<c>fwRefAwareBaseImpl</c>`.
+        /// </param>
+        /// <param name="rhs">The other <c>fwRegdRef</c> to copy reference.</param>
+        private static void AssignToFwRegdRefInternal(IntPtr lhs, IntPtr rhs)
+        {
+            if (lhs == IntPtr.Zero)
+            {
+                return;
+            }
+
+            IntPtr oldFwRegdRef = (IntPtr)(*(long*)(lhs));
+            if (oldFwRegdRef == rhs)
+            {
+                return;
+            }
+
+            if (oldFwRegdRef != IntPtr.Zero)
+            {
+                s_fwRefAwareBaseImpl__RemoveKnownRef(oldFwRegdRef, lhs);
+            }
+
+            *(ulong*)lhs = (ulong)rhs;
+
+            IntPtr newFwRegdRef = (IntPtr)(*(long*)(lhs));
+            if (newFwRegdRef != IntPtr.Zero)
+            {
+                s_fwRefAwareBaseImpl__AddKnownRef(newFwRegdRef, lhs);
+            }
+        }
+
+        #endregion
 
         #region -- fwExtensibleBase RTTI Sytem --
 
@@ -5905,9 +6006,53 @@ namespace SHVDN
         #endregion
 
         #region -- Projectile Offsets --
+
         public static int ProjectileAmmoInfoOffset { get; }
         public static int ProjectileOwnerOffset { get; }
+
+        #region -- Projectile Rocket Offsets --
+
+        // `CProjectileRocket` has additional members and the layout of `CProjectileRocket` self hasn't changed
+        // between b372 and b3095
+
+        public static int ProjectileRocketCachedTargetPosOffset { get; }
+        public static int ProjectileRocketLaunchDirOffset { get; }
         public static int ProjectileRocketTargetOffset { get; }
+
+        // We should provide an option to access individual flight model inputs, as the yaw field may be in a different
+        // cache line from one that the pitch and roll fields are in. `m_fPitch` and `m_fYaw` are at
+        // [`CProjectileRocket` + 0x648] and [`CProjectileRocket` + 0x650] respectively but the first digits are
+        // the same in all builds between b372 and b3095.
+        public static int ProjectileRocketFlightModelInputPitchOffset { get; }
+        public static int ProjectileRocketFlightModelInputRollOffset { get; }
+        public static int ProjectileRocketFlightModelInputYawOffset { get; }
+
+        /*
+         * `ProjectileRocketSpeedOffset` would be inserted in this position for `CProjectileRocket::m_fSpeed`
+         * but it is unused
+         */
+
+        public static int ProjectileRocketTimeBeforeHomingOffset { get; }
+        public static int ProjectileRocketTimeBeforeHomingAngleBreakOffset { get; }
+        public static int ProjectileRocketLauncherSpeedOffset { get; }
+        public static int ProjectileRocketTimeSinceLaunchOffset { get; }
+
+        /*
+         * `ProjectileWhistleSoundAddressOffset` would be inserted for `audSound* m_pWhistleSound` here, but `audSound`
+         * needs to be investigated before adding the member
+         */
+
+        /// <summary>
+        /// The offset of the `<c>CProjectileRocket</c>` flags, which are consist of `<c>m_bIsAccurate</c>`,
+        /// `<c>m_bLerpToLaunchDir</c>`, `<c>m_bApplyThrust</c>`, `<c>m_bOnFootHomingWeaponLockedOn</c>`,
+        /// `<c>m_bWasHoming</c>`, `<c>m_bStopHoming</c>`, `<c>m_bHasBeenRedirected</c>`, and
+        /// `<c>m_bTorpHasBeenOutOfWater</c>` (in said order).
+        /// </summary>
+        public static int ProjectileRocketFlagsOffset { get; }
+        public static int ProjectileRocketCachedDirectionOffset { get; }
+
+        #endregion
+
         #endregion
 
         #region -- Projectile Functions --

--- a/source/scripting_v3/GTA/Entities/Entity.cs
+++ b/source/scripting_v3/GTA/Entities/Entity.cs
@@ -21,7 +21,7 @@ namespace GTA
         {
         }
 
-        private enum EntityTypeInternal
+        internal enum EntityTypeInternal
         {
             Building = 1,
             Vehicle = 3,

--- a/source/scripting_v3/GTA/Entities/Projectile.cs
+++ b/source/scripting_v3/GTA/Entities/Projectile.cs
@@ -8,6 +8,9 @@ using System.ComponentModel;
 
 namespace GTA
 {
+    /// <summary>
+    /// Represents a projectile, which is for `<c>CProjectile</c>`.
+    /// </summary>
     public class Projectile : Prop
     {
         internal Projectile(int handle) : base(handle)

--- a/source/scripting_v3/GTA/Entities/ProjectileRocket.cs
+++ b/source/scripting_v3/GTA/Entities/ProjectileRocket.cs
@@ -1,0 +1,55 @@
+//
+// Copyright (C) 2023 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+using System;
+
+namespace GTA
+{
+    /// <summary>
+    /// Represents a rocket projectile, which is for `<c>CProjectileRocket</c>`.
+    /// </summary>
+    public sealed class ProjectileRocket : Projectile
+    {
+        internal ProjectileRocket(int handle) : base(handle)
+        {
+        }
+
+        public Entity Target
+        {
+            get
+            {
+                IntPtr address = SHVDN.NativeMemory.GetEntityAddress(Handle);
+                if (address == IntPtr.Zero)
+                {
+                    return null;
+                }
+
+                return Entity.FromHandle(SHVDN.NativeMemory.GetTargetEntityOfCProjectileRocket(address));
+            }
+        }
+
+        /// <summary>
+        /// Get a <see cref="ProjectileRocket"/> instance by its handle.
+        /// </summary>
+        /// <param name="handle">The handle to test.</param>
+        /// <returns>
+        /// A <see cref="ProjectileRocket"/> if the handle is assigned for a <see cref="ProjectileRocket"/>;
+        /// otherwise, <see langword="null"/>.
+        /// </returns>
+        public static new ProjectileRocket FromHandle(int handle)
+        {
+            IntPtr address = SHVDN.NativeMemory.GetEntityAddress(handle);
+            if (address == IntPtr.Zero
+                || (EntityTypeInternal)SHVDN.NativeMemory.ReadByte(address + 0x28) != EntityTypeInternal.Object)
+            {
+                return null;
+            }
+
+            // `CObject::GetAsCProjectileRocket` should return the same address if the vfunc is overridden by
+            // `CProjectileRocket`'s implementation and it should return false otherwise
+            return SHVDN.NativeMemory.GetAsCProjectileRocket(address) != address ? null : new ProjectileRocket(handle);
+        }
+    }
+}

--- a/source/scripting_v3/GTA/Entities/ProjectileRocket.cs
+++ b/source/scripting_v3/GTA/Entities/ProjectileRocket.cs
@@ -4,6 +4,8 @@
 //
 
 using System;
+using GTA.Math;
+using SHVDN;
 
 namespace GTA
 {
@@ -16,17 +18,443 @@ namespace GTA
         {
         }
 
+        /// <summary>
+        /// Gets or sets the homing target.
+        /// </summary>
         public Entity Target
         {
             get
             {
-                IntPtr address = SHVDN.NativeMemory.GetEntityAddress(Handle);
+                IntPtr address = NativeMemory.GetEntityAddress(Handle);
                 if (address == IntPtr.Zero)
                 {
                     return null;
                 }
 
-                return Entity.FromHandle(SHVDN.NativeMemory.GetTargetEntityOfCProjectileRocket(address));
+                return Entity.FromHandle(NativeMemory.GetTargetEntityOfCProjectileRocket(address));
+            }
+
+            set
+            {
+                IntPtr address = NativeMemory.GetEntityAddress(Handle);
+                if (address == IntPtr.Zero)
+                {
+                    return;
+                }
+
+                IntPtr targetAddress = IntPtr.Zero;
+                if (value != null)
+                {
+                    targetAddress = NativeMemory.GetEntityAddress(value.Handle);
+                    if (targetAddress == IntPtr.Zero)
+                    {
+                        return;
+                    }
+                }
+
+                NativeMemory.AssignToFwRegdRef(address + NativeMemory.ProjectileRocketTargetOffset, targetAddress);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the cached homing target position when the projectile is not homing <see cref="Target"/>
+        /// accurately for <see cref="IsAccurate"/> being not set.
+        /// </summary>
+        public Vector3 CachedTargetPosition
+        {
+            get
+            {
+                IntPtr address = MemoryAddress;
+                if (address == IntPtr.Zero || NativeMemory.ProjectileRocketCachedTargetPosOffset == 0)
+                {
+                    return Vector3.Zero;
+                }
+
+                return new Vector3(NativeMemory.ReadVector3(address + NativeMemory.ProjectileRocketCachedTargetPosOffset));
+            }
+            set
+            {
+                IntPtr address = MemoryAddress;
+                if (address == IntPtr.Zero || NativeMemory.ProjectileRocketCachedTargetPosOffset == 0)
+                {
+                    return;
+                }
+
+                NativeMemory.WriteVector3(address + NativeMemory.ProjectileRocketCachedTargetPosOffset,
+                    value.ToInternalFVector3());
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the launch direction.
+        /// The <see cref="ProjectileRocket"/> lerps to this direction first until it lerps close enough.
+        /// </summary>
+        public Vector3 LaunchDirection
+        {
+            get
+            {
+                IntPtr address = MemoryAddress;
+                if (address == IntPtr.Zero || NativeMemory.ProjectileRocketLaunchDirOffset == 0)
+                {
+                    return Vector3.Zero;
+                }
+
+                return new Vector3(NativeMemory.ReadVector3(address + NativeMemory.ProjectileRocketLaunchDirOffset));
+            }
+            set
+            {
+                IntPtr address = MemoryAddress;
+                if (address == IntPtr.Zero || NativeMemory.ProjectileRocketLaunchDirOffset == 0)
+                {
+                    return;
+                }
+
+                NativeMemory.WriteVector3(address + NativeMemory.ProjectileRocketLaunchDirOffset,
+                    value.ToInternalFVector3());
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the flight model input of this <see cref="ProjectileRocket"/> as a <see cref="Vector3"/>.
+        /// </summary>
+        /// <remarks>
+        /// If you are accessing subset of flight model input values and concern potential performance loss when
+        /// the property has to access 2 cache lines, use individual flight model input such as
+        /// <see cref="FlightModelInputPitch"/>. You might want to note that the address of
+        /// <see cref="FlightModelInputYaw"/> can be in a different cache line from one where
+        /// <see cref="FlightModelInputPitch"/> and <see cref="FlightModelInputRoll"/> are.
+        /// </remarks>
+        public Vector3 FlightModelInput
+        {
+            get
+            {
+                IntPtr address = MemoryAddress;
+                if (address == IntPtr.Zero || NativeMemory.ProjectileRocketFlightModelInputPitchOffset == 0)
+                {
+                    return Vector3.Zero;
+                }
+
+                return new Vector3(NativeMemory.ReadVector3(address + NativeMemory.ProjectileRocketFlightModelInputPitchOffset));
+            }
+            set
+            {
+                IntPtr address = MemoryAddress;
+                if (address == IntPtr.Zero || NativeMemory.ProjectileRocketFlightModelInputPitchOffset == 0)
+                {
+                    return;
+                }
+
+                NativeMemory.WriteVector3(address + NativeMemory.ProjectileRocketFlightModelInputPitchOffset,
+                    value.ToInternalFVector3());
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the pitch of flight model input of this <see cref="ProjectileRocket"/>.
+        /// </summary>
+        public float FlightModelInputPitch
+        {
+            get
+            {
+                IntPtr address = MemoryAddress;
+                if (address == IntPtr.Zero || NativeMemory.ProjectileRocketFlightModelInputPitchOffset == 0)
+                {
+                    return 0;
+                }
+
+                return NativeMemory.ReadFloat(address + NativeMemory.ProjectileRocketFlightModelInputPitchOffset);
+            }
+            set
+            {
+                IntPtr address = MemoryAddress;
+                if (address == IntPtr.Zero || NativeMemory.ProjectileRocketFlightModelInputPitchOffset == 0)
+                {
+                    return;
+                }
+
+                NativeMemory.WriteFloat(address + NativeMemory.ProjectileRocketFlightModelInputPitchOffset, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the roll of flight model input of this <see cref="ProjectileRocket"/>.
+        /// </summary>
+        public float FlightModelInputRoll
+        {
+            get
+            {
+                IntPtr address = MemoryAddress;
+                if (address == IntPtr.Zero || NativeMemory.ProjectileRocketFlightModelInputRollOffset == 0)
+                {
+                    return 0;
+                }
+
+                return NativeMemory.ReadFloat(address + NativeMemory.ProjectileRocketFlightModelInputRollOffset);
+            }
+            set
+            {
+                IntPtr address = MemoryAddress;
+                if (address == IntPtr.Zero || NativeMemory.ProjectileRocketFlightModelInputRollOffset == 0)
+                {
+                    return;
+                }
+
+                NativeMemory.WriteFloat(address + NativeMemory.ProjectileRocketFlightModelInputRollOffset, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the yaw of flight model input of this <see cref="ProjectileRocket"/>.
+        /// </summary>
+        public float FlightModelInputYaw
+        {
+            get
+            {
+                IntPtr address = MemoryAddress;
+                if (address == IntPtr.Zero || NativeMemory.ProjectileRocketFlightModelInputYawOffset == 0)
+                {
+                    return 0;
+                }
+
+                return NativeMemory.ReadFloat(address + NativeMemory.ProjectileRocketFlightModelInputYawOffset);
+            }
+            set
+            {
+                IntPtr address = MemoryAddress;
+                if (address == IntPtr.Zero || NativeMemory.ProjectileRocketFlightModelInputYawOffset == 0)
+                {
+                    return;
+                }
+
+                NativeMemory.WriteFloat(address + NativeMemory.ProjectileRocketFlightModelInputYawOffset, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the time before homing in seconds.
+        /// </summary>
+        public float TimeBeforeHoming
+        {
+            get
+            {
+                IntPtr address = MemoryAddress;
+                if (address == IntPtr.Zero || NativeMemory.ProjectileRocketTimeBeforeHomingOffset == 0)
+                {
+                    return 0;
+                }
+
+                return NativeMemory.ReadFloat(address + NativeMemory.ProjectileRocketTimeBeforeHomingOffset);
+            }
+            set
+            {
+                IntPtr address = MemoryAddress;
+                if (address == IntPtr.Zero || NativeMemory.ProjectileRocketTimeBeforeHomingOffset == 0)
+                {
+                    return;
+                }
+
+                NativeMemory.WriteFloat(address + NativeMemory.ProjectileRocketTimeBeforeHomingOffset, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the time before homing stops ignoring angle break in seconds.
+        /// If set to zero (or less) and the <see cref="ProjectileRocket"/> is homing, it should only home
+        /// <see cref="Target"/> is within a certain angle threshold.
+        /// </summary>
+        public float TimeBeforeHomingAngleBreak
+        {
+            get
+            {
+                IntPtr address = MemoryAddress;
+                if (address == IntPtr.Zero || NativeMemory.ProjectileRocketTimeBeforeHomingAngleBreakOffset == 0)
+                {
+                    return 0;
+                }
+
+                return NativeMemory.ReadFloat(address + NativeMemory.ProjectileRocketTimeBeforeHomingAngleBreakOffset);
+            }
+            set
+            {
+                IntPtr address = MemoryAddress;
+                if (address == IntPtr.Zero || NativeMemory.ProjectileRocketTimeBeforeHomingAngleBreakOffset == 0)
+                {
+                    return;
+                }
+
+                NativeMemory.WriteFloat(address + NativeMemory.ProjectileRocketTimeBeforeHomingAngleBreakOffset, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the speed this <see cref="ProjectileRocket"/> launched and should maintain in m/s.
+        /// </summary>
+        public float LauncherSpeed
+        {
+            get
+            {
+                IntPtr address = MemoryAddress;
+                if (address == IntPtr.Zero || NativeMemory.ProjectileRocketLauncherSpeedOffset == 0)
+                {
+                    return 0;
+                }
+
+                return NativeMemory.ReadFloat(address + NativeMemory.ProjectileRocketLauncherSpeedOffset);
+            }
+            set
+            {
+                IntPtr address = MemoryAddress;
+                if (address == IntPtr.Zero || NativeMemory.ProjectileRocketLauncherSpeedOffset == 0)
+                {
+                    return;
+                }
+
+                NativeMemory.WriteFloat(address + NativeMemory.ProjectileRocketLauncherSpeedOffset, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the time since launch that in seconds. If this value is less than the `SeparationTime` of
+        /// the `<c>CAmmoRocketInfo</c>` that this <see cref="ProjectileRocket"/> uses,
+        /// the <see cref="ProjectileRocket"/> will receive a small gravity force instead of the thrust force.
+        /// </summary>
+        public float TimeSinceLaunch
+        {
+            get
+            {
+                IntPtr address = MemoryAddress;
+                if (address == IntPtr.Zero || NativeMemory.ProjectileRocketTimeSinceLaunchOffset == 0)
+                {
+                    return 0;
+                }
+
+                return NativeMemory.ReadFloat(address + NativeMemory.ProjectileRocketTimeSinceLaunchOffset);
+            }
+            set
+            {
+                IntPtr address = MemoryAddress;
+                if (address == IntPtr.Zero || NativeMemory.ProjectileRocketTimeSinceLaunchOffset == 0)
+                {
+                    return;
+                }
+
+                NativeMemory.WriteFloat(address + NativeMemory.ProjectileRocketTimeSinceLaunchOffset, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets whether this <see cref="ProjectileRocket"/> is accurately homing, which is set when the player
+        /// locks on a <see cref="Entity"/> and fires the weapon.
+        /// </summary>
+        public bool IsAccurate
+        {
+            get => GetProjectileRocketFlag(0);
+            set => SetProjectileRocketFlag(0, value);
+        }
+
+        /// <summary>
+        /// Gets or sets whether this <see cref="ProjectileRocket"/> is lerping to the launch direction, which is set
+        /// in `<c>CProjectileRocket::Fire</c>`.
+        /// </summary>
+        public bool LerpToLaunchDirection
+        {
+            get => GetProjectileRocketFlag(1);
+            set => SetProjectileRocketFlag(1, value);
+        }
+
+        /// <summary>
+        /// Gets or sets whether this <see cref="ProjectileRocket"/> should apply thrust.
+        /// Sets to <see langword="false"/> when the <see cref="ProjectileRocket"/> goes into water if
+        /// `<c>CProjectileRocket::ProcessPhysics</c>` is controlling the physics and <c>`ThrustUnderwater`</c> is
+        /// not set in `<c>ProjectileFlags</c>` of the projectile's <c>`CAmmoRocketInfo`</c>.
+        /// </summary>
+        public bool ApplyThrust
+        {
+            get => GetProjectileRocketFlag(2);
+            set => SetProjectileRocketFlag(2, value);
+        }
+
+        /// <summary>
+        /// Gets or sets whether this <see cref="ProjectileRocket"/> is locked on with a on-foot homing weapon
+        /// that fired the <see cref="ProjectileRocket"/>. `<c>OnFootHoming</c>` should be set in
+        /// `<c>WeaponFlags</c>` of `<c>CWeaponInfo</c>` (in a `weapons.meta`), so the internal functions of
+        /// `<c>CProjectileRocket</c>` can work to home <see cref="Target"/> as intended.
+        /// </summary>
+        public bool OnFootHomingWeaponLockedOn
+        {
+            get => GetProjectileRocketFlag(3);
+            set => SetProjectileRocketFlag(3, value);
+        }
+
+        /// <summary>
+        /// Gets or sets whether this <see cref="ProjectileRocket"/> was homing <see cref="Target"/> at any time.
+        /// </summary>
+        public bool WasHoming
+        {
+            get => GetProjectileRocketFlag(4);
+            set => SetProjectileRocketFlag(4, value);
+        }
+
+        /// <summary>
+        /// Gets or sets whether this <see cref="ProjectileRocket"/> has stopped homing <see cref="Target"/>.
+        /// </summary>
+        public bool StopHoming
+        {
+            get => GetProjectileRocketFlag(5);
+            set => SetProjectileRocketFlag(5, value);
+        }
+
+        /// <summary>
+        /// <para>
+        /// Gets whether this <see cref="ProjectileRocket"/> is redirected to a <see cref="Projectile"/> attractor
+        /// whose `<c>CAmmoProjectileInfo</c>` (or one of its subclasses `<c>CAmmoRocketInfo</c>` or
+        /// `<c>CAmmoThrownInfo</c>`) has `<c>HomingAttractor</c>` flag in `<c>ProjectileFlags</c>`.
+        /// </para>
+        /// <para>
+        /// Not available in v1.0.1032.1 and earlier versions.
+        /// </para>
+        /// </summary>
+        public bool IsRedirected
+        {
+            get => GetProjectileRocketFlag(6);
+            // Maybe we should have our `OnFootHomingWeaponLockedOn` set true in our setter when
+            // `CWeaponInfo::GetIsOnFootHoming()` (where the instance is retrieved by
+            // `CProjectile::m_uWeaponFiredFromHash`) returns true, just like how `CProjectileRocket::SetIsRedirected`
+            // does.
+        }
+
+        /*
+         * We're 100% sure we should not mess with `m_bTorpHasBeenOutOfWater` (for 8th bit, assumed to exist since
+         * b2189 where Kosatka is introduced). It switches on when the projectile gets in and out of water, but both
+         * happens only if both `ThrustUnderwater` and `UseGravityOutOfWater` are set in `ProjectileFlags` of
+         * the projectile's `CAmmoRocketInfo`.
+         */
+
+        /// <summary>
+        /// Gets or sets the cached direction toward <see cref="Target"/>.
+        /// </summary>
+        public Vector3 CachedDirection
+        {
+            get
+            {
+                IntPtr address = MemoryAddress;
+                if (address == IntPtr.Zero || NativeMemory.ProjectileRocketCachedDirectionOffset == 0)
+                {
+                    return Vector3.Zero;
+                }
+
+                return new Vector3(NativeMemory.ReadVector3(address + NativeMemory.ProjectileRocketCachedDirectionOffset));
+            }
+            set
+            {
+                IntPtr address = MemoryAddress;
+                if (address == IntPtr.Zero || NativeMemory.ProjectileRocketCachedDirectionOffset == 0)
+                {
+                    return;
+                }
+
+                NativeMemory.WriteVector3(address + NativeMemory.ProjectileRocketCachedDirectionOffset,
+                    value.ToInternalFVector3());
             }
         }
 
@@ -50,6 +478,27 @@ namespace GTA
             // `CObject::GetAsCProjectileRocket` should return the same address if the vfunc is overridden by
             // `CProjectileRocket`'s implementation and it should return false otherwise
             return SHVDN.NativeMemory.GetAsCProjectileRocket(address) != address ? null : new ProjectileRocket(handle);
+        }
+
+        private bool GetProjectileRocketFlag(byte bit)
+        {
+            IntPtr address = MemoryAddress;
+            if (address == IntPtr.Zero || NativeMemory.ProjectileRocketFlagsOffset == 0)
+            {
+                return false;
+            }
+
+            return NativeMemory.IsBitSet(address + NativeMemory.ProjectileRocketFlagsOffset, bit);
+        }
+        private void SetProjectileRocketFlag(byte bit, bool value)
+        {
+            IntPtr address = MemoryAddress;
+            if (address == IntPtr.Zero || NativeMemory.ProjectileRocketFlagsOffset == 0)
+            {
+                return;
+            }
+
+            NativeMemory.SetBit(address + NativeMemory.ProjectileRocketFlagsOffset, bit, value);
         }
     }
 }

--- a/source/scripting_v3/GTA/Entities/ProjectileThrown.cs
+++ b/source/scripting_v3/GTA/Entities/ProjectileThrown.cs
@@ -1,0 +1,47 @@
+//
+// Copyright (C) 2023 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+using System;
+
+namespace GTA
+{
+    /// <summary>
+    /// Represents a thrown projectile, which is for `<c>CProjectileThrown</c>`.
+    /// </summary>
+    /// <remarks>
+    /// Unlike `<c>CProjectileRocket</c>`, `<c>CProjectileThrown</c>` only overrides
+    /// `<c>CObject::GetAsProjectileThrown</c>` (both const and non-const variants) and `<c>CProjectile::GetInfo</c>`
+    /// (which returns `<c>CAmmoProjectileInfo</c>`).
+    /// `<c>CProjectileThrown</c>` does not have additional members or functions, either.
+    /// </remarks>
+    public sealed class ProjectileThrown : Projectile
+    {
+        internal ProjectileThrown(int handle) : base(handle)
+        {
+        }
+
+        /// <summary>
+        /// Get a <see cref="ProjectileThrown"/> instance by its handle.
+        /// </summary>
+        /// <param name="handle">The handle to test.</param>
+        /// <returns>
+        /// A <see cref="ProjectileThrown"/> if the handle is assigned for a <see cref="ProjectileThrown"/>;
+        /// otherwise, <see langword="null"/>.
+        /// </returns>
+        public static new ProjectileThrown FromHandle(int handle)
+        {
+            IntPtr address = SHVDN.NativeMemory.GetEntityAddress(handle);
+            if (address == IntPtr.Zero
+                || (EntityTypeInternal)SHVDN.NativeMemory.ReadByte(address + 0x28) != EntityTypeInternal.Object)
+            {
+                return null;
+            }
+
+            // `CObject::GetAsCProjectileThrown` should return the same address if the vfunc is overridden by
+            // `CProjectileThrown`'s implementation and it should return false otherwise
+            return SHVDN.NativeMemory.GetAsCProjectileThrown(address) != address ? null : new ProjectileThrown(handle);
+        }
+    }
+}

--- a/source/scripting_v3/GTA/Entities/Prop.cs
+++ b/source/scripting_v3/GTA/Entities/Prop.cs
@@ -3,6 +3,7 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
 using SHVDN;
 
 namespace GTA
@@ -51,6 +52,68 @@ namespace GTA
         public new bool Exists()
         {
             return EntityType == EntityType.Prop;
+        }
+
+        /// <summary>
+        /// Get as a <see cref="Projectile"/> instance if this <see cref="Prop"/> is a <see cref="Projectile"/>.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="Projectile"/> if the <see cref="Prop"/> exists and is a <see cref="Projectile"/>;
+        /// otherwise, <see langword="null"/>.
+        /// </returns>
+        public Projectile AsProjectile()
+        {
+            IntPtr address = MemoryAddress;
+            if (address == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            // `CObject::GetAsCProjectile` should return the same address if the vfunc is overridden by `CProjectile`'s
+            // implementation and it should return false otherwise
+            return NativeMemory.GetAsCProjectile(address) != address ? null : new Projectile(Handle);
+        }
+
+        /// <summary>
+        /// Get as a <see cref="ProjectileRocket"/> instance if this <see cref="Prop"/> is
+        /// a <see cref="ProjectileRocket"/>.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="ProjectileRocket"/> if the <see cref="Prop"/> exists and is a <see cref="ProjectileRocket"/>;
+        /// otherwise, <see langword="null"/>.
+        /// </returns>
+        public ProjectileRocket AsProjectileRocket()
+        {
+            IntPtr address = MemoryAddress;
+            if (address == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            // `CObject::GetAsCProjectileRocket` should return the same address if the vfunc is overridden by
+            // `CProjectileRocket`'s implementation and it should return false otherwise
+            return NativeMemory.GetAsCProjectileRocket(address) != address ? null : new ProjectileRocket(Handle);
+        }
+
+        /// <summary>
+        /// Get as a <see cref="ProjectileThrown"/> instance if this <see cref="Prop"/> is
+        /// a <see cref="ProjectileThrown"/>.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="ProjectileThrown"/> if the <see cref="Prop"/> exists and is a <see cref="ProjectileThrown"/>;
+        /// otherwise, <see langword="null"/>.
+        /// </returns>
+        public ProjectileThrown AsProjectileThrown()
+        {
+            IntPtr address = MemoryAddress;
+            if (address == IntPtr.Zero)
+            {
+                return null;
+            }
+
+            // `CObject::GetAsCProjectileThrown` should return the same address if the vfunc is overridden by
+            // `CProjectileThrown`'s implementation and it should return false otherwise
+            return NativeMemory.GetAsCProjectileThrown(address) != address ? null : new ProjectileThrown(Handle);
         }
     }
 }

--- a/source/scripting_v3/GTA/World.cs
+++ b/source/scripting_v3/GTA/World.cs
@@ -779,7 +779,64 @@ namespace GTA
         /// <param name="radius">The maximum distance from the <paramref name="position"/> to detect <see cref="Projectile"/>s.</param>
         public static Projectile[] GetNearbyProjectiles(Vector3 position, float radius)
         {
-            return Array.ConvertAll(SHVDN.NativeMemory.GetProjectileHandles(position.ToInternalFVector3(), radius), handle => new Projectile(handle));
+            return Array.ConvertAll(SHVDN.NativeMemory.GetProjectileHandles(position.ToInternalFVector3(),
+                radius), handle => new Projectile(handle));
+        }
+        /// <summary>
+        /// Gets the closest <see cref="ProjectileRocket"/> to a given position in the World.
+        /// </summary>
+        /// <param name="position">The position to find the nearest <see cref="ProjectileRocket"/>.</param>
+        /// <param name="radius">The maximum distance from the <paramref name="position"/> to detect <see cref="ProjectileRocket"/>s.</param>
+        /// <remarks>Returns <see langword="null" /> if no <see cref="ProjectileRocket"/> was in the given region.</remarks>
+        public static ProjectileRocket GetClosestRocketProjectile(Vector3 position, float radius)
+        {
+            return GetClosest(position, GetNearbyRocketProjectiles(position, radius));
+        }
+        /// <summary>
+        /// Gets an <c>array</c> of all <see cref="ProjectileRocket"/>s in the World.
+        /// </summary>
+        public static ProjectileRocket[] GetAllRocketProjectiles()
+        {
+            return Array.ConvertAll(SHVDN.NativeMemory.GetRocketProjectileHandles(), handle => new
+                ProjectileRocket(handle));
+        }
+        /// <summary>
+        /// Gets an <c>array</c> of all <see cref="ProjectileRocket"/>s in a given region in the World.
+        /// </summary>
+        /// <param name="position">The position to check the <see cref="ProjectileRocket"/> against.</param>
+        /// <param name="radius">The maximum distance from the <paramref name="position"/> to detect <see cref="ProjectileRocket"/>s.</param>
+        public static ProjectileRocket[] GetNearbyRocketProjectiles(Vector3 position, float radius)
+        {
+            return Array.ConvertAll(SHVDN.NativeMemory.GetRocketProjectileHandles(position.ToInternalFVector3(),
+                radius), handle => new ProjectileRocket(handle));
+        }
+        /// <summary>
+        /// Gets the closest <see cref="ProjectileThrown"/> to a given position in the World.
+        /// </summary>
+        /// <param name="position">The position to find the nearest <see cref="ProjectileThrown"/>.</param>
+        /// <param name="radius">The maximum distance from the <paramref name="position"/> to detect <see cref="ProjectileThrown"/>s.</param>
+        /// <remarks>Returns <see langword="null" /> if no <see cref="ProjectileThrown"/> was in the given region.</remarks>
+        public static ProjectileThrown GetClosestThrownProjectile(Vector3 position, float radius)
+        {
+            return GetClosest(position, GetNearbyThrownProjectiles(position, radius));
+        }
+        /// <summary>
+        /// Gets an <c>array</c> of all <see cref="ProjectileRocket"/>s in the World.
+        /// </summary>
+        public static ProjectileThrown[] GetAllThrownProjectiles()
+        {
+            return Array.ConvertAll(SHVDN.NativeMemory.GetThrownProjectileHandles(), handle
+                => new ProjectileThrown(handle));
+        }
+        /// <summary>
+        /// Gets an <c>array</c> of all <see cref="ProjectileThrown"/>s in a given region in the World.
+        /// </summary>
+        /// <param name="position">The position to check the <see cref="ProjectileThrown"/> against.</param>
+        /// <param name="radius">The maximum distance from the <paramref name="position"/> to detect <see cref="ProjectileThrown"/>s.</param>
+        public static ProjectileThrown[] GetNearbyThrownProjectiles(Vector3 position, float radius)
+        {
+            return Array.ConvertAll(SHVDN.NativeMemory.GetThrownProjectileHandles(position.ToInternalFVector3(),
+                radius), handle => new ProjectileThrown(handle));
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
Have you ever thought of how to access additional data of `CProjectileRocket`, or how to distinguish the types of the `CAmmoProjectileInfo` member `CProjectile` has so you can safely access `CAmmoProjectileInfo` data? Or have you just thought of how to distinguish projectile types of projectile objects among the normal one, the rocket one, and the thrown one? This PR would solve them.