### PR TITLE
feat(api-v3): `Ped.SetIKTarget`

### DIFF
--- a/source/scripting_v3/GTA/Entities/Peds/IKPart.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/IKPart.cs
@@ -1,0 +1,26 @@
+//
+// Copyright (C) 2024 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+using GTA.Math;
+
+namespace GTA
+{
+    /// <summary>
+    /// An enumeration of all the possible IK parts that is only used in
+    /// <see cref="Ped.SetIKTarget(IKPart, PedBone, Vector3, IKTargetFlags, int, int)"/>.
+    /// </summary>
+    /// <remarks>
+    /// The members for `<c>IK_PART_INVALID</c>`, `<c>IK_PART_SPINE</c>`, `<c>IK_PART_LEG_LEFT</c>`, and
+    /// `<c>IK_PART_LEG_RIGHT</c>`, whose values are 0, 2, 5, and 6 respectively, are not defined in this enum.
+    /// This is because this enum is only meant to be used in `<c>SET_IK_TARGET</c>` and it actually does not support
+    /// any of the 4 members mentioned earlier.
+    /// </remarks>
+    public enum IKPart
+    {
+        Head = 1,
+        ArmLeft = 3,
+        ArmRight = 4,
+    }
+}

--- a/source/scripting_v3/GTA/Entities/Peds/IKTargetFlags.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/IKTargetFlags.cs
@@ -1,0 +1,69 @@
+//
+// Copyright (C) 2024 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+using System;
+using GTA.Math;
+
+namespace GTA
+{
+    /// <summary>
+    /// An enumeration of all the possible flags that is only used in
+    /// <see cref="Ped.SetIKTarget(IKPart, PedBone, Vector3, IKTargetFlags, int, int)"/>.
+    /// </summary>
+    [Flags]
+    public enum IKTargetFlags
+    {
+        Default = 0,
+        /// <summary>
+        /// Arm target relative to the hand bone.
+        /// </summary>
+        /// <remarks>
+        /// Has effect only in conjunction with <see cref="IKPart.ArmLeft"/> or <see cref="IKPart.ArmRight"/>.
+        /// </remarks>
+        ArmTargetWrtHandBone = 1,
+        /// <summary>
+        /// Arm target relative to the point helper.
+        /// </summary>
+        /// <remarks>
+        /// Has effect only in conjunction with <see cref="IKPart.ArmLeft"/> or <see cref="IKPart.ArmRight"/>.
+        /// </remarks>
+        ArmTargetWrtPointHelper = 2,
+        /// <summary>
+        /// Arm target relative to the IK helper.
+        /// </summary>
+        /// <remarks>
+        /// Has effect only in conjunction with <see cref="IKPart.ArmLeft"/> or <see cref="IKPart.ArmRight"/>.
+        /// </remarks>
+        ArmTargetWrtIKHelper = 4,
+        /// <summary>
+        /// Use animation tags directly.
+        /// </summary>
+        /// <remarks>
+        /// Has effect only in conjunction with <see cref="IKPart.Head"/>.
+        /// </remarks>
+        IKTagModeNormal = 8,
+        /// <summary>
+        /// Use animation tags in ALLOW mode.
+        /// </summary>
+        /// <remarks>
+        /// Has effect only in conjunction with <see cref="IKPart.ArmLeft"/> or <see cref="IKPart.ArmRight"/>.
+        /// </remarks>
+        IKTagModeAllow = 16,
+        /// <summary>
+        /// Use animation tags in BLOCK mode.
+        /// </summary>
+        /// <remarks>
+        /// Has effect only in conjunction with <see cref="IKPart.ArmLeft"/> or <see cref="IKPart.ArmRight"/>.
+        /// </remarks>
+        IKTagModeBlock = 32,
+        /// <summary>
+        /// Solve for orientation in addition to position.
+        /// </summary>
+        /// <remarks>
+        /// Has effect only in conjunction with <see cref="IKPart.ArmLeft"/> or <see cref="IKPart.ArmRight"/>.
+        /// </remarks>
+        IKArmUseOrientation = 64
+    }
+}

--- a/source/scripting_v3/GTA/Entities/Peds/Ped.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Ped.cs
@@ -2791,8 +2791,14 @@ namespace GTA
         /// <param name="targetBone">The target <see cref="EntityBone"/>.</param>
         /// <param name="targetOffset">The target offset relative to the bone.</param>
         /// <param name="flags">The flags.</param>
-        /// <param name="blendInTimeMS">The blend in time in milliseconds.</param>
-        /// <param name="blendOutTimeMS">The blend out time in milliseconds.</param>
+        /// <param name="blendInTimeMS">
+        /// The blend in time in milliseconds.
+        /// Set to -1 for default blend in time. Set to 0 for instant blend in time.
+        /// </param>
+        /// <param name="blendOutTimeMS">
+        /// The blend out time in milliseconds.
+        /// Set to -1 for default blend out time. Set to 0 for instant blend out time.
+        /// </param>
         /// <remarks>
         /// The IK target will only be valid for one update, so it needs to be set for as long as it is needed (to
         /// avoid IK targets not being cleared and getting stuck enabled).
@@ -2814,8 +2820,14 @@ namespace GTA
         /// <param name="targetBone">The target <see cref="EntityBone"/>.</param>
         /// <param name="targetOffset">The target offset relative to the bone.</param>
         /// <param name="flags">The flags.</param>
-        /// <param name="blendInTimeMS">The blend in time in milliseconds.</param>
-        /// <param name="blendOutTimeMS">The blend out time in milliseconds.</param>
+        /// <param name="blendInTimeMS">
+        /// The blend in time in milliseconds.
+        /// Set to -1 for default blend in time. Set to 0 for instant blend in time.
+        /// </param>
+        /// <param name="blendOutTimeMS">
+        /// The blend out time in milliseconds.
+        /// Set to -1 for default blend out time. Set to 0 for instant blend out time.
+        /// </param>
         /// <remarks>
         /// <inheritdoc cref="SetIKTarget(IKPart, PedBone, Vector3, IKTargetFlags, int, int)" path="/remarks"/>
         /// </remarks>
@@ -2840,14 +2852,21 @@ namespace GTA
         /// Set to -1 for no target bone.
         /// </param>
         /// <param name="targetOffset">
-        /// If target entity is <see langword="null"/>, this is assumed to be world coordinates.
-        /// If target entity is not <see langword="null"/>, this is an offset from the target entity.
-        /// If target entity is not <see langword="null"/> and <paramref name="boneTag"/> is not -1, this is an offset
-        /// relative to the bone.
+        /// If <paramref name="targetEntity"/> is <see langword="null"/>, this is assumed to be world coordinates.
+        /// If <paramref name="targetEntity"/> is not <see langword="null"/>, this is an offset from
+        /// <paramref name="targetEntity"/>.
+        /// If <paramref name="targetEntity"/> is not <see langword="null"/> and <paramref name="boneTag"/> is not -1,
+        /// this is an offset relative to the bone.
         /// </param>
         /// <param name="flags">The flags.</param>
-        /// <param name="blendInTimeMS">The blend in time in milliseconds.</param>
-        /// <param name="blendOutTimeMS">The blend out time in milliseconds.</param>
+        /// <param name="blendInTimeMS">
+        /// The blend in time in milliseconds.
+        /// Set to -1 for default blend in time. Set to 0 for instant blend in time.
+        /// </param>
+        /// <param name="blendOutTimeMS">
+        /// The blend out time in milliseconds.
+        /// Set to -1 for default blend out time. Set to 0 for instant blend out time.
+        /// </param>
         /// <remarks>
         /// <inheritdoc cref="SetIKTarget(IKPart, PedBone, Vector3, IKTargetFlags, int, int)" path="/remarks"/>
         /// </remarks>
@@ -2864,12 +2883,19 @@ namespace GTA
         /// <param name="ikPart">The IK Part to set.</param>
         /// <param name="target">The world position/coordinates to target.</param>
         /// <param name="flags">The flags.</param>
-        /// <param name="blendInTimeMS">The blend in time in milliseconds.</param>
-        /// <param name="blendOutTimeMS">The blend out time in milliseconds.</param>
+        /// <param name="blendInTimeMS">
+        /// The blend in time in milliseconds.
+        /// Set to -1 for default blend in time. Set to 0 for instant blend in time.
+        /// </param>
+        /// <param name="blendOutTimeMS">
+        /// The blend out time in milliseconds.
+        /// Set to -1 for default blend out time. Set to 0 for instant blend out time.
+        /// </param>
         /// <remarks>
         /// <inheritdoc cref="SetIKTarget(IKPart, PedBone, Vector3, IKTargetFlags, int, int)" path="/remarks"/>
         /// </remarks>
-        public void SetIKTarget(IKPart ikPart, Vector3 target, IKTargetFlags flags, int blendInTimeMS = -1, int blendOutTimeMS = -1)
+        public void SetIKTarget(IKPart ikPart, Vector3 target, IKTargetFlags flags, int blendInTimeMS = -1,
+            int blendOutTimeMS = -1)
         {
             Function.Call(Hash.SET_IK_TARGET, (int)ikPart, 0, -1, target.X, target.Y, target.Z, (int)flags,
                 blendInTimeMS, blendOutTimeMS);

--- a/source/scripting_v3/GTA/Entities/Peds/Ped.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Ped.cs
@@ -2782,6 +2782,101 @@ namespace GTA
 
         #endregion
 
+        #region IK
+
+        /// <summary>
+        /// Sets the IK target for a given IK part belonging to this <see cref="Ped"/>.
+        /// </summary>
+        /// <param name="ikPart">The IK Part to set.</param>
+        /// <param name="targetBone">The target <see cref="EntityBone"/>.</param>
+        /// <param name="targetOffset">The target offset relative to the bone.</param>
+        /// <param name="flags">The flags.</param>
+        /// <param name="blendInTimeMS">The blend in time in milliseconds.</param>
+        /// <param name="blendOutTimeMS">The blend out time in milliseconds.</param>
+        /// <remarks>
+        /// The IK target will only be valid for one update, so it needs to be set for as long as it is needed (to
+        /// avoid IK targets not being cleared and getting stuck enabled).
+        /// </remarks>
+        public void SetIKTarget(IKPart ikPart, PedBone targetBone, Vector3 targetOffset, IKTargetFlags flags,
+            int blendInTimeMS = -1, int blendOutTimeMS = -1)
+        {
+            Function.Call(Hash.SET_IK_TARGET, (int)ikPart, targetBone.Owner, targetBone.Tag, targetOffset.X,
+                targetOffset.Y, targetOffset.Z, (int)flags, blendInTimeMS, blendOutTimeMS);
+        }
+
+        // This overload is intentionally separated to reduce issues with ped bones if some game update breaks our bone
+        // memory stuff and thus we struggle to find a new solution. We have to use our memory stuff when we want to
+        // find a bone tag by a sequential index.
+        /// <summary>
+        /// <inheritdoc cref="SetIKTarget(IKPart, PedBone, Vector3, IKTargetFlags, int, int)" path="/summary"/>
+        /// </summary>
+        /// <param name="ikPart">The IK Part to set.</param>
+        /// <param name="targetBone">The target <see cref="EntityBone"/>.</param>
+        /// <param name="targetOffset">The target offset relative to the bone.</param>
+        /// <param name="flags">The flags.</param>
+        /// <param name="blendInTimeMS">The blend in time in milliseconds.</param>
+        /// <param name="blendOutTimeMS">The blend out time in milliseconds.</param>
+        /// <remarks>
+        /// <inheritdoc cref="SetIKTarget(IKPart, PedBone, Vector3, IKTargetFlags, int, int)" path="/remarks"/>
+        /// </remarks>
+        public void SetIKTarget(IKPart ikPart, EntityBone targetBone, Vector3 targetOffset, IKTargetFlags flags,
+            int blendInTimeMS = -1, int blendOutTimeMS = -1)
+        {
+            Function.Call(Hash.SET_IK_TARGET, (int)ikPart, targetBone.Owner, targetBone.Tag, targetOffset.X,
+                targetOffset.Y, targetOffset.Z, (int)flags, blendInTimeMS, blendOutTimeMS);
+        }
+
+        // This overload is provided to let users specify without using our `EntityBone` stuff when they know the bone
+        // tag to specify as the target bone. `finale_heist2A.sc` and `finale_heist2B.sc` call the native with target
+        // objects whose model is either `prop_large_gold` or `prop_large_gold_alt_a`, and hard coded bone tags
+        // (the grip left and grip right bones, whose bone tag values are 14991 and 50415 respectively).
+        /// <summary>
+        /// <inheritdoc cref="SetIKTarget(IKPart, PedBone, Vector3, IKTargetFlags, int, int)" path="/summary"/>
+        /// </summary>
+        /// <param name="ikPart">The IK Part to set.</param>
+        /// <param name="targetEntity">The target <see cref="Entity"/>.</param>
+        /// <param name="boneTag">
+        /// The target bone tag (an identifier, not a sequential index).
+        /// Set to -1 for no target bone.
+        /// </param>
+        /// <param name="targetOffset">
+        /// If target entity is <see langword="null"/>, this is assumed to be world coordinates.
+        /// If target entity is not <see langword="null"/>, this is an offset from the target entity.
+        /// If target entity is not <see langword="null"/> and <paramref name="boneTag"/> is not -1, this is an offset
+        /// relative to the bone.
+        /// </param>
+        /// <param name="flags">The flags.</param>
+        /// <param name="blendInTimeMS">The blend in time in milliseconds.</param>
+        /// <param name="blendOutTimeMS">The blend out time in milliseconds.</param>
+        /// <remarks>
+        /// <inheritdoc cref="SetIKTarget(IKPart, PedBone, Vector3, IKTargetFlags, int, int)" path="/remarks"/>
+        /// </remarks>
+        public void SetIKTarget(IKPart ikPart, Entity targetEntity, int boneTag, Vector3 targetOffset,
+            IKTargetFlags flags, int blendInTimeMS = -1, int blendOutTimeMS = -1)
+        {
+            Function.Call(Hash.SET_IK_TARGET, (int)ikPart, targetEntity, boneTag, targetOffset.X, targetOffset.Y,
+                targetOffset.Z, (int)flags, blendInTimeMS, blendOutTimeMS);
+        }
+
+        /// <summary>
+        /// <inheritdoc cref="SetIKTarget(IKPart, PedBone, Vector3, IKTargetFlags, int, int)" path="/summary"/>
+        /// </summary>
+        /// <param name="ikPart">The IK Part to set.</param>
+        /// <param name="target">The world position/coordinates to target.</param>
+        /// <param name="flags">The flags.</param>
+        /// <param name="blendInTimeMS">The blend in time in milliseconds.</param>
+        /// <param name="blendOutTimeMS">The blend out time in milliseconds.</param>
+        /// <remarks>
+        /// <inheritdoc cref="SetIKTarget(IKPart, PedBone, Vector3, IKTargetFlags, int, int)" path="/remarks"/>
+        /// </remarks>
+        public void SetIKTarget(IKPart ikPart, Vector3 target, IKTargetFlags flags, int blendInTimeMS = -1, int blendOutTimeMS = -1)
+        {
+            Function.Call(Hash.SET_IK_TARGET, (int)ikPart, 0, -1, target.X, target.Y, target.Z, (int)flags,
+                blendInTimeMS, blendOutTimeMS);
+        }
+
+        #endregion
+
         public static PedHash[] GetAllModels()
         {
             return SHVDN.NativeMemory.PedModels.Select(x => (PedHash)x).ToArray();


### PR DESCRIPTION
## Summary
Adds `Ped.SetIKTarget` with typed IK part enum and sufficient info to figure out how the IK target flag parameter works.

fingaweg not having reviewed PRs in the GTAV native DB increased priority to publish this PR a lot, as well as the DB not having sufficient info to completely understand what the native expects as the params. While he merged 2 PRs in RDR3 one in this 1 year. We could build docs in SHVDN for some methods or properties that use natives that aren't fully documented in that native DB.