### PR TITLE
feat(api-v3): add `Ped.IsEnteringVehicle` and mark `Ped.IsGettingIntoVehicle` as obsolete

### DIFF
--- a/source/scripting_v3/GTA/Entities/Peds/Ped.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Ped.cs
@@ -818,7 +818,7 @@ namespace GTA
 
         #region Tasks
 
-        public bool IsIdle => !IsInjured && !IsRagdoll && !IsInAir && !IsOnFire && !IsDucking && !IsGettingIntoVehicle && !IsInCombat && !IsInMeleeCombat && (!IsInVehicle() || IsSittingInVehicle());
+        public bool IsIdle => !IsInjured && !IsRagdoll && !IsInAir && !IsOnFire && !IsDucking && !IsEnteringVehicle && !IsInCombat && !IsInMeleeCombat && (!IsInVehicle() || IsSittingInVehicle());
 
         /// <summary>
         /// Indicates whether this <see cref="Ped"/> is basically lying on the ground.
@@ -828,7 +828,7 @@ namespace GTA
         /// <summary>
         /// Indicates whether this <see cref="Ped"/> is getting up.
         /// </summary>
-        public bool IsGettingUp => Function.Call<bool>(Hash.IS_PED_GETTING_UP, Handle);
+        public bool Up => Function.Call<bool>(Hash.IS_PED_GETTING_UP, Handle);
 
         /// <summary>
         /// Indicates whether this <see cref="Ped"/> is currently diving (includes jump launch/clamber phase).
@@ -1641,11 +1641,15 @@ namespace GTA
         public bool IsInBoat => Function.Call<bool>(Hash.IS_PED_IN_ANY_BOAT, Handle);
 
         public bool IsInPoliceVehicle => Function.Call<bool>(Hash.IS_PED_IN_ANY_POLICE_VEHICLE, Handle);
+        
+        [Obsolete("Use ScriptSoundId.PlaySoundFrontend or Audio.PlaySoundFrontendAndForget instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool IsGettingIntoVehicle => IsEnteringVehicle;
 
         /// <summary>
-        /// Indicates whether is getting into a <see cref="Vehicle"/> but not sitting in a <see cref="Vehicle"/>.
+        /// Indicates whether is currently entering a <see cref="Vehicle"/> but not sitting in a <see cref="Vehicle"/>.
         /// </summary>
-        public bool IsGettingIntoVehicle => Function.Call<bool>(Hash.IS_PED_GETTING_INTO_A_VEHICLE, Handle);
+        public bool IsEnteringVehicle => Function.Call<bool>(Hash.IS_PED_GETTING_INTO_A_VEHICLE, Handle);
 
         /// <summary>
         /// Indicates whether is currently exiting a <see cref="Vehicle"/>.

--- a/source/scripting_v3/GTA/Entities/Peds/Ped.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Ped.cs
@@ -828,7 +828,7 @@ namespace GTA
         /// <summary>
         /// Indicates whether this <see cref="Ped"/> is getting up.
         /// </summary>
-        public bool Up => Function.Call<bool>(Hash.IS_PED_GETTING_UP, Handle);
+        public bool IsGettingUp => Function.Call<bool>(Hash.IS_PED_GETTING_UP, Handle);
 
         /// <summary>
         /// Indicates whether this <see cref="Ped"/> is currently diving (includes jump launch/clamber phase).

--- a/source/scripting_v3/GTA/Entities/Peds/Ped.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Ped.cs
@@ -1642,7 +1642,7 @@ namespace GTA
 
         public bool IsInPoliceVehicle => Function.Call<bool>(Hash.IS_PED_IN_ANY_POLICE_VEHICLE, Handle);
         
-        [Obsolete("Use ScriptSoundId.PlaySoundFrontend or Audio.PlaySoundFrontendAndForget instead.")]
+        [Obsolete("Use IsEnteringVehicle instead.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public bool IsGettingIntoVehicle => IsEnteringVehicle;
 


### PR DESCRIPTION
Changed the language of the function call for checking if a Ped is Entering a Vehicle.

Entering is the opposing word to Exiting.
If we have IsGettingInto then the opposing should IsGettingOutOf.