### PR TITLE
feat(api-v3): `Ped.PedType` and `Ped.SetAsCop`

### DIFF
--- a/source/scripting_v3/GTA/Entities/Peds/Ped.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Ped.cs
@@ -69,6 +69,28 @@ namespace GTA
         }
 
         /// <summary>
+        /// Returns the <see cref="PedType"/> of this <see cref="Ped"/>.
+        /// </summary>
+        public PedType PedType => Function.Call<PedType>(Hash.GET_PED_TYPE, Handle);
+
+        /// <summary>
+        /// Sets up this <see cref="Ped"/> so that they are treated as a cop.
+        /// </summary>
+        /// <param name="setRelationshipGroup">
+        /// If <see langword="true"/>, this <see cref="Ped"/>'s <see cref="RelationshipGroup"/> will be changed to
+        /// <see cref="RelationshipGroupHash.Cop"/>.
+        /// </param>
+        /// <remarks>
+        /// Adjusts an appropriate population count of the population counts for non-cop <see cref="Ped"/>s and
+        /// one for cop <see cref="Ped"/>s. Sets <see cref="DecisionMaker"/> to
+        /// <see cref="DecisionMakerTypeHash.Cop"/>.
+        /// </remarks>
+        public void SetAsCop(bool setRelationshipGroup = true)
+        {
+            Function.Call(Hash.SET_PED_AS_COP, Handle, setRelationshipGroup);
+        }
+
+        /// <summary>
         /// Creates a new <see cref="Ped"/> at where this <see cref="Ped"/> is by cloning this <see cref="Ped"/>.
         /// </summary>
         /// <param name="linkBlends">

--- a/source/scripting_v3/GTA/Entities/Peds/PedType.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/PedType.cs
@@ -1,0 +1,73 @@
+//
+// Copyright (C) 2024 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+namespace GTA
+{
+    /// <summary>
+    /// An enumeration of all the possible ped types.
+    /// </summary>
+    public enum PedType
+    {
+        /// <remarks>
+        /// In the game's codebase, this value is only used by `<c>CSelectionWheel::TriggerFadeInEffect</c>`
+        /// (the class manages the player selection wheel), `<c>CNetObjPed::GetPedScriptGameStateData</c>`,
+        /// `<c>ReplayBufferMarkerMgr::AddMarkerInternal</c>`, and 3 functions of `<c>CEventPlayerDeath</c>`.
+        /// </remarks>
+        Invalid = -1,
+        /// <summary>
+        /// The <see cref="PedType"/> for Michael.
+        /// </summary>
+        Player0,
+        /// <summary>
+        /// The <see cref="PedType"/> for Franklin.
+        /// </summary>
+        Player1,
+        /// <summary>
+        /// The <see cref="PedType"/> for players controlled over the network (not by the local machine)
+        /// </summary>
+        /// <remarks>
+        /// Although this is only relevant when the game is online, player <see cref="Ped"/>s will have this type if
+        /// the static network session instance is not null and is active, and the ped type of the player ped is not
+        /// the animal ped type in `<c>CPlayerInfo::SetPlayerPed</c>`.
+        /// </remarks>
+        NetworkPlayer,
+        /// <summary>
+        /// The <see cref="PedType"/> for Trevor.
+        /// </summary>
+        Player2,
+        /// <summary>
+        /// The civilian male <see cref="PedType"/>.
+        /// </summary>
+        CivMale,
+        /// <summary>
+        /// The civilian female <see cref="PedType"/>.
+        /// </summary>
+        CivFemale,
+        Cop,
+        GangAlbanian,
+        GangBiker1,
+        GangBiker2,
+        GangItalian,
+        GangRussian,
+        GangRussian2,
+        GangIrish,
+        GangJamaican,
+        GangAfricanAmerican,
+        GangKorean,
+        GangChineseJapanese,
+        GangPuertoRican,
+        Dealer,
+        Medic,
+        Fire,
+        Criminal,
+        Bum,
+        Prostitute,
+        Special,
+        Mission,
+        Swat,
+        Animal,
+        Army
+    }
+}


### PR DESCRIPTION
You can't specify a ped type when spawning a ped with natives like in older GTA games (natives just ignore ped type params), but still the game use ped type members for various stuff such as detecting cop peds.