### PR TITLE
feat(api-v3): add custom `ToString()` impls to 4 game clock date time and duration structs

### DIFF
--- a/source/scripting_v3/GTA.Chrono/BitOperations.cs
+++ b/source/scripting_v3/GTA.Chrono/BitOperations.cs
@@ -15,9 +15,27 @@ namespace GTA.Chrono
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int Log2(uint value)
         {
+            // The 0->0 contract is fulfilled by setting the LSB to 1.
+            // Log(1) is 0, and setting the LSB for values > 1 does not change the log2 result.
+            value |= 1;
+
             // Maybe we could use write assembly code where a `lzcnt` opcode is used and call it via a function pointer?
             // We'll need to test if the CPU supports `lzcnt` before trying to use it, of course.
             return Log2SoftwareFallback(value);
+        }
+
+        public static int Log2(ulong value)
+        {
+            // should add `value |= 1` here if we decided to add `lzcnt` support
+
+            uint hi = (uint)(value >> 32);
+
+            if (hi == 0)
+            {
+                return Log2((uint)value);
+            }
+
+            return 32 + Log2(hi);
         }
 
         private static int Log2SoftwareFallback(uint value)

--- a/source/scripting_v3/GTA.Chrono/BitOperations.cs
+++ b/source/scripting_v3/GTA.Chrono/BitOperations.cs
@@ -1,0 +1,39 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace GTA.Chrono
+{
+    internal static class BitOperations
+    {
+        private static readonly byte[] Log2DeBruijn = new byte[32]
+        {
+            00, 09, 01, 10, 13, 21, 02, 29,
+            11, 14, 16, 18, 22, 25, 03, 30,
+            08, 12, 20, 28, 15, 17, 24, 07,
+            19, 27, 23, 06, 26, 05, 04, 31
+        };
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int Log2(uint value)
+        {
+            // Maybe we could use write assembly code where a `lzcnt` opcode is used and call it via a function pointer?
+            // We'll need to test if the CPU supports `lzcnt` before trying to use it, of course.
+            return Log2SoftwareFallback(value);
+        }
+
+        private static int Log2SoftwareFallback(uint value)
+        {
+            // No AggressiveInlining due to large method size.
+            // Has conventional contract 0->0 (Log(0) is undefined).
+
+            // Fill trailing zeros with ones, eg 00010010 becomes 00011111
+            value |= value >> 01;
+            value |= value >> 02;
+            value |= value >> 04;
+            value |= value >> 08;
+            value |= value >> 16;
+
+            // uint.MaxValue >> 27 is always in range [0 - 31] so there's no need to let perform bounds check, really
+            return (int)Log2DeBruijn[(value * 0x07C4ACDDu) >> 27];
+        }
+    }
+}

--- a/source/scripting_v3/GTA.Chrono/BitOperations.cs
+++ b/source/scripting_v3/GTA.Chrono/BitOperations.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (C) 2024 kagikn & contributors
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
@@ -24,15 +24,13 @@ namespace GTA.Chrono
             // Log(1) is 0, and setting the LSB for values > 1 does not change the log2 result.
             value |= 1;
 
-            // Maybe we could use write assembly code where a `lzcnt` opcode is used and call it via a function pointer?
-            // We'll need to test if the CPU supports `lzcnt` before trying to use it, of course.
+            // Bothering to call lzcnt code from C++ code or calling asm code in C# code isn't worth the effort,
+            // because calling lzcnt saves only 25% of the time compared to the software fallback.
             return Log2SoftwareFallback(value);
         }
 
         public static int Log2(ulong value)
         {
-            // should add `value |= 1` here if we decided to add `lzcnt` support
-
             uint hi = (uint)(value >> 32);
 
             if (hi == 0)

--- a/source/scripting_v3/GTA.Chrono/BitOperations.cs
+++ b/source/scripting_v3/GTA.Chrono/BitOperations.cs
@@ -24,8 +24,8 @@ namespace GTA.Chrono
             // Log(1) is 0, and setting the LSB for values > 1 does not change the log2 result.
             value |= 1;
 
-            // Bothering to call lzcnt code from C++ code or calling asm code in C# code isn't worth the effort,
-            // because calling lzcnt saves only 25% of the time compared to the software fallback.
+            // Bothering to call `lzcnt` code from C++ code or calling asm code in C# code isn't worth the effort,
+            // because calling `lzcnt` saves only 25% of the time compared to the software fallback.
             return Log2SoftwareFallback(value);
         }
 
@@ -43,18 +43,20 @@ namespace GTA.Chrono
 
         private static int Log2SoftwareFallback(uint value)
         {
-            // No AggressiveInlining due to large method size.
-            // Has conventional contract 0->0 (Log(0) is undefined).
+            // No `AggressiveInlining` due to large method size.
+            // Has conventional contract 0->0 (`Log(0)` is undefined).
 
-            // Fill trailing zeros with ones, eg 00010010 becomes 00011111
+            // Fill trailing zeros with ones, eg `00010010` becomes `00011111`
             value |= value >> 01;
             value |= value >> 02;
             value |= value >> 04;
             value |= value >> 08;
             value |= value >> 16;
 
-            // uint.MaxValue >> 27 is always in range [0 - 31] so there's no need to let perform bounds check, really
-            return (int)Log2DeBruijn[(value * 0x07C4ACDDu) >> 27];
+            // `uint.MaxValue >> 27` is always in range [0 - 31] so there's no need to let the JIT perform bound
+            // checks, really, but pinning the array takes more time than accepting bound checks if we access
+            // the array only couple times after pinning it.
+            return Log2DeBruijn[(value * 0x07C4ACDDu) >> 27];
         }
     }
 }

--- a/source/scripting_v3/GTA.Chrono/BitOperations.cs
+++ b/source/scripting_v3/GTA.Chrono/BitOperations.cs
@@ -1,4 +1,9 @@
-﻿using System.Runtime.CompilerServices;
+﻿//
+// Copyright (C) 2024 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+using System.Runtime.CompilerServices;
 
 namespace GTA.Chrono
 {

--- a/source/scripting_v3/GTA.Chrono/FormattingHelpers.cs
+++ b/source/scripting_v3/GTA.Chrono/FormattingHelpers.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿//
+// Copyright (C) 2024 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;

--- a/source/scripting_v3/GTA.Chrono/FormattingHelpers.cs
+++ b/source/scripting_v3/GTA.Chrono/FormattingHelpers.cs
@@ -7,6 +7,60 @@ namespace GTA.Chrono
 {
     internal static class FormattingHelpers
     {
+        // Map the log2(value) to a power of 10.
+        private static readonly long[] Log2ToPow10ForU64 = new long[64]
+        {
+            1,  1,  1,  2,  2,  2,  3,  3,  3,  4,  4,  4,  4,  5,  5,  5,
+            6,  6,  6,  7,  7,  7,  7,  8,  8,  8,  9,  9,  9,  10, 10, 10,
+            10, 11, 11, 11, 12, 12, 12, 13, 13, 13, 13, 14, 14, 14, 15, 15,
+            15, 16, 16, 16, 16, 17, 17, 17, 18, 18, 18, 19, 19, 19, 19, 20
+        };
+
+        // Read the associated power of 10.
+        private static readonly ulong[] PowersOf10 = new ulong[21]
+        {
+            0, // unused entry to avoid needing to subtract
+            0,
+            10,
+            100,
+            1000,
+            10000,
+            100000,
+            1000000,
+            10000000,
+            100000000,
+            1000000000,
+            10000000000,
+            100000000000,
+            1000000000000,
+            10000000000000,
+            100000000000000,
+            1000000000000000,
+            10000000000000000,
+            100000000000000000,
+            1000000000000000000,
+            10000000000000000000,
+        };
+
+        // Based on do_count_digits from https://github.com/fmtlib/fmt/blob/662adf4f33346ba9aba8b072194e319869ede54a/include/fmt/format.h#L1124
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int CountDigits(ulong value)
+        {
+            Debug.Assert(Log2ToPow10ForU64.Length == 64);
+            var index = (uint)Log2ToPow10ForU64[BitOperations.Log2(value)];
+
+            Debug.Assert((index + 1) <= PowersOf10.Length);
+            ulong powerOf10 = PowersOf10[BitOperations.Log2(index)];
+
+            // Return the number of digits based on the power of 10, shifted by 1 if it falls below the threshold.
+            bool lessThan = value < powerOf10;
+            unsafe
+            {
+                // while arbitrary bools may be non-0/1, comparison operators are expected to return 0/1
+                return (int)(index - *(byte*)&lessThan);
+            }
+        }
+
         // Algorithm based on https://lemire.me/blog/2021/06/03/computing-the-number-of-digits-of-an-integer-even-faster.
         private static readonly long[] FastCountDigitTable = new long[32]
         {

--- a/source/scripting_v3/GTA.Chrono/FormattingHelpers.cs
+++ b/source/scripting_v3/GTA.Chrono/FormattingHelpers.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+
+namespace GTA.Chrono
+{
+    internal static class FormattingHelpers
+    {
+        // Algorithm based on https://lemire.me/blog/2021/06/03/computing-the-number-of-digits-of-an-integer-even-faster.
+        private static readonly long[] FastCountDigitTable = new long[32]
+        {
+            4294967296,
+            8589934582,
+            8589934582,
+            8589934582,
+            12884901788,
+            12884901788,
+            12884901788,
+            17179868184,
+            17179868184,
+            17179868184,
+            21474826480,
+            21474826480,
+            21474826480,
+            21474826480,
+            25769703776,
+            25769703776,
+            25769703776,
+            30063771072,
+            30063771072,
+            30063771072,
+            34349738368,
+            34349738368,
+            34349738368,
+            34349738368,
+            38554705664,
+            38554705664,
+            38554705664,
+            41949672960,
+            41949672960,
+            41949672960,
+            42949672960,
+            42949672960,
+        };
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int CountDigits(uint value)
+        {
+            Debug.Assert(FastCountDigitTable.Length == 32, "Every result of CountDigits(value) needs a long entry in the table.");
+
+            long tableValue = FastCountDigitTable[BitOperations.Log2(value)];
+            return (int)((value + tableValue) >> 32);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int CountDecimalTrailingZeros(uint value, out uint valueWithoutTrailingZeros)
+        {
+            int zeroCount = 0;
+
+            if (value != 0)
+            {
+                while (true)
+                {
+                    uint temp = value / 10;
+                    if (value != (temp * 10))
+                    {
+                        break;
+                    }
+
+                    value = temp;
+                    zeroCount++;
+                }
+            }
+
+            valueWithoutTrailingZeros = value;
+            return zeroCount;
+        }
+    }
+}

--- a/source/scripting_v3/GTA.Chrono/GameClockDate.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDate.cs
@@ -8,6 +8,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace GTA.Chrono
 {
@@ -57,6 +58,8 @@ namespace GTA.Chrono
 
         private static OrdFlags OrdFlagsForMaxDate = new(365, YearFlags.FromYear(int.MaxValue));
         private static OrdFlags OrdFlagsForMinDate = new(1, YearFlags.FromYear(int.MinValue));
+
+        private const char HyphenForDateSeparator = '-';
 
         /// <summary>
         /// Represents the largest possible value of a <see cref="GameClockDate"/>.
@@ -916,6 +919,100 @@ namespace GTA.Chrono
             }
 
             return false;
+        }
+
+        public override string ToString()
+        {
+            unsafe
+            {
+                if (_year < -9999 || _year > 9999)
+                {
+                    return ToStringForDateWithMoreThan4DigitYear();
+                }
+
+                return ToStringWith4DigitYear();
+            }
+        }
+
+        [SkipLocalsInit]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe string ToStringWith4DigitYear()
+        {
+            if (_year < 0)
+            {
+                return ToStringWithNegative4DigitYear();
+            }
+            const int RequiredStrLen = 10;
+            char* buffer = stackalloc char[RequiredStrLen];
+
+            NumberFormatting.WriteFourDigits((uint)_year, buffer);
+            WriteMonthDayStrWithLeadingHyphen(buffer + 4);
+
+            return new string(buffer, 0, RequiredStrLen);
+        }
+
+        [SkipLocalsInit]
+        // Negative year values would be way less common than the year values between 0 and 9999, so no aggressive
+        // inlining
+        private unsafe string ToStringWithNegative4DigitYear()
+        {
+            // Without considering the year part but considering the first hyphen, any date string takes 6 chars
+            // ("-0001-01-01", "-2006-01-02" etc...)
+            const int RequiredStrLen = 11;
+            char* buffer = stackalloc char[RequiredStrLen];
+
+            buffer[0] = '-';
+            NumberFormatting.WriteFourDigits((uint)(-_year), buffer + 1);
+            WriteMonthDayStrWithLeadingHyphen(buffer + 5);
+
+            return new string(buffer, 0, RequiredStrLen);
+        }
+
+        [SkipLocalsInit]
+        // Year values more than 9999 would be way less common than the year values between 0 and 9999, so no aggressive
+        // inlining
+        private unsafe string ToStringForDateWithMoreThan4DigitYear()
+        {
+            const int MinDigitsForYearPart = 4;
+            const int RequiredStrLenWithoutYearPart = 6;
+
+            bool yearIsNegative = _year < 0;
+            // We can't use `System.Math.Abs(int)`, because it throws an `OverflowException` for int.MinValue,
+            // but negating and then casting int.MinValue to uint doesn't cause any problems for `WriteDigits`.
+            uint absYear = (uint)(yearIsNegative ? -_year : _year);
+
+            int yearDigitCount = System.Math.Max(FormattingHelpers.CountDigits(absYear), MinDigitsForYearPart);
+            int bufferLen = yearIsNegative
+                ? yearDigitCount + RequiredStrLenWithoutYearPart + 1
+                : yearDigitCount + RequiredStrLenWithoutYearPart;
+
+            char* buffer = stackalloc char[bufferLen];
+
+            int i;
+            if (yearIsNegative)
+            {
+                buffer[0] = '-';
+                i = 1;
+            }
+            else
+            {
+                i = 0;
+            }
+
+            NumberFormatting.WriteDigits(absYear, buffer + i, yearDigitCount);
+            i += yearDigitCount;
+            WriteMonthDayStrWithLeadingHyphen(buffer + i);
+
+            return new string(buffer, 0, bufferLen);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe void WriteMonthDayStrWithLeadingHyphen(char* ptr)
+        {
+            ptr[0] = HyphenForDateSeparator;
+            NumberFormatting.WriteTwoDigits((uint)Month, ptr + 1);
+            ptr[3] = HyphenForDateSeparator;
+            NumberFormatting.WriteTwoDigits((uint)Day, ptr + 4);
         }
 
         /// <summary>

--- a/source/scripting_v3/GTA.Chrono/GameClockDateTime.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDateTime.cs
@@ -7,6 +7,7 @@
 //
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace GTA.Chrono
 {
@@ -571,6 +572,17 @@ namespace GTA.Chrono
             }
 
             return false;
+        }
+
+        public override string ToString() => ToStringInternal();
+
+        [SkipLocalsInit]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe string ToStringInternal()
+        {
+            // this implementation is shit enough to improve in time wise, we could use stackalloc for an entire string
+            // buffer
+            return _date.ToString() + " " + _time.ToString();
         }
 
         /// <summary>

--- a/source/scripting_v3/GTA.Chrono/GameClockDateTime.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDateTime.cs
@@ -580,9 +580,19 @@ namespace GTA.Chrono
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private unsafe string ToStringInternal()
         {
-            // this implementation is shit enough to improve in time wise, we could use stackalloc for an entire string
-            // buffer
-            return _date.ToString() + " " + _time.ToString();
+            unsafe
+            {
+                // this is the minimum number that is large enough to contain any date time string and is multiple of 4
+                const int bufferLen = 28;
+                char* buffer = stackalloc char[bufferLen];
+                GameClockDateTimeFormat.TryFormatDateS(this._date, buffer, bufferLen, out int charWritten);
+                buffer[charWritten++] = ' ';
+                GameClockDateTimeFormat.TryFormatTimeS(this._time, buffer + charWritten, bufferLen - charWritten,
+                    out int timeWritten);
+                charWritten += timeWritten;
+
+                return new string(buffer, 0, charWritten);
+            }
         }
 
         /// <summary>

--- a/source/scripting_v3/GTA.Chrono/GameClockDateTimeFormat.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDateTimeFormat.cs
@@ -1,0 +1,202 @@
+//
+// Copyright (C) 2024 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+using System.Runtime.CompilerServices;
+
+namespace GTA.Chrono
+{
+    internal static class GameClockDateTimeFormat
+    {
+        private const char HyphenForDateSeparator = '-';
+        private const char MinusSign = HyphenForDateSeparator;
+
+        private const int RequiredStrLenForDateWithNonNegative4DigitYear = 10;
+
+        private const char ColonForTimeSeparator = ':';
+
+        internal static unsafe bool TryFormatDateS(GameClockDate date, char* dest, int destLengthInElemCount,
+            out int charsWritten)
+        {
+            int year = date.Year;
+
+            if (year is < -9999 or > 9999)
+            {
+                return FormatStringForDateWithMoreThan4DigitYear(date, dest, destLengthInElemCount, out charsWritten);
+            }
+
+            if (year >= 0)
+            {
+                if (destLengthInElemCount < RequiredStrLenForDateWithNonNegative4DigitYear)
+                {
+                    charsWritten = 0;
+                    return false;
+                }
+
+                FormatStringForDateWithNonNegative4DigitYear(date, dest);
+                charsWritten = RequiredStrLenForDateWithNonNegative4DigitYear;
+                return true;
+            }
+
+            return TryFormatDateSNegative4DigitYear(date, dest, destLengthInElemCount, out charsWritten);
+        }
+
+        // Negative year values would be way less common than the year values between 0 and 9999, so no aggressive
+        // inlining
+        private static unsafe bool TryFormatDateSNegative4DigitYear(GameClockDate date, char* dest,
+            int destLengthInElemCount, out int charsWritten)
+        {
+            if (destLengthInElemCount < RequiredStrLenForDateWithNonNegative4DigitYear + 1)
+            {
+                charsWritten = 0;
+                return false;
+            }
+
+            FormatStringForDateWithNegative4DigitYear(date, dest);
+            charsWritten = RequiredStrLenForDateWithNonNegative4DigitYear + 1;
+            return true;
+        }
+
+        [SkipLocalsInit]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static unsafe bool TryFormatTimeS(GameClockTime time, char* dest, int destLengthInElemCount,
+            out int charsWritten)
+        {
+            if (destLengthInElemCount < 8)
+            {
+                charsWritten = 0;
+                return false;
+            }
+            time.Deconstruct(out int hour, out int minute, out int second);
+
+            NumberFormatting.WriteTwoDigits((uint)hour, dest);
+            dest[2] = ColonForTimeSeparator;
+
+            NumberFormatting.WriteTwoDigits((uint)minute, dest + 3);
+            dest[5] = ColonForTimeSeparator;
+
+            NumberFormatting.WriteTwoDigits((uint)second, dest + 6);
+
+            charsWritten = 8;
+            return true;
+        }
+
+        /// <summary>
+        /// Writes characters that represents a human-readable date string, assuming the year is between 0 and 9999.
+        /// <paramref name="dest"/> must have 10 elements to write.
+        /// </summary>
+        /// <param name="date">The date to create a date string. the year must non-negative and less than 10000.</param>
+        /// <param name="dest">The destination pointer. Must have 10 elements to write.</param>
+        /// <returns>
+        /// A human-readable date string where the year part has 4 digit characters, such as "2008-04-29".
+        /// </returns>
+        [SkipLocalsInit]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe void FormatStringForDateWithNonNegative4DigitYear(GameClockDate date, char* dest)
+        {
+            NumberFormatting.WriteFourDigits((uint)date.Year, dest);
+            WriteMonthDayStrWithLeadingHyphen(date, dest + 4);
+        }
+
+        /// <summary>
+        /// Writes characters that represents a human-readable date string, assuming the year is between -9999 and -1.
+        /// <paramref name="dest"/> must have 11 elements to write.
+        /// </summary>
+        /// <param name="date">The date to create a date string. the year must negative and more than 0.</param>
+        /// <param name="dest">The destination pointer. Must have 11 elements to write.</param>
+        /// <returns>
+        /// A human-readable date string where the year part has 4 digit characters, such as "2008-04-29".
+        /// </returns>
+        [SkipLocalsInit]
+        private static unsafe void FormatStringForDateWithNegative4DigitYear(GameClockDate date, char* dest)
+        {
+            dest[0] = MinusSign;
+            NumberFormatting.WriteFourDigits((uint)-date.Year, dest + 1);
+            WriteMonthDayStrWithLeadingHyphen(date, dest + 5);
+        }
+
+        /// <summary>
+        /// Writes characters that represents a human-readable date string, assuming the year is between 0 and 9999.
+        /// <paramref name="dest"/> must have 11 elements to write a date string with 5 digit positive year and must
+        /// have 17 elements to write any date string.
+        /// </summary>
+        /// <param name="date">The date to create a date string. the year must non-negative and less than 10000.</param>
+        /// <param name="dest">
+        /// The destination pointer. Must have 11 elements to write a date string with 5 digit positive year and must
+        /// have 17 elements to write any date string.
+        /// </param>
+        /// <param name="destLengthInElemCount">
+        /// The length in element count that tells how many elements can be written from <paramref name="dest"/>.
+        /// </param>
+        /// <param name="charsWritten">
+        /// The actual written characters.
+        /// </param>
+        /// <returns>
+        /// A human-readable date string, such as "12008-04-29".
+        /// </returns>
+        [SkipLocalsInit]
+        // Year values more than 9999 would be way less common than the year values between 0 and 9999, so no aggressive
+        // inlining
+        private static unsafe bool FormatStringForDateWithMoreThan4DigitYear(GameClockDate date, char* dest,
+            int destLengthInElemCount, out int charsWritten)
+        {
+            const int MinDigitsForYearPart = 4;
+            const int RequiredStrLenWithoutYearPart = 6;
+
+            int year = date.Year;
+            bool yearIsNegative = year < 0;
+            // We can't use `System.Math.Abs(int)`, because it throws an `OverflowException` for int.MinValue,
+            // but negating and then casting int.MinValue to uint doesn't cause any problems for `WriteDigits`.
+            uint absYear = (uint)(yearIsNegative ? -year : year);
+
+            int yearDigitCount = System.Math.Max(FormattingHelpers.CountDigits(absYear), MinDigitsForYearPart);
+            int requiredLen = yearIsNegative
+                ? yearDigitCount + RequiredStrLenWithoutYearPart + 1
+                : yearDigitCount + RequiredStrLenWithoutYearPart;
+
+            if (destLengthInElemCount < requiredLen)
+            {
+                charsWritten = 0;
+                return false;
+            }
+
+            int i;
+            if (yearIsNegative)
+            {
+                dest[0] = MinusSign;
+                i = 1;
+            }
+            else
+            {
+                i = 0;
+            }
+
+            NumberFormatting.WriteDigits(absYear, dest + i, yearDigitCount);
+            i += yearDigitCount;
+            WriteMonthDayStrWithLeadingHyphen(date, dest + i);
+            i += 6;
+
+            charsWritten = i;
+            return true;
+        }
+
+        /// <summary>
+        /// Writes characters that represents a human-readable month-day string with a leading hyphen.
+        /// <paramref name="ptr"/> must have 6 elements to write.
+        /// </summary>
+        /// <param name="date">The date to create a month-day string with a leading hyphen.</param>
+        /// <param name="ptr">The destination pointer. Must have 6 elements to write.</param>
+        /// <returns>
+        /// A human-readable month-day string with a leading hyphen, such as "-04-29".
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe void WriteMonthDayStrWithLeadingHyphen(GameClockDate date, char* ptr)
+        {
+            ptr[0] = HyphenForDateSeparator;
+            NumberFormatting.WriteTwoDigits((uint)date.Month, ptr + 1);
+            ptr[3] = HyphenForDateSeparator;
+            NumberFormatting.WriteTwoDigits((uint)date.Day, ptr + 4);
+        }
+    }
+}

--- a/source/scripting_v3/GTA.Chrono/GameClockDuration.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDuration.cs
@@ -4,13 +4,16 @@
 //
 
 using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace GTA.Chrono
 {
     /// <summary>
     /// Represents a fixed length of game clock time with the millisecond precision.
     /// </summary>
-    public readonly struct GameClockDuration : IEquatable<GameClockDuration>, IComparable<GameClockDuration>, IComparable
+    public readonly struct GameClockDuration : IEquatable<GameClockDuration>, IComparable<GameClockDuration>,
+        IComparable
     {
         private readonly long _secs;
 
@@ -21,10 +24,13 @@ namespace GTA.Chrono
 
         /// The number of seconds in a minute.
         const long SecsPerMinute = 60;
+
         /// The number of seconds in an hour.
         const long SecsPerHour = 3600;
+
         /// The number of (non-leap) seconds in days.
         const long SecsPerDay = 86_400;
+
         /// The number of (non-leap) seconds in a week.
         const long SecsPerWeek = 604_800;
 
@@ -37,24 +43,28 @@ namespace GTA.Chrono
         /// </summary>
         const long DayCountUInt32YearsLaterSinceInt32MinValueYear = (LeapYearCountOfInt32 * 366)
             + (NonLeapYearCountOfInt32 * 365) - 1;
+
         /// <summary>
         /// The same value as 135_536_076_801_503_999 seconds.
         /// </summary>
         const long MaxSecDifference = (DayCountUInt32YearsLaterSinceInt32MinValueYear) * SecsPerDay
-            + 23 * SecsPerHour + 59 * SecsPerMinute + 59;
+                                      + 23 * SecsPerHour + 59 * SecsPerMinute + 59;
+
         const long MinSecDifference = -((DayCountUInt32YearsLaterSinceInt32MinValueYear) * SecsPerDay
-            + 23 * SecsPerHour + 59 * SecsPerMinute + 59);
+                                        + 23 * SecsPerHour + 59 * SecsPerMinute + 59);
 
         /// <summary>
         /// Represents the zero <see cref="GameClockDuration"/> value. This field is read-only.
         /// </summary>
         public static GameClockDuration Zero = new(0);
+
         /// <summary>
         /// Represents the maximum <see cref="GameClockDuration"/> value, which can represent the duration from
         /// <see cref="GameClockDateTime.MinValue"/> to <see cref="GameClockDateTime.MaxValue"/>.
         /// This field is read-only.
         /// </summary>
         public static GameClockDuration MaxValue = new(MaxSecDifference);
+
         /// <summary>
         /// Represents the maximum <see cref="GameClockDuration"/> value, which can represent the duration from
         /// <see cref="GameClockDateTime.MaxValue"/> to <see cref="GameClockDateTime.MinValue"/>.
@@ -152,7 +162,8 @@ namespace GTA.Chrono
 
         private static void ThrowOutOfRange_TooLongDuration()
         {
-            ThrowHelper.ThrowArgumentOutOfRangeException(null, "GameClockDuration overflowed because the duration is too long.");
+            ThrowHelper.ThrowArgumentOutOfRangeException(null,
+                "GameClockDuration overflowed because the duration is too long.");
         }
 
         private static void ThrowIfOverflowedFromInt32YearMonthDay(long secs)
@@ -188,6 +199,7 @@ namespace GTA.Chrono
             if (_secs < t) return -1;
             return 0;
         }
+
         /// <summary>
         /// Compares the value of this instance to a specified <see cref="GameClockTime"/> value and indicates whether
         /// this instance is less than, the same as, or greater than the specified <see cref="GameClockTime"/> value.
@@ -231,6 +243,7 @@ namespace GTA.Chrono
 
             return new GameClockDuration(weeks * SecsPerWeek);
         }
+
         /// <summary>
         /// Returns a <see cref="GameClockDuration"/> that represents a specified number of days.
         /// </summary>
@@ -247,6 +260,7 @@ namespace GTA.Chrono
 
             return new GameClockDuration(days * SecsPerDay);
         }
+
         /// <summary>
         /// Returns a <see cref="GameClockDuration"/> that represents a specified number of hours.
         /// </summary>
@@ -263,6 +277,7 @@ namespace GTA.Chrono
 
             return new GameClockDuration(hours * SecsPerHour);
         }
+
         /// <summary>
         /// Returns a <see cref="GameClockDuration"/> that represents a specified number of minutes.
         /// </summary>
@@ -279,6 +294,7 @@ namespace GTA.Chrono
 
             return new GameClockDuration(minutes * SecsPerMinute);
         }
+
         /// <summary>
         /// Returns a <see cref="GameClockDuration"/> that represents a specified number of seconds.
         /// </summary>
@@ -295,6 +311,7 @@ namespace GTA.Chrono
 
             return new GameClockDuration(seconds);
         }
+
         public static GameClockDuration FromTimeSpan(TimeSpan timeSpan)
             => new GameClockDuration(timeSpan.Ticks / TimeSpan.TicksPerSecond);
 
@@ -368,10 +385,12 @@ namespace GTA.Chrono
                 // overflow, throw ArgumentOutOfRangeException if overflowed to avoid the exception type surprise.
                 ThrowOutOfRange_TooLongDuration();
             }
+
             ThrowIfOverflowedFromInt32YearMonthDay(result);
 
             return new GameClockDuration(result);
         }
+
         public static GameClockDuration operator *(GameClockDuration duration, double factor)
         {
             if (double.IsNaN(factor))
@@ -436,6 +455,7 @@ namespace GTA.Chrono
         /// </returns>
         public static GameClockDuration operator *(long factor, GameClockDuration duration)
             => duration * factor;
+
         /// <summary>
         /// Returns a new <see cref="GameClockDuration"/> object whose value is the result of multiplying the
         /// specified <paramref name="factor"/> and the specified <paramref name="duration"/> instance.
@@ -461,6 +481,7 @@ namespace GTA.Chrono
         /// </returns>
         public static GameClockDuration operator /(GameClockDuration duration, long divisor)
             => new GameClockDuration(duration._secs / divisor);
+
         /// <summary>
         /// Returns a new TimeSpan object whose value is the result of dividing the specified
         /// <paramref name="duration"/> by the specified <paramref name="divisor"/>.
@@ -522,6 +543,7 @@ namespace GTA.Chrono
                 }
             }
         }
+
         /// <summary>
         /// Returns a new Double value that's the result of dividing <paramref name="d1"/> by <paramref name="d2"/>.
         /// </summary>
@@ -541,6 +563,7 @@ namespace GTA.Chrono
             // Do not check the second boundary, as this method is supposed to be called within the boundary.
             return new GameClockDuration((long)System.Math.Round(secs, MidpointRounding.ToEven));
         }
+
         private static GameClockDuration FromDecimalSecondsInternal(decimal secs)
         {
             if (secs < MinSecDifference || secs > MaxSecDifference)
@@ -569,6 +592,7 @@ namespace GTA.Chrono
         {
             return _secs == value._secs;
         }
+
         /// <summary>
         /// Returns a value indicating whether this instance is equal to a specified object.
         /// </summary>
@@ -586,6 +610,95 @@ namespace GTA.Chrono
             }
 
             return false;
+        }
+
+        public override string ToString() => ToStringInternal();
+
+        [SkipLocalsInit]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private string ToStringInternal()
+        {
+            unsafe
+            {
+                // large enough for any standard string format for `GameClockDuration` (e.g. "-1568704592609:23:59:59"
+                // for the min value)
+                const int destSize = 24;
+                char* dest = stackalloc char[destSize];
+                TryFormatStandard(this, dest, destSize, out int charsWritten);
+
+                return new string(dest, 0, charsWritten);
+            }
+        }
+
+        [SkipLocalsInit]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe bool TryFormatStandard(GameClockDuration duration, char* dest,
+            int destSizeInElemCount, out int charsWritten)
+        {
+            bool secsValIsNegative = duration._secs < 0;
+            ulong absSecs = (ulong)(secsValIsNegative ? -duration._secs : duration._secs);
+
+            // start with "-HH:MM:SS" if the value is negative or else "HH:MM:SS", and adjust as necessary
+            int requiredOutputLength = secsValIsNegative ? 9 : 8;
+
+            ulong totalMinsRemaining = MathHelpers.DivRem(absSecs, SecsPerMinute, out ulong secs);
+            Debug.Assert(secs < 60);
+
+            ulong totalHoursRemaining = 0, mins = 0;
+            if (totalMinsRemaining > 0)
+            {
+                totalHoursRemaining = MathHelpers.DivRem(totalMinsRemaining, 60 /* minutes per hour */, out mins);
+                Debug.Assert(mins < 60);
+            }
+
+            ulong days = 0, hours = 0;
+            if (totalHoursRemaining > 0)
+            {
+                days = MathHelpers.DivRem(totalHoursRemaining, 24 /* hours per days */, out hours);
+                Debug.Assert(hours < 24);
+            }
+
+            int dayDigits = 0;
+            if (days > 0)
+            {
+                dayDigits = FormattingHelpers.CountDigits(days);
+                Debug.Assert(dayDigits <= 13);
+                requiredOutputLength += dayDigits + 1; // for the leading `D:`
+            }
+
+            if (destSizeInElemCount < requiredOutputLength)
+            {
+                charsWritten = 0;
+                return false;
+            }
+
+            char* p = dest;
+            if (secsValIsNegative)
+            {
+                *p++ = '-';
+            }
+
+            // Write day and separator, if necessary
+            if (dayDigits > 0)
+            {
+                NumberFormatting.WriteDigits(days, p, dayDigits);
+                p += dayDigits;
+                *p++ = ':';
+            }
+
+            // Write "HH:MM:SS"
+            NumberFormatting.WriteTwoDigits((uint)hours, p);
+            p += 2;
+            *p++ = ':';
+            NumberFormatting.WriteTwoDigits((uint)mins, p);
+            p += 2;
+            *p++ = ':';
+            NumberFormatting.WriteTwoDigits((uint)secs, p);
+            p += 2;
+            Debug.Assert(p - dest == requiredOutputLength);
+
+            charsWritten = requiredOutputLength;
+            return true;
         }
 
         /// <summary>

--- a/source/scripting_v3/GTA.Chrono/GameClockTime.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockTime.cs
@@ -7,6 +7,7 @@
 //
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace GTA.Chrono
 {
@@ -27,6 +28,8 @@ namespace GTA.Chrono
         {
             _secs = secs;
         }
+
+        private const char ColonForTimeSeparator = ':';
 
         /// <summary>
         /// Gets the largest possible value of <see cref="GameClockDate"/>.
@@ -288,6 +291,28 @@ namespace GTA.Chrono
             if (_secs > t) return 1;
             if (_secs < t) return -1;
             return 0;
+        }
+
+        public override string ToString() => ToStringInternal();
+
+        [SkipLocalsInit]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private unsafe string ToStringInternal()
+        {
+            const int RequiredStrLen = 8;
+            char* buffer = stackalloc char[RequiredStrLen];
+
+            Deconstruct(out int hour, out int minute, out int second);
+
+            NumberFormatting.WriteTwoDigits((uint)hour, buffer);
+            buffer[2] = ColonForTimeSeparator;
+
+            NumberFormatting.WriteTwoDigits((uint)minute, buffer + 3);
+            buffer[5] = ColonForTimeSeparator;
+
+            NumberFormatting.WriteTwoDigits((uint)second, buffer + 6);
+
+            return new string(buffer, 0, RequiredStrLen);
         }
 
         /// <summary>

--- a/source/scripting_v3/GTA.Chrono/GameClockTime.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockTime.cs
@@ -29,8 +29,6 @@ namespace GTA.Chrono
             _secs = secs;
         }
 
-        private const char ColonForTimeSeparator = ':';
-
         /// <summary>
         /// Gets the largest possible value of <see cref="GameClockDate"/>.
         /// </summary>
@@ -299,20 +297,14 @@ namespace GTA.Chrono
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private unsafe string ToStringInternal()
         {
-            const int RequiredStrLen = 8;
-            char* buffer = stackalloc char[RequiredStrLen];
-
-            Deconstruct(out int hour, out int minute, out int second);
-
-            NumberFormatting.WriteTwoDigits((uint)hour, buffer);
-            buffer[2] = ColonForTimeSeparator;
-
-            NumberFormatting.WriteTwoDigits((uint)minute, buffer + 3);
-            buffer[5] = ColonForTimeSeparator;
-
-            NumberFormatting.WriteTwoDigits((uint)second, buffer + 6);
-
-            return new string(buffer, 0, RequiredStrLen);
+            unsafe
+            {
+                // this is the minimum number that is large enough to contain any time string
+                const int bufferLen = 8;
+                char* buffer = stackalloc char[bufferLen];
+                GameClockDateTimeFormat.TryFormatTimeS(this, buffer, bufferLen, out int written);
+                return new string(buffer, 0, written);
+            }
         }
 
         /// <summary>

--- a/source/scripting_v3/GTA.Chrono/MathHelpers.cs
+++ b/source/scripting_v3/GTA.Chrono/MathHelpers.cs
@@ -1,0 +1,24 @@
+﻿//
+// Copyright (C) 2024 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+namespace GTA.Chrono
+{
+    internal static class MathHelpers
+    {
+        internal static uint DivRem(uint left, uint right, out uint remainder)
+        {
+            uint quotient = left / right;
+            remainder = left - (quotient * right);
+            return quotient;
+        }
+
+        internal static ulong DivRem(ulong left, ulong right, out ulong remainder)
+        {
+            ulong quotient = left / right;
+            remainder = left - (quotient * right);
+            return quotient;
+        }
+    }
+}

--- a/source/scripting_v3/GTA.Chrono/NumberFormatting.cs
+++ b/source/scripting_v3/GTA.Chrono/NumberFormatting.cs
@@ -1,4 +1,9 @@
-﻿using System.Diagnostics;
+﻿//
+// Copyright (C) 2024 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -30,7 +35,6 @@ namespace GTA.Chrono
             unsafe
             {
                 int offsetFromDigitsCharsArray = (int)(value * 2);
-                // pinning the `TwoDigitsChars` doesn't save time when picking two chars
                 ptr[0] = TwoDigitsChars[offsetFromDigitsCharsArray];
                 ptr[1] = TwoDigitsChars[offsetFromDigitsCharsArray + 1];
             }

--- a/source/scripting_v3/GTA.Chrono/NumberFormatting.cs
+++ b/source/scripting_v3/GTA.Chrono/NumberFormatting.cs
@@ -38,7 +38,7 @@ namespace GTA.Chrono
 
         internal static unsafe void WriteFourDigits(uint value, char* ptr)
         {
-            uint quotient = DivRem(value, 100, out uint remainder);
+            uint quotient = MathHelpers.DivRem(value, 100, out uint remainder);
 
             WriteTwoDigits(quotient, ptr);
             WriteTwoDigits(remainder, ptr + 2);
@@ -62,11 +62,19 @@ namespace GTA.Chrono
             }
         }
 
-        private static uint DivRem(uint left, uint right, out uint remainder)
+        internal static unsafe void WriteDigits(ulong value, char* ptr, int count)
         {
-            uint quotient = left / right;
-            remainder = left - (quotient * right);
-            return quotient;
+            char* cur;
+            for (cur = ptr + count - 1; cur > ptr; cur--)
+            {
+                ulong temp = '0' + value;
+                value /= 10;
+                *cur = (char)(temp - (value * 10));
+            }
+
+            Debug.Assert(value < 10);
+            Debug.Assert(cur == ptr);
+            *cur = (char)('0' + value);
         }
     }
 }

--- a/source/scripting_v3/GTA.Chrono/NumberFormatting.cs
+++ b/source/scripting_v3/GTA.Chrono/NumberFormatting.cs
@@ -1,0 +1,72 @@
+﻿using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace GTA.Chrono
+{
+    internal static class NumberFormatting
+    {
+        // Optimizations using "TwoDigits" inspired by:
+        // https://engineering.fb.com/2013/03/15/developer-tools/three-optimization-tips-for-c/
+        private static readonly char[] TwoDigitsChars =
+            ("00010203040506070809" +
+             "10111213141516171819" +
+             "20212223242526272829" +
+             "30313233343536373839" +
+             "40414243444546474849" +
+             "50515253545556575859" +
+             "60616263646566676869" +
+             "70717273747576777879" +
+             "80818283848586878889" +
+             "90919293949596979899").ToArray();
+
+        // Probably slower than the internal method `Number.WriteTwoDigits` in .NET 9, which `DateTime` uses when
+        // `ToString` is called, but way faster than the internal method of .NET Framework 4.8
+        // `DateTimeFormat.FormatDigits(StringBuilder outputBuffer, int value, int len, bool overrideLengthLimit)`,
+        // which `DateTime` uses when `ToString` is called in .NET Framework 4.8 (more than 2x faster).
+        internal static unsafe void WriteTwoDigits(uint value, char* ptr)
+        {
+            unsafe
+            {
+                int offsetFromDigitsCharsArray = (int)(value * 2);
+                // pinning the `TwoDigitsChars` doesn't save time when picking two chars
+                ptr[0] = TwoDigitsChars[offsetFromDigitsCharsArray];
+                ptr[1] = TwoDigitsChars[offsetFromDigitsCharsArray + 1];
+            }
+        }
+
+        internal static unsafe void WriteFourDigits(uint value, char* ptr)
+        {
+            uint quotient = DivRem(value, 100, out uint remainder);
+
+            WriteTwoDigits(quotient, ptr);
+            WriteTwoDigits(remainder, ptr + 2);
+        }
+
+        internal static unsafe void WriteDigits(uint value, char* ptr, int count)
+        {
+            unsafe
+            {
+                char* cur;
+                for (cur = ptr + count - 1; cur > ptr; cur--)
+                {
+                    uint temp = '0' + value;
+                    value /= 10;
+                    *cur = (char)(temp - (value * 10));
+                }
+
+                Debug.Assert(value < 10);
+                Debug.Assert(cur == ptr);
+                *cur = (char)('0' + value);
+            }
+        }
+
+        private static uint DivRem(uint left, uint right, out uint remainder)
+        {
+            uint quotient = left / right;
+            remainder = left - (quotient * right);
+            return quotient;
+        }
+    }
+}

--- a/source/scripting_v3/PolyfillAttributes/SkipLocalsInitAttribute.cs
+++ b/source/scripting_v3/PolyfillAttributes/SkipLocalsInitAttribute.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Used to indicate to the compiler that the <c>.locals init</c> flag should
+    /// not be set in nested method headers when emitting to metadata.
+    /// </summary>
+    /// <remarks>
+    /// This attribute is unsafe because it may reveal uninitialized memory to
+    /// the application in certain instances (e.g., reading from uninitialized
+    /// stackalloc'd memory). If applied to a method directly, the attribute
+    /// applies to that method and all nested functions (lambdas, local
+    /// functions) below it. If applied to a type or module, it applies to all
+    /// methods nested inside. This attribute is intentionally not permitted on
+    /// assemblies. Use at the module level instead to apply to multiple type
+    /// declarations.
+    /// </remarks>
+    [Security.SecurityCritical]
+    [AttributeUsage(AttributeTargets.Module
+                    | AttributeTargets.Class
+                    | AttributeTargets.Struct
+                    | AttributeTargets.Interface
+                    | AttributeTargets.Constructor
+                    | AttributeTargets.Method
+                    | AttributeTargets.Property
+                    | AttributeTargets.Event, Inherited = false)]
+    internal sealed class SkipLocalsInitAttribute : Attribute
+    {
+        [Security.SecurityCritical]
+        public SkipLocalsInitAttribute()
+        {
+        }
+    }
+}

--- a/source/scripting_v3_tests/GameClockDateTests.cs
+++ b/source/scripting_v3_tests/GameClockDateTests.cs
@@ -505,6 +505,66 @@ namespace ScriptHookVDotNet_APIv3_Tests
             Assert.Equal(expected, date.IsLeapYear);
         }
 
+        public static TheoryData<GameClockDate, string> ToString_Typical_NonNegative_4Digit_Year_Data =>
+            new()
+            {
+                { GameClockDate.FromYmd(0, 1, 1), "0000-01-01" },
+                { GameClockDate.FromYmd(30, 9, 17), "0030-09-17" },
+                { GameClockDate.FromYmd(700, 6, 30), "0700-06-30" },
+                { GameClockDate.FromYmd(1900, 1, 1), "1900-01-01" },
+                { GameClockDate.FromYmd(2500, 12, 31), "2500-12-31" },
+                { GameClockDate.FromYmd(9999, 12, 31), "9999-12-31" },
+            };
+
+        public static TheoryData<GameClockDate, string> ToString_Negative_4Digit_Year_Data =>
+            new()
+            {
+                { GameClockDate.FromYmd(-1, 1, 1), "-0001-01-01" },
+                { GameClockDate.FromYmd(-1900, 10, 26), "-1900-10-26" },
+                { GameClockDate.FromYmd(-9999, 12, 31), "-9999-12-31" },
+            };
+
+        public static TheoryData<GameClockDate, string> ToString_More_Than_4_Digit_Year_Data =>
+            new()
+            {
+                { GameClockDate.FromYmd(10000, 1, 1), "10000-01-01" },
+                { GameClockDate.FromYmd(-10000, 12, 31), "-10000-12-31" },
+                { GameClockDate.FromYmd(2147483647, 12, 31), "2147483647-12-31" },
+                { GameClockDate.FromYmd(-2147483648, 1, 1), "-2147483648-01-01" },
+            };
+
+        [Theory]
+        [MemberData(nameof(ToString_Typical_NonNegative_4Digit_Year_Data))]
+        public void ToString_with_no_params_returns_string_with_4_digit_year_2_digit_month_and_2_digit_day_concatenated_with_hyphen_separator_if_year_is_between_0_and_9999(
+            GameClockDate date, string expected)
+        {
+            string actual = date.ToString();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [MemberData(nameof(ToString_Negative_4Digit_Year_Data))]
+        public void
+        ToString_with_no_params_returns_string_with_leading_neg_sign_and_4_digit_year_if_year_is_between_neg_9999_and_neg_1(
+            GameClockDate date, string expected)
+        {
+            string actual = date.ToString();
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [MemberData(nameof(ToString_More_Than_4_Digit_Year_Data))]
+        public void
+            ToString_with_no_params_returns_string_with_more_than_5_digit_year_if_year_is_not_between_neg_9999_and_pos_9999(
+                GameClockDate date, string expected)
+        {
+            string actual = date.ToString();
+
+            Assert.Equal(expected, actual);
+        }
+
         public static IEnumerable<object[]> Deconstruct_Method_TestData()
         {
             yield return new object[] { int.MinValue, 1, 1 };

--- a/source/scripting_v3_tests/GameClockDateTimeTests.cs
+++ b/source/scripting_v3_tests/GameClockDateTimeTests.cs
@@ -128,6 +128,44 @@ namespace ScriptHookVDotNet_APIv3_Tests
                 => minDateTimeRightBeforeMidnight + GameClockDuration.MinValue);
         }
 
+        public static TheoryData<GameClockDateTime> ToString_Data =>
+            new()
+            {
+                {
+                    YmdHms(1, 1, 1, 0, 0, 0)
+                },
+                {
+                    YmdHms(9999, 12, 31, 23, 59, 59)
+                },
+                {
+                    YmdHms(10000, 1, 1, 13, 14, 15)
+                },
+                {
+                    YmdHms(-1, 1, 1, 23, 26, 27)
+                },
+                {
+                    YmdHms(2147483647, 12, 31, 23, 55, 59)
+                },
+                {
+                    YmdHms(-2147483648, 1, 1, 1, 2, 3)
+                },
+            };
+
+        [Theory]
+        [MemberData(nameof(ToString_Data))]
+        public void ToString_with_no_params_returns_string_with_ToString_of_date_and_space_and_ToString_of_time(
+            GameClockDateTime dt)
+        {
+            GameClockDate d = dt.Date;
+            string dStr = d.ToString();
+            GameClockTime t = dt.Time;
+            string tStr = t.ToString();
+
+            string actual = dt.ToString();
+
+            Assert.Equal($"{dStr} {tStr}", actual);
+        }
+
         private static GameClockDateTime YmdHms(int y, int m, int d, int h, int n, int s)
             => GameClockDate.FromYmd(y, m, d).AndHms(h, n, s);
 

--- a/source/scripting_v3_tests/GameClockTimeTests.cs
+++ b/source/scripting_v3_tests/GameClockTimeTests.cs
@@ -219,6 +219,25 @@ namespace ScriptHookVDotNet_APIv3_Tests
             Assert.Equal(-expectedDurationNonNegative, negDuration);
         }
 
+        public static TheoryData<GameClockTime, string> ToString_Data =>
+            new()
+            {
+                { GameClockTime.FromHms(0, 0, 0), "00:00:00" },
+                { GameClockTime.FromHms(1, 2, 3), "01:02:03" },
+                { GameClockTime.FromHms(13, 14, 15), "13:14:15" },
+                { GameClockTime.FromHms(23, 59, 59), "23:59:59" },
+            };
+
+        [Theory]
+        [MemberData(nameof(ToString_Data))]
+        public void ToString_with_no_params_returns_string_with_2_digit_hour_min_and_sec_concatenated_with_colon_separator(
+            GameClockTime date, string expected)
+        {
+            string actual = date.ToString();
+
+            Assert.Equal(expected, actual);
+        }
+
         private static void VerifyGameClockTimeHms(GameClockTime gameClockTime, int hour, int minute, int second)
         {
             Assert.Equal(hour, gameClockTime.Hour);


### PR DESCRIPTION
## Summary
Overrides `ToString()` on the 4 structs in `GTA.Chrono`, namely `GameClockDate`, `GameClockTime`, `GameClockDateTime`, and `GameClockDuration`.

Closes #1533.


### Format
None of the overridden `ToString()`s uses the `DateTimeFormatInfo` of the `CultureInfo` on the thread where the current script is running.
- `GameClockDate`: `YYYY-MM-DD` for dates where the year is between 0 and 9999, and `-YYYY-MM-DD` for dates where the year is negative and more than -10000. If the year is not between -9999 and 9999, then `Y-MM-DD` where the year part has no padding zero characters and has the negative sign if negative. Loosely follows the extended date format of ISO 8601, but strictly complies with it for dates where the years are between -9999 and 9999.
- `GameClockTime`: Always `HH:MM:SS`, where each part can have one leading zero character. Strictly complies with the extended time format of ISO 8601.
- `GameClockDateTime`: Combined with `GameClockDate.ToString()` and `GameClockTime.ToString()` but with a space separator, like `2013-9-16 20:00:00`.
- `GameClockDuration`: `HH:MM:SS` for durations that has 0 whole days, and `D:HH:MM:SS` where the date part has no padding zero characters for ones that have 1 or more whole days.

### Examples
- `GameClockDate`
```cs
// for XUnit
Assert.Equal("2008-04-29", GameClockDate.FromYmd(2008, 4, 29));
Assert.Equal("-2008-04-29", -GameClockDate.FromYmd(2008, 4, 29));
Assert.Equal("12013-09-17", -GameClockDate.FromYmd(-12013, 9, 17));
Assert.Equal("-2147483648-01-01", -GameClockDate.FromYmd(-2147483648, 1, 1));
```
- `GameClockTime`
```cs
// for XUnit
Assert.Equal("00:00:00", GameClockTime.FromHms(0, 0, 0));
Assert.Equal("00:00:01", GameClockTime.FromHms(0, 0, 1));
Assert.Equal("00:33:00", GameClockTime.FromHms(0, 33, 0));
Assert.Equal("22:00:00", GameClockTime.FromHms(22, 0, 0));
Assert.Equal("23:59:59", GameClockTime.FromHms(23, 59, 59));
```
- `GameClockDateTime`
```cs
// for XUnit
Assert.Equal("2001-10-22 00:00:00", GameClockDate.FromYmd(2001, 10, 22).AndHms(0, 0, 0));
Assert.Equal("2002-10-29 09:00:00", GameClockDate.FromYmd(2002, 10, 29).AndHms(9, 0, 0));
Assert.Equal("2004-10-26 20:33:05", GameClockDate.FromYmd(2004, 10, 26).AndHms(20, 33, 5));
```
- `GameClockDuration`
```cs
// for XUnit
Assert.Equal("00:00:02", GameClockDuration.FromSeconds(2));
Assert.Equal("00:04:00", GameClockDuration.FromMinutes(4));
Assert.Equal("06:00:00", GameClockDuration.FromHours(6));
Assert.Equal("23:55:51", GameClockDuration.FromSeconds(23 * 3600 + 55 * 60 + 51));
Assert.Equal("100:13:00:00", GameClockDuration.FromDays(100) + GameClockDuration.FromHours(13));
```