### PR TITLE
build(core): remove 4th version number from scripting dlls' version info

### DIFF
--- a/source/scripting_v2/ScriptHookVDotNet_APIv2.csproj
+++ b/source/scripting_v2/ScriptHookVDotNet_APIv2.csproj
@@ -22,9 +22,9 @@
     <PathMap>$(MSBuildProjectDirectory)=$(AssemblyName)</PathMap>
   </PropertyGroup>
   <PropertyGroup>
-    <Version>2.11.6.0</Version>
-    <FileVersion>2.11.6.0</FileVersion>
-    <AssemblyVersion>2.11.6.0</AssemblyVersion>
+    <Version>2.11.6</Version>
+    <FileVersion>2.11.6</FileVersion>
+    <AssemblyVersion>2.11.6</AssemblyVersion>
     <Authors>crosire &amp; kagikn &amp; contributors</Authors>
     <Company></Company>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/source/scripting_v3/ScriptHookVDotNet_APIv3.csproj
+++ b/source/scripting_v3/ScriptHookVDotNet_APIv3.csproj
@@ -22,9 +22,9 @@
     <PathMap>$(MSBuildProjectDirectory)=$(AssemblyName)</PathMap>
   </PropertyGroup>
   <PropertyGroup>
-    <Version>3.6.0.0</Version>
-    <FileVersion>3.6.0.0</FileVersion>
-    <AssemblyVersion>3.6.0.0</AssemblyVersion>
+    <Version>3.6.0</Version>
+    <FileVersion>3.6.0</FileVersion>
+    <AssemblyVersion>3.6.0</AssemblyVersion>
     <Authors>crosire &amp; kagikn &amp; contributors</Authors>
     <Company></Company>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
Remove the last ''.0'' from version numbers to make following SemVer more natural for contributors.