### PR TITLE
feat(api-v3): move network methods

### DIFF
--- a/source/scripting_v3/GTA/Entities/Peds/Ped.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Ped.cs
@@ -23,6 +23,8 @@ namespace GTA
         PedConfigFlags _pedConfigFlags;
         PedResetFlags _pedResetFlags;
 
+        PedMoveNetworkTaskInterface _moveNetworkInterface;
+
         internal static readonly string[] _speechModifierNames = {
             "SPEECH_PARAMS_STANDARD",
             "SPEECH_PARAMS_ALLOW_REPEAT",
@@ -2784,6 +2786,9 @@ namespace GTA
         /// </summary>
         public void ResetWeaponMovementClipSet()
             => Function.Call(Hash.RESET_PED_WEAPON_MOVEMENT_CLIPSET, Handle);
+
+        public PedMoveNetworkTaskInterface MoveNetworkTaskInterface
+            => _moveNetworkInterface ?? (_moveNetworkInterface = new PedMoveNetworkTaskInterface(this));
 
         #endregion
 

--- a/source/scripting_v3/GTA/Entities/Peds/Task/MoveNetworkFlags.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Task/MoveNetworkFlags.cs
@@ -1,0 +1,27 @@
+//
+// Copyright (C) 2024 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+using System;
+
+namespace GTA
+{
+    /// <summary>
+    /// Set of flags which may be passed in.
+    /// </summary>
+    [Flags]
+    public enum MoveNetworkFlags
+    {
+        Default = 0,
+        UseKinematicPhysics = 4,
+        /// <remarks>
+        /// With this flag set, the move network task methods in <see cref="TaskInvoker"/> cannot be used as a part of
+        /// a <see cref="TaskSequence"/>.
+        /// </remarks>
+        Secondary = 8,
+        UseFirstPersonArmIkLeft = 16,
+        UseFirstPersonArmIkRight = 32,
+        EnableCollisionOnNetworkCloneWhenFixed = 64
+    }
+}

--- a/source/scripting_v3/GTA/Entities/Peds/Task/PedMoveNetworkTaskInterface.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Task/PedMoveNetworkTaskInterface.cs
@@ -7,6 +7,10 @@ using GTA.Native;
 
 namespace GTA
 {
+    /// <summary>
+    /// Represents a move network task interface/facade class.
+    /// </summary>
+    // There is no classes that has the substring "Facade" as a part of class names in the game's codebase.
     public sealed class PedMoveNetworkTaskInterface
     {
         internal PedMoveNetworkTaskInterface(Ped p)

--- a/source/scripting_v3/GTA/Entities/Peds/Task/PedMoveNetworkTaskInterface.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Task/PedMoveNetworkTaskInterface.cs
@@ -15,32 +15,62 @@ namespace GTA
         }
 
         /// <summary>
-        /// Gets the <see cref="Ped"/>.
+        /// Gets the <see cref="GTA.Ped"/>.
         /// </summary>
         private Ped Ped
         {
             get;
         }
 
+        /// <summary>
+        /// Returns <see langword="true"/> if a move network is active.
+        /// </summary>
+        /// <value>
+        /// <see langword="true"/> if the <see cref="GTA.Ped"/> is processing a move network task
+        /// (`<c>CTaskMoVEScripted</c>`) and a move network is active in the found task; otherwise,
+        /// <see langword="false"/>.
+        /// </value>
+        /// <remarks>
+        /// The property searches for a `<c>CTaskMoVEScripted</c>` by searching primary tasks first, then secondary
+        /// tasks. The property returns <see langword="false"/> when `<c>CTaskMoVEScripted</c>`s are found among
+        /// both primary and secondary tasks and the found a move network is not active in
+        /// the found `<c>CTaskMoVEScripted</c>` of primary tasks.
+        /// </remarks>
         public bool IsTaskActive => Function.Call<bool>(Hash.IS_TASK_MOVE_NETWORK_ACTIVE, Ped);
 
+        /// <summary>
+        /// Returns <see langword="true"/> if a move network is ready for a state transition
+        /// </summary>
         public bool IsReadyForTransition => Function.Call<bool>(Hash.IS_TASK_MOVE_NETWORK_READY_FOR_TRANSITION, Ped);
 
+
+        /// <summary>
+        /// Returns <see langword="true"/> if a move network is ready for a state transition.
+        /// </summary>
         public bool RequestStateTransition(string stateName)
             => Function.Call<bool>(Hash.REQUEST_TASK_MOVE_NETWORK_STATE_TRANSITION, Ped, stateName);
 
-        /// <value>
-        /// The current script name if if a `<c>CTaskMoVEScripted</c>` is running on the <see cref="Ped"/> and
-        /// the network is active on the task; otherwise, the string `<c>Unknown</c>`.
-        /// </value>
+        /// <summary>
+        /// Returns the current state.
+        /// </summary>
+        /// <remarks>
+        /// Returns "<c>Unknown</c>" when <see cref="IsTaskActive"/> returns <see langword="false"/>.
+        /// </remarks>
         public string CurrentScriptStateName
             => Function.Call<string>(Hash.GET_TASK_MOVE_NETWORK_STATE, Ped);
 
         /// <summary>
         /// <para>
+        /// Sets a clip set for this move network to use.
+        /// </para>
+        /// <para>
         /// Only available in the game version v1.0.1493.0 and later.
         /// </para>
         /// </summary>
+        /// <param name="clipSet">The hash of the name of the actual clip set to use.</param>
+        /// <param name="varClipSet">
+        /// The hash of the name of the variable clip set you are setting.
+        /// </param>
         public void SetNetworkClipSet(AtHashValue clipSet, AtHashValue varClipSet)
         {
             GameVersionNotSupportedException.ThrowIfNotSupported(GameVersion.v1_0_1493_0_Steam,
@@ -49,16 +79,39 @@ namespace GTA
             Function.Call(Hash.SET_TASK_MOVE_NETWORK_ANIM_SET, Ped, clipSet, varClipSet);
         }
 
+        /// <summary>
+        /// Sets a <see cref="float"/> MoVE signal to the passed value.
+        /// </summary>
         public void SetSignalFloat(string signalName, float signal)
         {
             Function.Call(Hash.SET_TASK_MOVE_NETWORK_SIGNAL_FLOAT, Ped, signalName, signal);
         }
 
+        /*
+         *  We omit `SET_TASK_MOVE_NETWORK_SIGNAL_LOCAL_FLOAT` because there's nothing different from
+         *  `SET_TASK_MOVE_NETWORK_SIGNAL_FLOAT` when `NetworkInterface::IsGameInProgress()` returns false (meaning
+         *  the game is not online), or if the ped is not a network clone or the passed "allowOverrideCloneUpdate"
+         *  is set to false.
+         */
+
         /// <summary>
+        /// <para>
+        /// Sets the lerp rate to the passed value.
+        /// </para>
         /// <para>
         /// Only available in the game version v1.0.1493.0 and later.
         /// </para>
         /// </summary>
+        /// <remarks>
+        /// Lerp rate controls rate at which the corresponding MoVE float signal will lerp over frame updates on
+        /// the clone from the current value to the target value.
+        /// It is assumed that the corresponding MoVE float signal has already been created using
+        /// <see cref="SetSignalFloat"/>.
+        /// Currently the lerp rate defaults to a value of `<c>0.5f</c>`. The lerp value has to be above `<c>0.0f</c>`
+        /// and below `<c>1.0f</c>`.
+        /// If a lerp rate of `<c>1.0f</c>` is applied then no lerping is used and the exact float value will be
+        /// synced and applied immediately on the clone.
+        /// </remarks>
         public void SetSignalFloatLerpRate(string signalName, float lerpRate)
         {
             GameVersionNotSupportedException.ThrowIfNotSupported(GameVersion.v1_0_1493_0_Steam,
@@ -67,12 +120,18 @@ namespace GTA
             Function.Call(Hash.SET_TASK_MOVE_NETWORK_SIGNAL_FLOAT_LERP_RATE, Ped, signalName, lerpRate);
         }
 
+        /// <summary>
+        /// Sets a <see cref="bool"/> MoVE signal to the passed value.
+        /// </summary>
         public void SetSignalBool(string signalName, bool signal)
         {
             Function.Call(Hash.SET_TASK_MOVE_NETWORK_SIGNAL_BOOL, Ped, signalName, signal);
         }
 
         /// <summary>
+        /// <para>
+        /// Gets the value of a <see cref="float"/> type output parameter from the peds scripted MoVE network.
+        /// </para>
         /// <para>
         /// Only available in the game version v1.0.1493.0 and later.
         /// </para>
@@ -85,9 +144,16 @@ namespace GTA
             return Function.Call<float>(Hash.GET_TASK_MOVE_NETWORK_SIGNAL_FLOAT, Ped, signalName);
         }
 
+        /// <summary>
+        /// Gets the value of a <see cref="bool"/> type output parameter from the peds scripted MoVE network.
+        /// </summary>
         public bool GetSignalBool(string signalName)
             => Function.Call<bool>(Hash.GET_TASK_MOVE_NETWORK_SIGNAL_BOOL, Ped, signalName);
 
+        /// <summary>
+        /// Returns <see langword="true"/> if an event with the given name has just fired on
+        /// the <see cref="GTA.Ped"/>'s script owned MoVE network.
+        /// </summary>
         public bool GetEvent(string eventName)
             => Function.Call<bool>(Hash.GET_TASK_MOVE_NETWORK_EVENT, Ped, eventName);
     }

--- a/source/scripting_v3/GTA/Entities/Peds/Task/PedMoveNetworkTaskInterface.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Task/PedMoveNetworkTaskInterface.cs
@@ -71,7 +71,7 @@ namespace GTA
         /// <param name="varClipSet">
         /// The hash of the name of the variable clip set you are setting.
         /// </param>
-        public void SetNetworkClipSet(AtHashValue clipSet, AtHashValue varClipSet)
+        public void SetNetworkClipSet(AtHashValue clipSet, AtHashValue varClipSet = default)
         {
             GameVersionNotSupportedException.ThrowIfNotSupported(GameVersion.v1_0_1493_0_Steam,
                 nameof(PedMoveNetworkTaskInterface), nameof(SetNetworkClipSet));

--- a/source/scripting_v3/GTA/Entities/Peds/Task/PedMoveNetworkTaskInterface.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Task/PedMoveNetworkTaskInterface.cs
@@ -1,0 +1,94 @@
+//
+// Copyright (C) 2024 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+using GTA.Native;
+
+namespace GTA
+{
+    public sealed class PedMoveNetworkTaskInterface
+    {
+        internal PedMoveNetworkTaskInterface(Ped p)
+        {
+            Ped = p;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="Ped"/>.
+        /// </summary>
+        private Ped Ped
+        {
+            get;
+        }
+
+        public bool IsTaskActive => Function.Call<bool>(Hash.IS_TASK_MOVE_NETWORK_ACTIVE, Ped);
+
+        public bool IsReadyForTransition => Function.Call<bool>(Hash.IS_TASK_MOVE_NETWORK_READY_FOR_TRANSITION, Ped);
+
+        public bool RequestStateTransition(string stateName)
+            => Function.Call<bool>(Hash.REQUEST_TASK_MOVE_NETWORK_STATE_TRANSITION, Ped, stateName);
+
+        /// <value>
+        /// The current script name if if a `<c>CTaskMoVEScripted</c>` is running on the <see cref="Ped"/> and
+        /// the network is active on the task; otherwise, the string `<c>Unknown</c>`.
+        /// </value>
+        public string CurrentScriptStateName
+            => Function.Call<string>(Hash.GET_TASK_MOVE_NETWORK_STATE, Ped);
+
+        /// <summary>
+        /// <para>
+        /// Only available in the game version v1.0.1493.0 and later.
+        /// </para>
+        /// </summary>
+        public void SetNetworkClipSet(AtHashValue clipSet, AtHashValue varClipSet)
+        {
+            GameVersionNotSupportedException.ThrowIfNotSupported(GameVersion.v1_0_1493_0_Steam,
+                nameof(PedMoveNetworkTaskInterface), nameof(SetNetworkClipSet));
+
+            Function.Call(Hash.SET_TASK_MOVE_NETWORK_ANIM_SET, Ped, clipSet, varClipSet);
+        }
+
+        public void SetSignalFloat(string signalName, float signal)
+        {
+            Function.Call(Hash.SET_TASK_MOVE_NETWORK_SIGNAL_FLOAT, Ped, signalName, signal);
+        }
+
+        /// <summary>
+        /// <para>
+        /// Only available in the game version v1.0.1493.0 and later.
+        /// </para>
+        /// </summary>
+        public void SetSignalFloatLerpRate(string signalName, float lerpRate)
+        {
+            GameVersionNotSupportedException.ThrowIfNotSupported(GameVersion.v1_0_1493_0_Steam,
+                nameof(PedMoveNetworkTaskInterface), nameof(SetSignalFloatLerpRate));
+
+            Function.Call(Hash.SET_TASK_MOVE_NETWORK_SIGNAL_FLOAT_LERP_RATE, Ped, signalName, lerpRate);
+        }
+
+        public void SetSignalBool(string signalName, bool signal)
+        {
+            Function.Call(Hash.SET_TASK_MOVE_NETWORK_SIGNAL_BOOL, Ped, signalName, signal);
+        }
+
+        /// <summary>
+        /// <para>
+        /// Only available in the game version v1.0.1493.0 and later.
+        /// </para>
+        /// </summary>
+        public float GetSignalFloat(string signalName)
+        {
+            GameVersionNotSupportedException.ThrowIfNotSupported(GameVersion.v1_0_1493_0_Steam,
+                nameof(PedMoveNetworkTaskInterface), nameof(GetSignalFloat));
+
+            return Function.Call<float>(Hash.GET_TASK_MOVE_NETWORK_SIGNAL_FLOAT, Ped, signalName);
+        }
+
+        public bool GetSignalBool(string signalName)
+            => Function.Call<bool>(Hash.GET_TASK_MOVE_NETWORK_SIGNAL_BOOL, Ped, signalName);
+
+        public bool GetEvent(string eventName)
+            => Function.Call<bool>(Hash.GET_TASK_MOVE_NETWORK_EVENT, Ped, eventName);
+    }
+}

--- a/source/scripting_v3/GTA/Entities/Peds/Task/TaskInvoker.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Task/TaskInvoker.cs
@@ -862,6 +862,123 @@ namespace GTA
                 blendIn, blendOut, (int)flags, (int)ragdollFlags, moverBlendInArg, (int)ikFlags);
         }
 
+        /// <summary>
+        /// Tasks the <see cref="Ped"/> to start a move network with the passed network name.
+        /// </summary>
+        /// <param name="networkName">
+        /// The move network name. This should match some mrf file name without the extension `<c>.mrf</c>`.
+        /// </param>
+        /// <param name="blendDuration">The blend duration in seconds.</param>
+        /// <param name="flags">The move network flags.</param>
+        public void StartMoveNetworkByName(string networkName, float blendDuration = 0f,
+            MoveNetworkFlags flags = MoveNetworkFlags.Default)
+        {
+            // There must be a network clone before `allowOverrideCloneUpdate` param can have actual effect, but we
+            // don't know how to create one without the game being online/networked.
+            const bool allowOverrideCloneUpdate = false;
+            // The clip dict string *may* have actual effect if we're missing something with `CTaskMoVEScripted`...
+            const string clipDictStr = null;
+
+            Function.Call(Hash.TASK_MOVE_NETWORK_BY_NAME_WITH_INIT_PARAMS, _ped.Handle, networkName,
+                blendDuration, allowOverrideCloneUpdate, clipDictStr, (int)flags);
+        }
+
+        /// <summary>
+        /// Tasks the <see cref="Ped"/> to start a move network with the passed network and with custom start pos and
+        /// orientation.
+        /// </summary>
+        /// <param name="networkName">
+        /// The move network name. This should match some mrf file name without the extension `<c>.mrf</c>`.
+        /// </param>
+        /// <param name="pos">The start position.</param>
+        /// <param name="rot">The start rotation.</param>
+        /// <param name="rotOrder">The rotation order in world space.</param>
+        /// <param name="blendDuration">The blend duration in seconds.</param>
+        /// <param name="flags">The move network flags.</param>
+        public void StartMoveNetworkAdvancedByName(string networkName, Vector3 pos, Vector3 rot,
+            EulerRotationOrder rotOrder, float blendDuration = 0f, MoveNetworkFlags flags = MoveNetworkFlags.Default)
+        {
+            const bool allowOverrideCloneUpdate = false;
+            const string clipDictStr = null;
+
+            Function.Call(Hash.TASK_MOVE_NETWORK_ADVANCED_BY_NAME, _ped.Handle, networkName, pos.X, pos.Y, pos.Z,
+                rot.X, rot.Y, rot.Z, (int)rotOrder, blendDuration, allowOverrideCloneUpdate, clipDictStr, (int)flags);
+        }
+
+        /// <summary>
+        /// <para>
+        /// Tasks the <see cref="Ped"/> to start a move network with the passed network name.
+        /// </para>
+        /// <para>
+        /// Only available in the game version v1.0.1493.0 and later.
+        /// </para>
+        /// </summary>
+        /// <param name="networkName">
+        /// The move network name. This should match some mrf file name without the extension `<c>.mrf</c>`.
+        /// </param>
+        /// <param name="initParams">The initial parameters.</param>
+        /// <param name="blendDuration">The blend duration in seconds.</param>
+        /// <param name="flags">The move network flags.</param>
+        public void StartMoveNetworkByNameWithInitParams(string networkName,
+            TaskMoVEScriptedInitialParameters initParams, float blendDuration = 0f,
+            MoveNetworkFlags flags = MoveNetworkFlags.Default)
+        {
+            GameVersionNotSupportedException.ThrowIfNotSupported(GameVersion.v1_0_1493_0_Steam, nameof(TaskInvoker),
+                nameof(StartMoveNetworkByNameWithInitParams));
+
+            unsafe
+            {
+                using (TaskMoVEScriptedInitialParametersStruct paramStruct = initParams.BuildStructForNatives())
+                {
+                    const bool allowOverrideCloneUpdate = false;
+                    const string clipDictStr = null;
+
+                    Function.Call(Hash.TASK_MOVE_NETWORK_BY_NAME_WITH_INIT_PARAMS, _ped.Handle, networkName,
+                        &paramStruct, blendDuration, allowOverrideCloneUpdate, clipDictStr, (int)flags);
+                }
+            }
+        }
+
+        /// <summary>
+        /// <para>
+        /// Tasks the <see cref="Ped"/> to start a move network with the passed network and with custom start pos and
+        /// orientation.
+        /// </para>
+        /// <para>
+        /// Only available in the game version v1.0.1868.0 and later.
+        /// </para>
+        /// </summary>
+        /// <param name="networkName">
+        /// The move network name. This should match some mrf file name without the extension `<c>.mrf</c>`.
+        /// </param>
+        /// <param name="initParams">The initial parameters.</param>
+        /// <param name="pos">The start position.</param>
+        /// <param name="rot">The start rotation.</param>
+        /// <param name="rotOrder">The rotation order in world space.</param>
+        /// <param name="blendDuration">The blend duration in seconds.</param>
+        /// <param name="flags">The move network flags.</param>
+        public void StartMoveNetworkByNameAdvancedWithInitParams(string networkName,
+            TaskMoVEScriptedInitialParameters initParams, Vector3 pos, Vector3 rot,
+            EulerRotationOrder rotOrder, float blendDuration = 0f,
+            MoveNetworkFlags flags = MoveNetworkFlags.Default)
+        {
+            GameVersionNotSupportedException.ThrowIfNotSupported(GameVersion.v1_0_1868_0_Steam, nameof(TaskInvoker),
+                nameof(StartMoveNetworkByNameWithInitParams));
+
+            unsafe
+            {
+                using (TaskMoVEScriptedInitialParametersStruct paramStruct = initParams.BuildStructForNatives())
+                {
+                    const bool allowOverrideCloneUpdate = false;
+                    const string clipDictStr = null;
+
+                    Function.Call(Hash.TASK_MOVE_NETWORK_ADVANCED_BY_NAME_WITH_INIT_PARAMS, _ped.Handle, networkName,
+                        &paramStruct, pos.X, pos.Y, pos.Z, rot.X, rot.Y, rot.Z, (int)rotOrder, blendDuration,
+                        allowOverrideCloneUpdate, clipDictStr, (int)flags);
+                }
+            }
+        }
+
         public void RappelFromHelicopter()
         {
             Function.Call(Hash.TASK_RAPPEL_FROM_HELI, _ped.Handle, 0x41200000);

--- a/source/scripting_v3/GTA/Entities/Peds/Task/TaskInvoker.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Task/TaskInvoker.cs
@@ -866,16 +866,16 @@ namespace GTA
         /// Tasks the <see cref="Ped"/> to start a move network with the passed network name.
         /// </summary>
         /// <param name="networkName">
-        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/param[@name='networkName']"/>
+        /// <inheritdoc cref="StartMoveNetworkAdvancedByNameWithInitParams" path="/param[@name='networkName']"/>
         /// </param>
         /// <param name="blendDuration">
-        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/param[@name='blendDuration']"/>
+        /// <inheritdoc cref="StartMoveNetworkAdvancedByNameWithInitParams" path="/param[@name='blendDuration']"/>
         /// </param>
         /// <param name="flags">
-        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/param[@name='flags']"/>
+        /// <inheritdoc cref="StartMoveNetworkAdvancedByNameWithInitParams" path="/param[@name='flags']"/>
         /// </param>
         /// <remarks>
-        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/remarks"/>
+        /// <inheritdoc cref="StartMoveNetworkAdvancedByNameWithInitParams" path="/remarks"/>
         /// </remarks>
         public void StartMoveNetworkByName(string networkName, float blendDuration = 0f,
             MoveNetworkFlags flags = MoveNetworkFlags.Default)
@@ -897,25 +897,25 @@ namespace GTA
         /// and orientation.
         /// </summary>
         /// <param name="networkName">
-        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/param[@name='networkName']"/>
+        /// <inheritdoc cref="StartMoveNetworkAdvancedByNameWithInitParams" path="/param[@name='networkName']"/>
         /// </param>
         /// <param name="pos">
-        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/param[@name='pos']"/>
+        /// <inheritdoc cref="StartMoveNetworkAdvancedByNameWithInitParams" path="/param[@name='pos']"/>
         /// </param>
         /// <param name="rot">
-        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/param[@name='rot']"/>
+        /// <inheritdoc cref="StartMoveNetworkAdvancedByNameWithInitParams" path="/param[@name='rot']"/>
         /// </param>
         /// <param name="rotOrder">
-        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/param[@name='rotOrder']"/>
+        /// <inheritdoc cref="StartMoveNetworkAdvancedByNameWithInitParams" path="/param[@name='rotOrder']"/>
         /// </param>
         /// <param name="blendDuration">
-        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/param[@name='blendDuration']"/>
+        /// <inheritdoc cref="StartMoveNetworkAdvancedByNameWithInitParams" path="/param[@name='blendDuration']"/>
         /// </param>
         /// <param name="flags">
-        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/param[@name='flags']"/>
+        /// <inheritdoc cref="StartMoveNetworkAdvancedByNameWithInitParams" path="/param[@name='flags']"/>
         /// </param>
         /// <remarks>
-        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/remarks"/>
+        /// <inheritdoc cref="StartMoveNetworkAdvancedByNameWithInitParams" path="/remarks"/>
         /// </remarks>
         public void StartMoveNetworkAdvancedByName(string networkName, Vector3 pos, Vector3 rot,
             EulerRotationOrder rotOrder = EulerRotationOrder.YXZ, float blendDuration = 0f,
@@ -938,19 +938,19 @@ namespace GTA
         /// </para>
         /// </summary>
         /// <param name="networkName">
-        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/param[@name='networkName']"/>
+        /// <inheritdoc cref="StartMoveNetworkAdvancedByNameWithInitParams" path="/param[@name='networkName']"/>
         /// </param>
         /// <param name="initParams">
-        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/param[@name='initParams']"/>
+        /// <inheritdoc cref="StartMoveNetworkAdvancedByNameWithInitParams" path="/param[@name='initParams']"/>
         /// </param>
         /// <param name="blendDuration">
-        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/param[@name='blendDuration']"/>
+        /// <inheritdoc cref="StartMoveNetworkAdvancedByNameWithInitParams" path="/param[@name='blendDuration']"/>
         /// </param>
         /// <param name="flags">
-        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/param[@name='flags']"/>
+        /// <inheritdoc cref="StartMoveNetworkAdvancedByNameWithInitParams" path="/param[@name='flags']"/>
         /// </param>
         /// <remarks>
-        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/remarks"/>
+        /// <inheritdoc cref="StartMoveNetworkAdvancedByNameWithInitParams" path="/remarks"/>
         /// </remarks>
         public void StartMoveNetworkByNameWithInitParams(string networkName,
             TaskMoVEScriptedInitialParameters initParams, float blendDuration = 0f,
@@ -998,13 +998,13 @@ namespace GTA
         /// set signal parameters to the task using <see cref="PedMoveNetworkTaskInterface"/> in some states
         /// before the <see cref="Ped"/> can perform the animations defined in the state structure.
         /// </remarks>
-        public void StartMoveNetworkByNameAdvancedWithInitParams(string networkName,
+        public void StartMoveNetworkAdvancedByNameWithInitParams(string networkName,
             TaskMoVEScriptedInitialParameters initParams, Vector3 pos, Vector3 rot,
             EulerRotationOrder rotOrder = EulerRotationOrder.YXZ, float blendDuration = 0f,
             MoveNetworkFlags flags = MoveNetworkFlags.Default)
         {
             GameVersionNotSupportedException.ThrowIfNotSupported(GameVersion.v1_0_1868_0_Steam, nameof(TaskInvoker),
-                nameof(StartMoveNetworkByNameWithInitParams));
+                nameof(StartMoveNetworkAdvancedByNameWithInitParams));
 
             unsafe
             {

--- a/source/scripting_v3/GTA/Entities/Peds/Task/TaskInvoker.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Task/TaskInvoker.cs
@@ -896,7 +896,8 @@ namespace GTA
         /// <param name="blendDuration">The blend duration in seconds.</param>
         /// <param name="flags">The move network flags.</param>
         public void StartMoveNetworkAdvancedByName(string networkName, Vector3 pos, Vector3 rot,
-            EulerRotationOrder rotOrder, float blendDuration = 0f, MoveNetworkFlags flags = MoveNetworkFlags.Default)
+            EulerRotationOrder rotOrder = EulerRotationOrder.YXZ, float blendDuration = 0f,
+            MoveNetworkFlags flags = MoveNetworkFlags.Default)
         {
             const bool allowOverrideCloneUpdate = false;
             const string clipDictStr = null;
@@ -959,7 +960,7 @@ namespace GTA
         /// <param name="flags">The move network flags.</param>
         public void StartMoveNetworkByNameAdvancedWithInitParams(string networkName,
             TaskMoVEScriptedInitialParameters initParams, Vector3 pos, Vector3 rot,
-            EulerRotationOrder rotOrder, float blendDuration = 0f,
+            EulerRotationOrder rotOrder = EulerRotationOrder.YXZ, float blendDuration = 0f,
             MoveNetworkFlags flags = MoveNetworkFlags.Default)
         {
             GameVersionNotSupportedException.ThrowIfNotSupported(GameVersion.v1_0_1868_0_Steam, nameof(TaskInvoker),

--- a/source/scripting_v3/GTA/Entities/Peds/Task/TaskInvoker.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Task/TaskInvoker.cs
@@ -877,7 +877,7 @@ namespace GTA
         /// <remarks>
         /// <inheritdoc cref="StartMoveNetworkAdvancedByNameWithInitParams" path="/remarks"/>
         /// </remarks>
-        public void StartMoveNetworkByName(string networkName, float blendDuration = 0f,
+        public void StartMoveNetworkByName(string networkName, AnimationBlendDuration? blendDuration = null,
             MoveNetworkFlags flags = MoveNetworkFlags.Default)
         {
             // There must be a network clone before the 2 params below can have actual effect, but we
@@ -888,8 +888,10 @@ namespace GTA
             // have peds properly perform the animations.
             const string clipDictStr = null;
 
+            AnimationBlendDuration durationArg = blendDuration ?? AnimationBlendDuration.Instant;
+
             Function.Call(Hash.TASK_MOVE_NETWORK_BY_NAME_WITH_INIT_PARAMS, _ped.Handle, networkName,
-                blendDuration, allowOverrideCloneUpdate, clipDictStr, (int)flags);
+                durationArg, allowOverrideCloneUpdate, clipDictStr, (int)flags);
         }
 
         /// <summary>
@@ -918,14 +920,16 @@ namespace GTA
         /// <inheritdoc cref="StartMoveNetworkAdvancedByNameWithInitParams" path="/remarks"/>
         /// </remarks>
         public void StartMoveNetworkAdvancedByName(string networkName, Vector3 pos, Vector3 rot,
-            EulerRotationOrder rotOrder = EulerRotationOrder.YXZ, float blendDuration = 0f,
+            EulerRotationOrder rotOrder = EulerRotationOrder.YXZ, AnimationBlendDuration? blendDuration = null,
             MoveNetworkFlags flags = MoveNetworkFlags.Default)
         {
             const bool allowOverrideCloneUpdate = false;
             const string clipDictStr = null;
 
+            AnimationBlendDuration durationArg = blendDuration ?? AnimationBlendDuration.Instant;
+
             Function.Call(Hash.TASK_MOVE_NETWORK_ADVANCED_BY_NAME, _ped.Handle, networkName, pos.X, pos.Y, pos.Z,
-                rot.X, rot.Y, rot.Z, (int)rotOrder, blendDuration, allowOverrideCloneUpdate, clipDictStr, (int)flags);
+                rot.X, rot.Y, rot.Z, (int)rotOrder, durationArg, allowOverrideCloneUpdate, clipDictStr, (int)flags);
         }
 
         /// <summary>
@@ -953,7 +957,7 @@ namespace GTA
         /// <inheritdoc cref="StartMoveNetworkAdvancedByNameWithInitParams" path="/remarks"/>
         /// </remarks>
         public void StartMoveNetworkByNameWithInitParams(string networkName,
-            TaskMoVEScriptedInitialParameters initParams, float blendDuration = 0f,
+            TaskMoVEScriptedInitialParameters initParams, AnimationBlendDuration? blendDuration = null,
             MoveNetworkFlags flags = MoveNetworkFlags.Default)
         {
             GameVersionNotSupportedException.ThrowIfNotSupported(GameVersion.v1_0_1493_0_Steam, nameof(TaskInvoker),
@@ -966,8 +970,10 @@ namespace GTA
                     const bool allowOverrideCloneUpdate = false;
                     const string clipDictStr = null;
 
+                    AnimationBlendDuration durationArg = blendDuration ?? AnimationBlendDuration.Instant;
+
                     Function.Call(Hash.TASK_MOVE_NETWORK_BY_NAME_WITH_INIT_PARAMS, _ped.Handle, networkName,
-                        &paramStruct, blendDuration, allowOverrideCloneUpdate, clipDictStr, (int)flags);
+                        &paramStruct, durationArg, allowOverrideCloneUpdate, clipDictStr, (int)flags);
                 }
             }
         }
@@ -989,7 +995,10 @@ namespace GTA
         /// <param name="pos">The start position.</param>
         /// <param name="rot">The start rotation.</param>
         /// <param name="rotOrder">The rotation order in world space.</param>
-        /// <param name="blendDuration">The blend duration in seconds.</param>
+        /// <param name="blendDuration">
+        /// The blend duration in seconds. If set to <see langword="null"/>,
+        /// <see cref="AnimationBlendDuration.Instant"/> will be used.
+        /// </param>
         /// <param name="flags">The move network flags.</param>
         /// <remarks>
         /// You will need to request the <see cref="CrClipDictionary"/>s specified in the mrf file that
@@ -1000,7 +1009,7 @@ namespace GTA
         /// </remarks>
         public void StartMoveNetworkAdvancedByNameWithInitParams(string networkName,
             TaskMoVEScriptedInitialParameters initParams, Vector3 pos, Vector3 rot,
-            EulerRotationOrder rotOrder = EulerRotationOrder.YXZ, float blendDuration = 0f,
+            EulerRotationOrder rotOrder = EulerRotationOrder.YXZ, AnimationBlendDuration? blendDuration = null,
             MoveNetworkFlags flags = MoveNetworkFlags.Default)
         {
             GameVersionNotSupportedException.ThrowIfNotSupported(GameVersion.v1_0_1868_0_Steam, nameof(TaskInvoker),
@@ -1013,8 +1022,10 @@ namespace GTA
                     const bool allowOverrideCloneUpdate = false;
                     const string clipDictStr = null;
 
+                    AnimationBlendDuration durationArg = blendDuration ?? AnimationBlendDuration.Instant;
+
                     Function.Call(Hash.TASK_MOVE_NETWORK_ADVANCED_BY_NAME_WITH_INIT_PARAMS, _ped.Handle, networkName,
-                        &paramStruct, pos.X, pos.Y, pos.Z, rot.X, rot.Y, rot.Z, (int)rotOrder, blendDuration,
+                        &paramStruct, pos.X, pos.Y, pos.Z, rot.X, rot.Y, rot.Z, (int)rotOrder, durationArg,
                         allowOverrideCloneUpdate, clipDictStr, (int)flags);
                 }
             }

--- a/source/scripting_v3/GTA/Entities/Peds/Task/TaskInvoker.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Task/TaskInvoker.cs
@@ -866,17 +866,26 @@ namespace GTA
         /// Tasks the <see cref="Ped"/> to start a move network with the passed network name.
         /// </summary>
         /// <param name="networkName">
-        /// The move network name. This should match some mrf file name without the extension `<c>.mrf</c>`.
+        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/param[@name='networkName']"/>
         /// </param>
-        /// <param name="blendDuration">The blend duration in seconds.</param>
-        /// <param name="flags">The move network flags.</param>
+        /// <param name="blendDuration">
+        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/param[@name='blendDuration']"/>
+        /// </param>
+        /// <param name="flags">
+        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/param[@name='flags']"/>
+        /// </param>
+        /// <remarks>
+        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/remarks"/>
+        /// </remarks>
         public void StartMoveNetworkByName(string networkName, float blendDuration = 0f,
             MoveNetworkFlags flags = MoveNetworkFlags.Default)
         {
-            // There must be a network clone before `allowOverrideCloneUpdate` param can have actual effect, but we
+            // There must be a network clone before the 2 params below can have actual effect, but we
             // don't know how to create one without the game being online/networked.
             const bool allowOverrideCloneUpdate = false;
-            // The clip dict string *may* have actual effect if we're missing something with `CTaskMoVEScripted`...
+            // This param does not have any effect on peds who aren't network clones. You'll need to request
+            // the clip dicts specified in the mrf file (named what `networkName` says) on your own before you can
+            // have peds properly perform the animations.
             const string clipDictStr = null;
 
             Function.Call(Hash.TASK_MOVE_NETWORK_BY_NAME_WITH_INIT_PARAMS, _ped.Handle, networkName,
@@ -884,17 +893,30 @@ namespace GTA
         }
 
         /// <summary>
-        /// Tasks the <see cref="Ped"/> to start a move network with the passed network and with custom start pos and
-        /// orientation.
+        /// Tasks the <see cref="Ped"/> to start a move network with the passed network and with custom start position
+        /// and orientation.
         /// </summary>
         /// <param name="networkName">
-        /// The move network name. This should match some mrf file name without the extension `<c>.mrf</c>`.
+        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/param[@name='networkName']"/>
         /// </param>
-        /// <param name="pos">The start position.</param>
-        /// <param name="rot">The start rotation.</param>
-        /// <param name="rotOrder">The rotation order in world space.</param>
-        /// <param name="blendDuration">The blend duration in seconds.</param>
-        /// <param name="flags">The move network flags.</param>
+        /// <param name="pos">
+        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/param[@name='pos']"/>
+        /// </param>
+        /// <param name="rot">
+        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/param[@name='rot']"/>
+        /// </param>
+        /// <param name="rotOrder">
+        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/param[@name='rotOrder']"/>
+        /// </param>
+        /// <param name="blendDuration">
+        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/param[@name='blendDuration']"/>
+        /// </param>
+        /// <param name="flags">
+        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/param[@name='flags']"/>
+        /// </param>
+        /// <remarks>
+        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/remarks"/>
+        /// </remarks>
         public void StartMoveNetworkAdvancedByName(string networkName, Vector3 pos, Vector3 rot,
             EulerRotationOrder rotOrder = EulerRotationOrder.YXZ, float blendDuration = 0f,
             MoveNetworkFlags flags = MoveNetworkFlags.Default)
@@ -908,18 +930,28 @@ namespace GTA
 
         /// <summary>
         /// <para>
-        /// Tasks the <see cref="Ped"/> to start a move network with the passed network name.
+        /// Tasks the <see cref="Ped"/> to start a move network with the passed network name. This method allows
+        /// the network to be setup with initial parameters (clipsets, floats and bools).
         /// </para>
         /// <para>
         /// Only available in the game version v1.0.1493.0 and later.
         /// </para>
         /// </summary>
         /// <param name="networkName">
-        /// The move network name. This should match some mrf file name without the extension `<c>.mrf</c>`.
+        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/param[@name='networkName']"/>
         /// </param>
-        /// <param name="initParams">The initial parameters.</param>
-        /// <param name="blendDuration">The blend duration in seconds.</param>
-        /// <param name="flags">The move network flags.</param>
+        /// <param name="initParams">
+        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/param[@name='initParams']"/>
+        /// </param>
+        /// <param name="blendDuration">
+        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/param[@name='blendDuration']"/>
+        /// </param>
+        /// <param name="flags">
+        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/param[@name='flags']"/>
+        /// </param>
+        /// <remarks>
+        /// <inheritdoc cref="StartMoveNetworkByNameAdvancedWithInitParams" path="/remarks"/>
+        /// </remarks>
         public void StartMoveNetworkByNameWithInitParams(string networkName,
             TaskMoVEScriptedInitialParameters initParams, float blendDuration = 0f,
             MoveNetworkFlags flags = MoveNetworkFlags.Default)
@@ -942,8 +974,9 @@ namespace GTA
 
         /// <summary>
         /// <para>
-        /// Tasks the <see cref="Ped"/> to start a move network with the passed network and with custom start pos and
-        /// orientation.
+        /// Tasks the <see cref="Ped"/> to start a move network with the passed network and with custom start position
+        /// and orientation. This method allows the network to be setup with initial parameters (clipsets, floats
+        /// and bools).
         /// </para>
         /// <para>
         /// Only available in the game version v1.0.1868.0 and later.
@@ -958,6 +991,13 @@ namespace GTA
         /// <param name="rotOrder">The rotation order in world space.</param>
         /// <param name="blendDuration">The blend duration in seconds.</param>
         /// <param name="flags">The move network flags.</param>
+        /// <remarks>
+        /// You will need to request the <see cref="CrClipDictionary"/>s specified in the mrf file that
+        /// <paramref name="networkName"/> specifies on your own before you can have <see cref="Ped"/>s properly
+        /// perform the animations. You can use CodeWalker to inspect what mrf files define. You might also need to
+        /// set signal parameters to the task using <see cref="PedMoveNetworkTaskInterface"/> in some states
+        /// before the <see cref="Ped"/> can perform the animations defined in the state structure.
+        /// </remarks>
         public void StartMoveNetworkByNameAdvancedWithInitParams(string networkName,
             TaskMoVEScriptedInitialParameters initParams, Vector3 pos, Vector3 rot,
             EulerRotationOrder rotOrder = EulerRotationOrder.YXZ, float blendDuration = 0f,

--- a/source/scripting_v3/GTA/Entities/Peds/Task/TaskMoVEScriptedInitialParameters.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Task/TaskMoVEScriptedInitialParameters.cs
@@ -1,0 +1,303 @@
+//
+// Copyright (C) 2024 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+using GTA.Native;
+using System;
+using System.Runtime.InteropServices;
+
+namespace GTA
+{
+    public sealed class TaskMoVEScriptedInitialParameters
+    {
+        internal TaskMoVEScriptedInitialParameters(AtHashValue clipSet0, AtHashValue varclipSet0,
+            AtHashValue clipSet1, AtHashValue varclipSet1, string floatParamName0, float floatParamValue0,
+            float floatParamLerpValue0, string floatParamName1, float floatParamValue1, float floatParamLerpValue1,
+            string boolParamName0, bool boolParamValue0, string boolParamName1, bool boolParamValue1)
+        {
+            ClipSet0 = clipSet0;
+            VarClipSet0 = varclipSet0;
+            ClipSet1 = clipSet1;
+            VarClipSet1 = varclipSet1;
+
+            FloatParamName0 = floatParamName0;
+            FloatParamValue0 = floatParamValue0;
+            FloatParamLerpValue0 = floatParamLerpValue0;
+            FloatParamName1 = floatParamName1;
+            FloatParamValue1 = floatParamValue1;
+            FloatParamLerpValue1 = floatParamLerpValue1;
+
+            BoolParamName0 = boolParamName0;
+            BoolParamValue0 = boolParamValue0;
+            BoolParamName1 = boolParamName1;
+            BoolParamValue1 = boolParamValue1;
+        }
+
+        public AtHashValue ClipSet0 { get; }
+
+        public AtHashValue VarClipSet0 { get; }
+
+        public AtHashValue ClipSet1 { get; }
+
+        public AtHashValue VarClipSet1 { get; }
+
+        public string FloatParamName0 { get; }
+
+        public float FloatParamValue0 { get; }
+
+        public float FloatParamLerpValue0 { get; }
+
+        public string FloatParamName1 { get; }
+
+        public float FloatParamValue1 { get; }
+
+        public float FloatParamLerpValue1 { get; }
+
+        public string BoolParamName0 { get; }
+
+        public bool BoolParamValue0 { get; }
+
+        public string BoolParamName1 { get; }
+
+        public bool BoolParamValue1 { get; }
+
+        internal TaskMoVEScriptedInitialParametersStruct BuildStructForNatives()
+        {
+            IntPtr floatParamNamePtr0 = FloatParamName0 != null
+                ? SHVDN.StringMarshal.StringToCoTaskMemUtf8(FloatParamName0)
+                : IntPtr.Zero;
+            IntPtr floatParamNamePtr1 = FloatParamName1 != null
+                ? SHVDN.StringMarshal.StringToCoTaskMemUtf8(FloatParamName1)
+                : IntPtr.Zero;
+            IntPtr boolParamNamePtr0 = BoolParamName0 != null
+                ? SHVDN.StringMarshal.StringToCoTaskMemUtf8(BoolParamName0)
+                : IntPtr.Zero;
+            IntPtr boolParamNamePtr1 = BoolParamName1 != null
+                ? SHVDN.StringMarshal.StringToCoTaskMemUtf8(BoolParamName1)
+                : IntPtr.Zero;
+
+            return new TaskMoVEScriptedInitialParametersStruct(ClipSet0, VarClipSet0, ClipSet1, VarClipSet1,
+                               floatParamNamePtr0, FloatParamValue0, FloatParamLerpValue0, floatParamNamePtr1,
+                               FloatParamValue1, FloatParamLerpValue1, boolParamNamePtr0, BoolParamValue0,
+                               boolParamNamePtr1, BoolParamValue1);
+        }
+    }
+
+    public sealed class TaskMoVEScriptedInitialParametersBuilder
+    {
+        public TaskMoVEScriptedInitialParametersBuilder()
+        {
+            // These 2 lerp variables should be initialized to -1.0f as how `MOVE_INITIAL_PARAMETERS` in
+            // `commands_task.sch` and `CTaskMoVEScripted::InitialParameters` suggest.
+            _floatParamLerpValue0 = -1.0f;
+            _floatParamLerpValue1 = -1.0f;
+        }
+
+        private AtHashValue _clipSet0;
+
+        private AtHashValue _varClipSet0;
+
+        private AtHashValue _clipSet1;
+
+        private AtHashValue _varClipSet1;
+
+        private string _floatParamName0;
+
+        private float _floatParamValue0;
+
+        private float _floatParamLerpValue0;
+
+        private string _floatParamName1;
+
+        private float _floatParamValue1;
+
+        private float _floatParamLerpValue1;
+
+        private string _boolParamName0;
+
+        private bool _boolParamValue0;
+
+        private string _boolParamName1;
+
+        private bool _boolParamValue1;
+
+        public TaskMoVEScriptedInitialParametersBuilder ClipSet0(AtHashValue clipSet0)
+        {
+            _clipSet0 = clipSet0;
+            return this;
+        }
+
+        public TaskMoVEScriptedInitialParametersBuilder VarClipSet0(AtHashValue varClipSet0)
+        {
+            _varClipSet0 = varClipSet0;
+            return this;
+        }
+
+        public TaskMoVEScriptedInitialParametersBuilder ClipSet1(AtHashValue clipSet1)
+        {
+            _clipSet1 = clipSet1;
+            return this;
+        }
+
+        public TaskMoVEScriptedInitialParametersBuilder VarClipSet1(AtHashValue varClipSet1)
+        {
+            _varClipSet1 = varClipSet1;
+            return this;
+        }
+
+        public TaskMoVEScriptedInitialParametersBuilder FloatParamName0(string floatParamName0)
+        {
+            _floatParamName0 = floatParamName0;
+            return this;
+        }
+
+        public TaskMoVEScriptedInitialParametersBuilder FloatParamValue0(float floatParamValue0)
+        {
+            _floatParamValue0 = floatParamValue0;
+            return this;
+        }
+
+        public TaskMoVEScriptedInitialParametersBuilder FloatParamLerpValue0(float floatParamLerpValue0)
+        {
+            _floatParamLerpValue0 = floatParamLerpValue0;
+            return this;
+        }
+
+        public TaskMoVEScriptedInitialParametersBuilder FloatParamName1(string floatParamName1)
+        {
+            _floatParamName1 = floatParamName1;
+            return this;
+        }
+
+        public TaskMoVEScriptedInitialParametersBuilder FloatParamValue1(float floatParamValue1)
+        {
+            _floatParamValue1 = floatParamValue1;
+            return this;
+        }
+
+        public TaskMoVEScriptedInitialParametersBuilder FloatParamLerpValue1(float floatParamLerpValue1)
+        {
+            _floatParamLerpValue1 = floatParamLerpValue1;
+            return this;
+        }
+
+        public TaskMoVEScriptedInitialParametersBuilder BoolParamName0(string boolParamName0)
+        {
+            _boolParamName0 = boolParamName0;
+            return this;
+        }
+
+        public TaskMoVEScriptedInitialParametersBuilder BoolParamValue0(bool boolParamValue0)
+        {
+            _boolParamValue0 = boolParamValue0;
+            return this;
+        }
+
+        public TaskMoVEScriptedInitialParametersBuilder BoolParamName1(string boolParamName1)
+        {
+            _boolParamName1 = boolParamName1;
+            return this;
+        }
+
+        public TaskMoVEScriptedInitialParametersBuilder BoolParamValue1(bool boolParamValue1)
+        {
+            _boolParamValue1 = boolParamValue1;
+            return this;
+        }
+
+        public TaskMoVEScriptedInitialParameters Build()
+        {
+            return new TaskMoVEScriptedInitialParameters(_clipSet0, _varClipSet0, _clipSet1, _varClipSet1,
+                               _floatParamName0, _floatParamValue0, _floatParamLerpValue0, _floatParamName1,
+                               _floatParamValue1, _floatParamLerpValue1, _boolParamName0, _boolParamValue0,
+                               _boolParamName1, _boolParamValue1);
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 8)]
+    internal ref struct TaskMoVEScriptedInitialParametersStruct
+    {
+        internal TaskMoVEScriptedInitialParametersStruct(AtHashValue clipSet0, AtHashValue varclipSet0,
+            AtHashValue clipSet1, AtHashValue varclipSet1, IntPtr floatParamNamePtr0, float floatParamValue0,
+            float floatParamLerpValue0, IntPtr floatParamNamePtr1, float floatParamValue1, float floatParamLerpValue1,
+            IntPtr boolParamNamePtr0, bool boolParamValue0, IntPtr boolParamNamePtr1, bool boolParamValue1)
+        {
+            ClipSet0 = clipSet0;
+            VarClipSet0 = varclipSet0;
+            ClipSet1 = clipSet1;
+            VarClipSet1 = varclipSet1;
+
+            FloatParamNamePtr0 = floatParamNamePtr0;
+            FloatParamValue0 = floatParamValue0;
+            FloatParamLerpValue0 = floatParamLerpValue0;
+            FloatParamNamePtr1 = floatParamNamePtr1;
+            FloatParamValue1 = floatParamValue1;
+            FloatParamLerpValue1 = floatParamLerpValue1;
+
+            BoolParamNamePtr0 = boolParamNamePtr0;
+            BoolParamValue0 = boolParamValue0;
+            BoolParamNamePtr1 = boolParamNamePtr1;
+            BoolParamValue1 = boolParamValue1;
+
+            _disposed = false;
+        }
+
+        internal readonly AtHashValue ClipSet0 { get; }
+
+        internal readonly AtHashValue VarClipSet0 { get; }
+
+        internal readonly AtHashValue ClipSet1 { get; }
+
+        internal readonly AtHashValue VarClipSet1 { get; }
+
+        internal readonly IntPtr FloatParamNamePtr0 { get; }
+
+        internal readonly float FloatParamValue0 { get; }
+
+        internal readonly float FloatParamLerpValue0 { get; }
+
+        internal readonly IntPtr FloatParamNamePtr1 { get; }
+
+        internal readonly float FloatParamValue1 { get; }
+
+        internal readonly float FloatParamLerpValue1 { get; }
+
+        internal readonly IntPtr BoolParamNamePtr0 { get; }
+
+        internal readonly bool BoolParamValue0 { get; }
+
+        internal readonly IntPtr BoolParamNamePtr1 { get; }
+
+        internal readonly bool BoolParamValue1 { get; }
+
+        private bool _disposed;
+
+        internal void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (FloatParamNamePtr0 != IntPtr.Zero)
+            {
+                Marshal.FreeCoTaskMem(FloatParamNamePtr0);
+            }
+            if (FloatParamNamePtr1 != IntPtr.Zero)
+            {
+                Marshal.FreeCoTaskMem(FloatParamNamePtr1);
+            }
+            if (BoolParamNamePtr0 != IntPtr.Zero)
+            {
+                Marshal.FreeCoTaskMem(BoolParamNamePtr0);
+            }
+            if (BoolParamNamePtr1 != IntPtr.Zero)
+            {
+                Marshal.FreeCoTaskMem(BoolParamNamePtr1);
+            }
+
+            _disposed = true;
+        }
+    }
+}

--- a/source/scripting_v3/GTA/Entities/Peds/Task/TaskMoVEScriptedInitialParameters.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Task/TaskMoVEScriptedInitialParameters.cs
@@ -9,6 +9,9 @@ using System.Runtime.InteropServices;
 
 namespace GTA
 {
+    /// <summary>
+    /// Represents an immutable set of initial parameters for scripted move network tasks.
+    /// </summary>
     public sealed class TaskMoVEScriptedInitialParameters
     {
         internal TaskMoVEScriptedInitialParameters(AtHashValue clipSet0, AtHashValue varclipSet0,
@@ -62,6 +65,9 @@ namespace GTA
 
         public bool BoolParamValue1 { get; }
 
+        /// <remarks>
+        /// Builds a new <see cref="TaskMoVEScriptedInitialParametersStruct"/> instance to pass to native functions.
+        /// </remarks>
         internal TaskMoVEScriptedInitialParametersStruct BuildStructForNatives()
         {
             IntPtr floatParamNamePtr0 = FloatParamName0 != null
@@ -84,6 +90,9 @@ namespace GTA
         }
     }
 
+    /// <summary>
+    /// Represents a builder that builds <see cref="TaskMoVEScriptedInitialParameters"/>.
+    /// </summary>
     public sealed class TaskMoVEScriptedInitialParametersBuilder
     {
         public TaskMoVEScriptedInitialParametersBuilder()
@@ -158,6 +167,9 @@ namespace GTA
             return this;
         }
 
+        /// <remarks>
+        /// The default value is -1.0f.
+        /// </remarks>
         public TaskMoVEScriptedInitialParametersBuilder FloatParamLerpValue0(float floatParamLerpValue0)
         {
             _floatParamLerpValue0 = floatParamLerpValue0;
@@ -176,6 +188,9 @@ namespace GTA
             return this;
         }
 
+        /// <remarks>
+        /// The default value is -1.0f.
+        /// </remarks>
         public TaskMoVEScriptedInitialParametersBuilder FloatParamLerpValue1(float floatParamLerpValue1)
         {
             _floatParamLerpValue1 = floatParamLerpValue1;
@@ -206,6 +221,9 @@ namespace GTA
             return this;
         }
 
+        /// <remarks>
+        /// Builds a new <see cref="TaskMoVEScriptedInitialParameters"/> instance.
+        /// </remarks>
         public TaskMoVEScriptedInitialParameters Build()
         {
             return new TaskMoVEScriptedInitialParameters(_clipSet0, _varClipSet0, _clipSet1, _varClipSet1,
@@ -215,6 +233,13 @@ namespace GTA
         }
     }
 
+    /// <summary>
+    /// Represents an immutable struct that has a set of initial parameters and for scripted move network tasks.
+    /// Intended to be used to pass the data to native functions.
+    /// </summary>
+    /// <remarks>
+    /// Since this struct has a private disposed field, this struct should not be passed by value as a argument.
+    /// </remarks>
     [StructLayout(LayoutKind.Sequential, Pack = 8)]
     internal ref struct TaskMoVEScriptedInitialParametersStruct
     {


### PR DESCRIPTION
If you wonder what move network means, you could inspect mrf files with some tool such as CodeWalker. `TASK_MOVE_NETWORK_ADVANCED_BY_NAME` is called in a few sc scripts, which are `jewelry_heist.sc`, `Family6.sc`, and `FBI5A.sc`. Even `CTaskMotionBase` and its subclasses use move network helpers.

## Examples
### StartMoveNetworkAdvancedByName
```cs
void OnKeyDown(object sender, KeyEventArgs e)
{
    if (e.KeyCode == Keys.G)
    {
        var player = Game.Player.Character;
        var playerPos = player.Position;

        // The clip "mini@biotech@blowtorch_def" needs to be loaded beforehand before the ped can properly play
        // the intro animation
        player.Task.StartMoveNetworkAdvancedByName("minigame_BLOWTORCH", player.Position, new Vector3(0f, 0f, player.Heading));
    }
    if (e.KeyCode == Keys.K)
    {
        var player = Game.Player.Character;

        PedMoveNetworkTaskInterface playerMoVETaskInterface = player.MoveNetworkTaskInterface;
        if (playerMoVETaskInterface.IsTaskActive)
        {
            if (playerMoVETaskInterface.IsReadyForTransition)
            {
                // The clip "mini@biotech@blowtorch_str" needs to be loaded.
                // Also "x_axis" and "y_axis" parameters need to be supplied to have peds properly perform 
                // the animation, but sending parameters to them right after requesting state transition
                // won't work.
                playerMoVETaskInterface.RequestStateTransition("Cutting");
                
                //playerMoVETaskInterface.SetSignalFloat("x_axis", 0.4f);
                //playerMoVETaskInterface.SetSignalFloat("y_axis", 0.6f);
            }
        }
    }
}
```

### StartMoveNetworkAdvancedByNameWithParams
```cs
void OnKeyDown(object sender, KeyEventArgs e)
{
    if (e.KeyCode == Keys.G)
    {
        var player = Game.Player.Character;
        var playerPos = player.Position;

        // You can use either "ANIM_HEIST@ARCADE@STRENGTH@MALE@" or "ANIM_HEIST@ARCADE@STRENGTH@FEMALE@" as
        // the `ClipSet0` parameter and you need to load either of them beforehand.
        TaskMoVEScriptedInitialParametersBuilder initParamsBuilder = new TaskMoVEScriptedInitialParametersBuilder();
        TaskMoVEScriptedInitialParameters initParams 
            = initParamsBuilder.ClipSet0(AtHashValue.FromString("clipset@anim_heist@arcade@strength@male"))
                               .VarClipSet0(AtHashValue.FromString("default"))
                               .Build();

        player.Task.StartMoveNetworkAdvancedByNameWithInitParams("Heist_Arcade_Strength_Hammer", initParams,
            player.Position, new Vector3(0f, 0f, player.Heading), blendDuration: AnimationBlendDuration.ReallySlow,
            flags: MoveNetworkFlags.Default);
    }
    if (e.KeyCode == Keys.K)
    {
        var player = Game.Player.Character;
        if (player == null || !player.Exists()) { return; }

        PedMoveNetworkTaskInterface playerMoVETaskInterface = player.MoveNetworkTaskInterface;
        if (playerMoVETaskInterface.IsTaskActive)
        {
            playerMoVETaskInterface.RequestStateTransition("EnterFinish");
            playerMoVETaskInterface.SetSignalFloat("Weight", 0.75f);
        }
    }
    if (e.KeyCode == Keys.L)
    {
        var player = Game.Player.Character;
        if (player == null || !player.Exists()) { return; }

        PedMoveNetworkTaskInterface playerMoVETaskInterface = player.MoveNetworkTaskInterface;
        if (playerMoVETaskInterface.IsTaskActive)
        {
            // Make sure the state is "EnterFinish" before request a state transition into a result state!
            // you can use "PerfectResult", "GoodResult", "AverageResult", or "BadResult".
            playerMoVETaskInterface.RequestStateTransition("PerfectResult");
        }
    }
}
```