### PR TITLE
feat!(api-v3): add `Wanted` and `DispatchData` classes

### DIFF
--- a/source/scripting_v3/GTA/DispatchData.cs
+++ b/source/scripting_v3/GTA/DispatchData.cs
@@ -1,0 +1,64 @@
+//
+// Copyright (C) 2025 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+using System;
+using GTA.Native;
+
+namespace GTA
+{
+    /// <summary>
+    /// A static collection of dispatch data. This "dispatch" includes but not limited to those for responses of
+    /// law enforcements, ambulances, and fires.
+    /// </summary>
+    public static class DispatchData
+    {
+        private const int MinWantedLevel = 0;
+        private const int MaxWantedLevel = 5;
+
+        /// <summary>
+        /// Gets the wanted radius for a specified wanted level. Can affect the difficulty level of <see cref="Wanted"/>
+        /// by the distance between the last spotted position and the current player position, and by the wanted radius
+        /// value.
+        /// </summary>
+        /// <param name="wantedLevel">The wanted level to retrieve the wanted radius.</param>
+        /// <returns>The wanted level radius.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="wantedLevel"/> is not between 0 and 5, inclusive.
+        /// </exception>
+        public static float GetWantedLevelRadius(int wantedLevel)
+        {
+            // The native doesn't test if the arg is in the value range in final builds and the native indirectly
+            // accesses an array of the singleton `CDispatchData` out of bounds if the arg is out of the value range,
+            // so we need to test that instead.
+            ThrowHelper.CheckArgumentRange(nameof(wantedLevel), wantedLevel, MinWantedLevel, MaxWantedLevel);
+            return Function.Call<float>(Hash.GET_WANTED_LEVEL_RADIUS, wantedLevel);
+        }
+
+        /// <summary>
+        /// Gets the minimum threshold of a specified wanted level at which <see cref="Wanted.CurrentCrimeValue"/> must
+        /// be or above so the <see cref="Player"/> will have said wanted level or greater one.
+        /// </summary>
+        /// <param name="wantedLevel">The wanted level to retrieve the minimum threshold.</param>
+        /// <returns>
+        /// The minimum threshold of a specified wanted level (the same unit as <see cref="Wanted.CurrentCrimeValue"/>).
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="wantedLevel"/> is not between 0 and 5, inclusive.
+        /// </exception>
+        public static int GetWantedLevelThreshold(int wantedLevel)
+        {
+            // The native doesn't test if the arg is in the value range in final builds and the native indirectly
+            // accesses an array of the singleton `CDispatchData` out of bounds if the arg is out of the value range,
+            // so we need to test that instead.
+            ThrowHelper.CheckArgumentRange(nameof(wantedLevel), wantedLevel, MinWantedLevel, MaxWantedLevel);
+            return Function.Call<int>(Hash.GET_WANTED_LEVEL_THRESHOLD, wantedLevel);
+        }
+
+        // `GET_WANTED_LEVEL_TIME_TO_ESCAPE` gets a parole value from `CDispatchData::GetParoleDuration()`. However,
+        // the parole duration is used only when `CDispatchData::sm_bEnableRadiusEvasion` is `true`, which can't be
+        // `true` in final builds. The variable can be set to `true` only by `CWanted::InitWidgets` (or direct memory
+        // editing).
+    }
+}

--- a/source/scripting_v3/GTA/DispatchData.cs
+++ b/source/scripting_v3/GTA/DispatchData.cs
@@ -18,9 +18,9 @@ namespace GTA
         private const int MaxWantedLevel = 5;
 
         /// <summary>
-        /// Gets the wanted radius for a specified wanted level. Can affect the difficulty level of <see cref="Wanted"/>
-        /// by the distance between the last spotted position and the current player position, and by the wanted radius
-        /// value.
+        /// Gets the wanted radius for a specified wanted level. The raduis value can affect the difficulty level of
+        /// <see cref="Wanted"/> by the distance between the last spotted position and the current player position, and
+        /// by the wanted radius value.
         /// </summary>
         /// <param name="wantedLevel">The wanted level to retrieve the wanted radius.</param>
         /// <returns>The wanted level radius.</returns>
@@ -42,7 +42,8 @@ namespace GTA
         /// </summary>
         /// <param name="wantedLevel">The wanted level to retrieve the minimum threshold.</param>
         /// <returns>
-        /// The minimum threshold of a specified wanted level (the same unit as <see cref="Wanted.CurrentCrimeValue"/>).
+        /// The minimum threshold of the specified wanted level (the same unit as
+        /// <see cref="Wanted.CurrentCrimeValue"/>).
         /// </returns>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="wantedLevel"/> is not between 0 and 5, inclusive.

--- a/source/scripting_v3/GTA/Player.cs
+++ b/source/scripting_v3/GTA/Player.cs
@@ -14,7 +14,8 @@ namespace GTA
     public sealed class Player : INativeValue
     {
         #region Fields
-        Ped _ped;
+        private Ped _ped;
+        private Wanted _wanted;
         #endregion
 
         internal Player(int handle)
@@ -60,6 +61,11 @@ namespace GTA
                 return _ped;
             }
         }
+
+        /// <summary>
+        /// Gets the wanted info.
+        /// </summary>
+        public Wanted Wanted => _wanted ??= new Wanted(Handle);
 
         /// <summary>
         /// Gets the Social Club name of this <see cref="Player"/>.
@@ -275,7 +281,10 @@ namespace GTA
         /// </remarks>
         public int WantedLevel
         {
+            [Obsolete("Use `GTA.Wanted.WantedLevel` instead via the property `GTA.Player.Wanted`.")]
             get => Function.Call<int>(Hash.GET_PLAYER_WANTED_LEVEL, Handle);
+            [Obsolete("Use the combination of `SetWantedLevel` and `ApplyWantedLevelChangeNow` of `GTA.Wanted` " +
+                      "instead via the property `GTA.Player.Wanted`.")]
             set
             {
                 Function.Call(Hash.SET_PLAYER_WANTED_LEVEL, Handle, value, false);
@@ -291,275 +300,11 @@ namespace GTA
         /// </value>
         public Vector3 WantedCenterPosition
         {
+            [Obsolete("Use `GTA.Wanted.LastPositionSpottedByPolice` instead via the property `GTA.Player.Wanted`.")]
             get => Function.Call<Vector3>(Hash.GET_PLAYER_WANTED_CENTRE_POSITION, Handle);
+            [Obsolete("Use `GTA.Wanted.SetRadiusCenter` instead via the property `GTA.Player.Wanted`.")]
             set => Function.Call(Hash.SET_PLAYER_WANTED_CENTRE_POSITION, Handle, value.X, value.Y, value.Z);
         }
-
-        /// <summary>
-        /// Gets or sets the current crime value that determines the real wanted level when the game updates the real wanted level.
-        /// </summary>
-        /// <remarks>
-        /// For instance, if this value is 32 and a vehicle theft crime you started gets reported (increases by 18) without crime directly getting spotted by the police,
-        /// this value will be 50 and the wanted level will be one when the game updates the real wanted level using this value.
-        /// </remarks>
-        /// <value>
-        /// The current crime value.
-        /// </value>
-        public int CurrentCrimeValue
-        {
-            get
-            {
-                if (SHVDN.NativeMemory.CurrentCrimeValueOffset == 0)
-                {
-                    return 0;
-                }
-
-                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(Handle);
-                if (cWantedAddress == IntPtr.Zero)
-                {
-                    return 0;
-                }
-
-                return SHVDN.MemDataMarshal.ReadInt32(cWantedAddress + SHVDN.NativeMemory.CurrentCrimeValueOffset);
-            }
-            set
-            {
-                if (SHVDN.NativeMemory.CurrentCrimeValueOffset == 0)
-                {
-                    return;
-                }
-
-                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(Handle);
-                if (cWantedAddress == IntPtr.Zero)
-                {
-                    return;
-                }
-
-                SHVDN.MemDataMarshal.WriteInt32(cWantedAddress + SHVDN.NativeMemory.CurrentCrimeValueOffset, value);
-            }
-        }
-        /// <summary>
-        /// Gets or sets the pending crime value that will be applied when the game ticks
-        /// if <see cref="TimeWhenNewCrimeValueTakesEffect"/> is not zero and less than <see cref="Game.GameTime"/>.
-        /// </summary>
-        /// <remarks>
-        /// The game sets this value only when this <see cref="Player"/> commit a crime that will immediately increase their wanted level such as targeting a police officer,
-        /// when <c>SET_PLAYER_WANTED_LEVEL</c> is called and the wanted level is to increase, or when the game applies this value to <see cref="CurrentCrimeValue"/>.
-        /// </remarks>
-        /// <value>
-        /// The pending crime value.
-        /// </value>
-        public int NewCrimeValue
-        {
-            get
-            {
-                if (SHVDN.NativeMemory.NewCrimeValueOffset == 0)
-                {
-                    return 0;
-                }
-
-                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(Handle);
-                if (cWantedAddress == IntPtr.Zero)
-                {
-                    return 0;
-                }
-
-                return SHVDN.MemDataMarshal.ReadInt32(cWantedAddress + SHVDN.NativeMemory.NewCrimeValueOffset);
-            }
-            set
-            {
-                if (SHVDN.NativeMemory.NewCrimeValueOffset == 0)
-                {
-                    return;
-                }
-
-                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(Handle);
-                if (cWantedAddress == IntPtr.Zero)
-                {
-                    return;
-                }
-
-                SHVDN.MemDataMarshal.WriteInt32(cWantedAddress + SHVDN.NativeMemory.NewCrimeValueOffset, value);
-            }
-        }
-        /// <summary>
-        /// Gets or sets the game time when <see cref="NewCrimeValue"/> will be set to <see cref="CurrentCrimeValue"/>.
-        /// If zero, the game will not apply <see cref="NewCrimeValue"/>.
-        /// </summary>
-        /// <remarks>
-        /// The game sets this value only when <c>SET_PLAYER_WANTED_LEVEL</c> is called and the wanted level is to increase
-        /// or when the game applies <see cref="NewCrimeValue"/> to <see cref="CurrentCrimeValue"/> and set this value to zero.
-        /// </remarks>
-        /// <value>
-        /// The game time when <see cref="NewCrimeValue"/> will be set to <see cref="CurrentCrimeValue"/>.
-        /// </value>
-        public int TimeWhenNewCrimeValueTakesEffect
-        {
-            get
-            {
-                if (SHVDN.NativeMemory.TimeWhenNewCrimeValueTakesEffectOffset == 0)
-                {
-                    return 0;
-                }
-
-                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(Handle);
-                if (cWantedAddress == IntPtr.Zero)
-                {
-                    return 0;
-                }
-
-                return SHVDN.MemDataMarshal.ReadInt32(cWantedAddress + SHVDN.NativeMemory.TimeWhenNewCrimeValueTakesEffectOffset);
-            }
-            set
-            {
-                if (SHVDN.NativeMemory.TimeWhenNewCrimeValueTakesEffectOffset == 0)
-                {
-                    return;
-                }
-
-                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(Handle);
-                if (cWantedAddress == IntPtr.Zero)
-                {
-                    return;
-                }
-
-                SHVDN.MemDataMarshal.WriteInt32(cWantedAddress + SHVDN.NativeMemory.TimeWhenNewCrimeValueTakesEffectOffset, value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the last time when the search area got refocused for this <see cref="Player"/>.
-        /// When you commit a crime that refocus the search area, this value will update.
-        /// </summary>
-        /// <remarks>
-        /// The game will set this value to zero when the wanted level is zero.
-        /// </remarks>
-        public int TimeSearchLastRefocused
-        {
-            get
-            {
-                if (SHVDN.NativeMemory.CWantedTimeSearchLastRefocusedOffset == 0)
-                {
-                    return 0;
-                }
-
-                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(Handle);
-                if (cWantedAddress == IntPtr.Zero)
-                {
-                    return 0;
-                }
-
-                return SHVDN.MemDataMarshal.ReadInt32(cWantedAddress + SHVDN.NativeMemory.CWantedTimeSearchLastRefocusedOffset);
-            }
-            set
-            {
-                if (SHVDN.NativeMemory.CWantedTimeSearchLastRefocusedOffset == 0)
-                {
-                    return;
-                }
-
-                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(Handle);
-                if (cWantedAddress == IntPtr.Zero)
-                {
-                    return;
-                }
-
-                SHVDN.MemDataMarshal.WriteInt32(cWantedAddress + SHVDN.NativeMemory.CWantedTimeSearchLastRefocusedOffset, value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the last game time when this <see cref="Player"/> is spotted by the police.
-        /// The game will set this value to zero when the wanted level is zero.
-        /// </summary>
-        /// <remarks>
-        /// The game will set to the game time as long as this <see cref="Player"/> is spotted by the police each frame,
-        /// but you can make the <see cref="Player"/> getting in the hidden evasion phase up to 1 or 2 seconds if the police does not know where the <see cref="Player"/> is.
-        /// </remarks>
-        public int TimeLastSpotted
-        {
-            get
-            {
-                if (SHVDN.NativeMemory.CWantedTimeLastSpottedOffset == 0)
-                {
-                    return 0;
-                }
-
-                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(Handle);
-                if (cWantedAddress == IntPtr.Zero)
-                {
-                    return 0;
-                }
-
-                return SHVDN.MemDataMarshal.ReadInt32(cWantedAddress + SHVDN.NativeMemory.CWantedTimeLastSpottedOffset);
-            }
-            set
-            {
-                if (SHVDN.NativeMemory.CWantedTimeLastSpottedOffset == 0)
-                {
-                    return;
-                }
-
-                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(Handle);
-                if (cWantedAddress == IntPtr.Zero)
-                {
-                    return;
-                }
-
-                SHVDN.MemDataMarshal.WriteInt32(cWantedAddress + SHVDN.NativeMemory.CWantedTimeLastSpottedOffset, value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the game time when hidden evasion phase gets started.
-        /// </summary>
-        /// <remarks>
-        /// The game will set to zero when this <see cref="Player"/> is spotted by the police each frame,
-        /// but you can set small value (but not zero) to clear the wanted level when the <see cref="Player"/> is in the hidden evasion phase
-        /// if not suppressed by <c>SUPPRESS_LOSING_WANTED_LEVEL_IF_HIDDEN_THIS_FRAME</c>.
-        /// </remarks>
-        public int TimeHiddenEvasionStarted
-        {
-            get
-            {
-                if (SHVDN.NativeMemory.CWantedTimeHiddenEvasionStartedOffset == 0)
-                {
-                    return 0;
-                }
-
-                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(Handle);
-                if (cWantedAddress == IntPtr.Zero)
-                {
-                    return 0;
-                }
-
-                return SHVDN.MemDataMarshal.ReadInt32(cWantedAddress + SHVDN.NativeMemory.CWantedTimeHiddenEvasionStartedOffset);
-            }
-            set
-            {
-                if (SHVDN.NativeMemory.CWantedTimeHiddenEvasionStartedOffset == 0)
-                {
-                    return;
-                }
-
-                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(Handle);
-                if (cWantedAddress == IntPtr.Zero)
-                {
-                    return;
-                }
-
-                SHVDN.MemDataMarshal.WriteInt32(cWantedAddress + SHVDN.NativeMemory.CWantedTimeHiddenEvasionStartedOffset, value);
-            }
-        }
-        /// <summary>
-        /// Returns <see langword="true"/> if this <see cref="Player"/> has a wanted level and the stars are displayed gray.
-        /// </summary>
-        /// <remarks>
-        /// Technically, this property returns <see langword="true"/> when the flag for stars graying out is set
-        /// and <see cref="TimeLastSpotted"/> has more value by more than <c>1000</c> or <c>2000</c> (depending on a unknown state)
-        /// than <see cref="Game.GameTime"/>.
-        /// </remarks>
-        public bool AreWantedStarsGrayedOut => Function.Call<bool>(Hash.ARE_PLAYER_STARS_GREYED_OUT, Handle);
 
         /// <summary>
         /// Gets or sets a value indicating whether this <see cref="Player"/> is ignored by the police.
@@ -569,6 +314,7 @@ namespace GTA
         /// </value>
         public bool IgnoredByPolice
         {
+            [Obsolete("Use `GTA.Wanted.PoliceBackOff` instead via the property `GTA.Player.Wanted`.")]
             get
             {
                 if (SHVDN.NativeMemory.CWantedIgnorePlayerFlagOffset == 0)
@@ -584,6 +330,7 @@ namespace GTA
 
                 return SHVDN.MemDataMarshal.IsBitSet(cWantedAddress + SHVDN.NativeMemory.CWantedIgnorePlayerFlagOffset, 16);
             }
+            [Obsolete("Use `GTA.Wanted.SetPoliceIgnorePlayer` instead via the property `GTA.Player.Wanted`.")]
             set => Function.Call(Hash.SET_POLICE_IGNORE_PLAYER, Handle, value);
         }
 
@@ -595,6 +342,7 @@ namespace GTA
         /// </value>
         public bool IgnoredByEveryone
         {
+            [Obsolete("Use `GTA.Wanted.EveryoneBackOff` instead via the property `GTA.Player.Wanted`.")]
             get
             {
                 if (SHVDN.NativeMemory.CWantedIgnorePlayerFlagOffset == 0)
@@ -610,6 +358,7 @@ namespace GTA
 
                 return SHVDN.MemDataMarshal.IsBitSet(cWantedAddress + SHVDN.NativeMemory.CWantedIgnorePlayerFlagOffset, 18);
             }
+            [Obsolete("Use `GTA.Wanted.SetEveryoneIgnorePlayer` instead via the property `GTA.Player.Wanted`.")]
             set => Function.Call(Hash.SET_EVERYONE_IGNORE_PLAYER, Handle, value);
         }
 
@@ -619,6 +368,7 @@ namespace GTA
         /// <value>
         /// <see langword="true" /> if cops will be dispatched; otherwise, <see langword="false" />.
         /// </value>
+        [Obsolete("Use `GTA.Wanted.DispatchesCopsForPlayer` instead via the property `GTA.Player.Wanted`.")]
         public bool DispatchsCops
         {
             get
@@ -638,96 +388,6 @@ namespace GTA
             }
             set => Function.Call(Hash.SET_DISPATCH_COPS_FOR_PLAYER, Handle, value);
         }
-
-        /// <summary>
-        /// Sets the "new" wanted level for the player.
-        /// The current wanted level changes takes 10 seconds before it gets applied (emulating the time it takes
-        /// a citizen to report the crime) if the passed wanted level is higher than the current.
-        /// Otherwise, the change will get applied immediately, including <see cref="CurrentCrimeValue"/> and
-        /// <see cref="WantedCenterPosition"/>.
-        /// </summary>
-        public void SetNewWantedLevel(int wantedLevel, bool delayLawResponse = false)
-            => Function.Call(Hash.SET_PLAYER_WANTED_LEVEL, Handle, wantedLevel, delayLawResponse);
-
-        /// <summary>
-        /// Sets the "new" wanted level for the player only if its higher than the current.
-        /// The current wanted level changes takes 10 seconds before it gets applied.
-        /// </summary>
-        public void SetNewWantedLevelNoDrop(int wantedLevel, bool delayLawResponse = false)
-            => Function.Call(Hash.SET_PLAYER_WANTED_LEVEL_NO_DROP, Handle, wantedLevel, delayLawResponse);
-
-        /// <summary>
-        /// Sets the wanted level for this <see cref="Player"/> but without refocusing the search area.
-        /// </summary>
-        /// <remarks>
-        /// When the previous wanted level is zero, you cannot avoid refocusing the search area with this method.
-        /// </remarks>
-        public void SetWantedLevelNoRefocusSearchArea(int wantedLevel)
-        {
-            if (SHVDN.NativeMemory.CurrentCrimeValueOffset == 0 || SHVDN.NativeMemory.CurrentWantedLevelOffset == 0)
-            {
-                return;
-            }
-
-            IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(Handle);
-            if (cWantedAddress == IntPtr.Zero)
-            {
-                return;
-            }
-
-            int currentWantedLevel = SHVDN.MemDataMarshal.ReadInt32(cWantedAddress + SHVDN.NativeMemory.CurrentWantedLevelOffset);
-
-            if (wantedLevel <= 0 || wantedLevel >= currentWantedLevel)
-            {
-                // Just call SET_PLAYER_WANTED_LEVEL and SET_PLAYER_WANTED_LEVEL_NOW, because setting to the current wanted level or above won't refocus the search area (the crime value will be reset)
-                Function.Call(Hash.SET_PLAYER_WANTED_LEVEL, Handle, wantedLevel, false);
-                Function.Call(Hash.SET_PLAYER_WANTED_LEVEL_NOW, Handle, false);
-                return;
-            }
-
-            // Clamps and/or sets the wanted level just like SET_PLAYER_WANTED_LEVEL does
-            int wantedLevelToApply = wantedLevel;
-            if (wantedLevelToApply >= 6)
-            {
-                wantedLevelToApply = 5;
-            }
-
-            // This additional crime value is hardcoded in a function that is called by SET_PLAYER_WANTED_LEVEL
-            const int ADDITIONAL_CRIME_VALUE = 20;
-            int threshold = Function.Call<int>(Hash.GET_WANTED_LEVEL_THRESHOLD, Handle, wantedLevelToApply);
-
-            CurrentCrimeValue = threshold + ADDITIONAL_CRIME_VALUE;
-            SHVDN.MemDataMarshal.WriteInt32(cWantedAddress + SHVDN.NativeMemory.CurrentWantedLevelOffset, wantedLevelToApply);
-
-            // Set the pending crime value just like SET_PLAYER_WANTED_LEVEL does (SET_PLAYER_WANTED_LEVEL_NOW does not clear the value)
-            NewCrimeValue = threshold + ADDITIONAL_CRIME_VALUE;
-        }
-
-        /// <summary>
-        /// Reports a crime for this <see cref="Player"/>.
-        /// </summary>
-        /// <param name="crimeToReport">The crime time to report.</param>
-        /// <param name="crimeValue">
-        /// If left at zero, the crime will get evaluated.
-        /// It not zero, the crime value will be overridden to specify an amount (can be both positive or negative).
-        /// </param>
-        /// <remarks>
-        /// Clearing the wanted level will disable to increase the crime value for commiting crimes for 2 seconds.
-        /// </remarks>
-        public void ReportCrime(CrimeType crimeToReport, int crimeValue = 0) => Function.Call(Hash.REPORT_CRIME, Handle, (int)crimeToReport, crimeValue);
-
-        /// <summary>
-        /// Forces this <see cref="Player"/> to get spotted by police.
-        /// </summary>
-        /// <remarks>
-        /// Unlike when you commit a crime that refocuses the search area, this method also updates <see cref="TimeLastSpotted"/>.
-        /// </remarks>
-        public void ReportPoliceSpottingPlayer() => Function.Call(Hash.REPORT_POLICE_SPOTTED_PLAYER, Handle);
-        /// <summary>
-        /// Force hidden evasion to start for this <see cref="Player"/>, making wanted stars flashing and cops using vision cones to search for the player.
-        /// You can use this method at any point that police know where this player is.
-        /// </summary>
-        public void ForceStartHiddenEvasion() => Function.Call(Hash.FORCE_START_HIDDEN_EVASION, Handle);
 
         #endregion
 

--- a/source/scripting_v3/GTA/Wanted.cs
+++ b/source/scripting_v3/GTA/Wanted.cs
@@ -32,8 +32,8 @@ namespace GTA
         /// Will refocus the search area if you set a value less than the current value and is not zero.
         /// </para>
         /// <para>
-        /// Hardcoded to clamp to at most 5 since <c>SET_PLAYER_WANTED_LEVEL</c> just sets the pending crime value to zero
-        /// when passed wanted level is a value other than from 1 to 5 (inclusive).
+        /// Hardcoded to clamp to at most 5 since <c>SET_PLAYER_WANTED_LEVEL</c> just sets the pending crime value to
+        /// zero when passed wanted level is a value other than from 1 to 5 (inclusive).
         /// Also, the game does not read <c>WantedLevel6</c> items from <c>dispatch.meta</c>.
         /// </para>
         /// </remarks>
@@ -269,7 +269,8 @@ namespace GTA
                     return;
                 }
 
-                SHVDN.MemDataMarshal.WriteInt32(cWantedAddress + SHVDN.NativeMemory.TimeWhenNewCrimeValueTakesEffectOffset, value);
+                SHVDN.MemDataMarshal.WriteInt32(cWantedAddress
+                    + SHVDN.NativeMemory.TimeWhenNewCrimeValueTakesEffectOffset, value);
             }
         }
 
@@ -321,9 +322,9 @@ namespace GTA
         /// The game will set this value to zero when the wanted level is zero.
         /// </summary>
         /// <remarks>
-        /// The game will set to the game time as long as this <see cref="Player"/> is spotted by the police each frame,
-        /// but you can make the <see cref="Player"/> getting in the hidden evasion phase up to 1 or 2 seconds if
-        /// the police does not know where the <see cref="Player"/> is.
+        /// The game will set to the game time as long as this <see cref="Player"/> is spotted by the police each
+        /// frame, but you can make the <see cref="Player"/> getting in the hidden evasion phase up to 1 or 2 seconds
+        /// if the police does not know where the <see cref="Player"/> is.
         /// </remarks>
         public int TimeLastSpotted
         {
@@ -483,8 +484,8 @@ namespace GTA
         }
 
         /// <summary>
-        /// Sets <see cref="EverybodyBackOff"/> to a specified value. Also stops every law enforcement vehicles that has
-        /// a NPC driver by setting the velocity to the zero vector if set to <see langword="true"/>.
+        /// Sets <see cref="EverybodyBackOff"/> to a specified value. Also stops every law enforcement vehicles that
+        /// has a NPC driver by setting the velocity to the zero vector if set to <see langword="true"/>.
         /// </summary>
         /// <param name="value">
         /// <see langword="true"/> if this <see cref="Player"/> should be ignored by everyone; otherwise,

--- a/source/scripting_v3/GTA/Wanted.cs
+++ b/source/scripting_v3/GTA/Wanted.cs
@@ -1,0 +1,605 @@
+//
+// Copyright (C) 2025 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+using System;
+using GTA.Math;
+using GTA.Native;
+
+namespace GTA
+{
+    /// <summary>
+    /// Represents a data of player wanted info.
+    /// </summary>
+    /// <remarks>
+    /// For dispatch data, see <see cref="DispatchData"/>.
+    /// </remarks>
+    public class Wanted
+    {
+        internal Wanted(int playerIndex)
+        {
+            _playerIndex = playerIndex;
+        }
+
+        private readonly int _playerIndex;
+
+        /// <summary>
+        /// Gets or sets the wanted level for this <see cref="Player"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Will refocus the search area if you set a value less than the current value and is not zero.
+        /// </para>
+        /// <para>
+        /// Hardcoded to clamp to at most 5 since <c>SET_PLAYER_WANTED_LEVEL</c> just sets the pending crime value to zero
+        /// when passed wanted level is a value other than from 1 to 5 (inclusive).
+        /// Also, the game does not read <c>WantedLevel6</c> items from <c>dispatch.meta</c>.
+        /// </para>
+        /// </remarks>
+        public int WantedLevel
+        {
+            get => Function.Call<int>(Hash.GET_PLAYER_WANTED_LEVEL, _playerIndex);
+        }
+
+        /// <summary>
+        /// Sets the wanted level to a specified value with the 10-second delay. If <paramref name="newLevel"/> is
+        /// the same as <see cref="WantedLevel"/> or smaller, the change will get applied immediately.
+        /// </summary>
+        /// <param name="newLevel">The new wanted level to set.</param>
+        /// <param name="delayLawResponse">
+        /// If <see langword="true"/>, law response will be delayed and the hidden evasion will get started later
+        /// because of the law response delay.
+        /// The law response delay time varies for population zones and the delay time for the population zone where
+        /// the <see cref="Player"/> <see cref="Ped"/> is in will be used.
+        /// </param>
+        /// <remarks>
+        /// <para>
+        /// The wanted level change will not take place for 10 seconds (emulating the time it takes a citizen to report
+        /// the crime) unless <paramref name="newLevel"/> is the same as <see cref="WantedLevel"/> or smaller.
+        /// Call <see cref="ApplyWantedLevelChangeNow"/> after this method if you wish to apply the new wanted level
+        /// without having to wait for 10 seconds. If <paramref name="newLevel"/> is the same as
+        /// <see cref="WantedLevel"/> or smaller, the change will get applied immediately, as well as the changes of
+        /// <see cref="CurrentCrimeValue"/> and <see cref="LastPositionSpottedByPolice"/>.
+        /// </para>
+        /// <para>
+        /// Will refocus the search area if you set a value less than the current value and is not zero.
+        /// </para>
+        /// <para>
+        /// Hardcoded to clamp to at most 5 since <c>SET_PLAYER_WANTED_LEVEL</c> just sets <see cref="NewCrimeValue"/>
+        /// to zero when passed wanted level is a value other than from 1 to 5 (inclusive).
+        /// Also, the game does not read <c>WantedLevel6</c> items from <c>dispatch.meta</c>.
+        /// </para>
+        /// </remarks>
+        public void SetWantedLevel(int newLevel, bool delayLawResponse)
+        {
+            Function.Call(Hash.SET_PLAYER_WANTED_LEVEL, _playerIndex, newLevel, delayLawResponse);
+        }
+
+        /// <summary>
+        /// Sets the wanted level with the 10-second delay if <paramref name="newLevel"/> is greater than
+        /// <see cref="WantedLevel"/> and the desired crime value (threshold) is more than
+        /// <see cref="CurrentCrimeValue"/> or the same.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The wanted level change will not take place for 10 seconds (emulating the time it takes a citizen to report
+        /// the crime). Call <see cref="ApplyWantedLevelChangeNow"/> after this method if you wish to apply the new
+        /// wanted level without having to wait for 10 seconds.
+        /// </para>
+        /// <para>
+        /// Hardcoded to clamp to at most 5 since <c>SET_PLAYER_WANTED_LEVEL</c> just sets <see cref="NewCrimeValue"/>
+        /// to zero when passed wanted level is a value other than from 1 to 5 (inclusive).
+        /// Also, the game does not read <c>WantedLevel6</c> items from <c>dispatch.meta</c>.
+        /// </para>
+        /// </remarks>
+        /// <inheritdoc cref="SetWantedLevel"/>
+        public void SetWantedLevelNoDrop(int newLevel, bool delayLawResponse)
+        {
+            Function.Call(Hash.SET_PLAYER_WANTED_LEVEL_NO_DROP, _playerIndex, newLevel, delayLawResponse);
+        }
+
+        /// <summary>
+        /// Applies <see cref="NewCrimeValue"/> immediately, which can be set with <see cref="SetWantedLevel"/> and
+        /// <see cref="SetWantedLevelNoDrop"/>.
+        /// </summary>
+        /// <param name="delayLawResponse">
+        /// If <see langword="true"/>, law response will be delayed and the hidden evasion will get started later
+        /// because of the law response delay.
+        /// The law response delay time varies for population zones and the delay time for the population zone where
+        /// the <see cref="Player"/> <see cref="Ped"/> is in will be used.
+        /// </param>
+        public void ApplyWantedLevelChangeNow(bool delayLawResponse)
+        {
+            Function.Call(Hash.SET_PLAYER_WANTED_LEVEL_NOW, _playerIndex, delayLawResponse);
+        }
+
+        /// <summary>
+        /// Gets the last position spotted by police for this <see cref="Player"/>.
+        /// </summary>
+        /// <value>
+        /// The place in world coordinates where the last position spotted by police.
+        /// </value>
+        public Vector3 LastPositionSpottedByPolice
+        {
+            get => Function.Call<Vector3>(Hash.GET_PLAYER_WANTED_CENTRE_POSITION, _playerIndex);
+        }
+
+        /// <summary>
+        /// Sets <see cref="LastPositionSpottedByPolice"/> and the center position of the current search area.
+        /// </summary>
+        public void SetRadiusCenter(Vector3 pos)
+        {
+            Function.Call(Hash.SET_PLAYER_WANTED_CENTRE_POSITION, _playerIndex, pos.X, pos.Y, pos.Z);
+        }
+
+        /// <summary>
+        /// Gets or sets the current crime value that determines the real wanted level when the game updates the real
+        /// wanted level.
+        /// </summary>
+        /// <remarks>
+        /// For instance, if this value is 32 and a vehicle theft crime you started gets reported (increases by 18)
+        /// without crime directly getting spotted by the police,
+        /// this value will be 50 and the wanted level will be one when the game updates the real wanted level using
+        /// this value.
+        /// </remarks>
+        /// <value>
+        /// The current crime value.
+        /// </value>
+        public int CurrentCrimeValue
+        {
+            get
+            {
+                if (SHVDN.NativeMemory.CurrentCrimeValueOffset == 0)
+                {
+                    return 0;
+                }
+
+                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(_playerIndex);
+                if (cWantedAddress == IntPtr.Zero)
+                {
+                    return 0;
+                }
+
+                return SHVDN.MemDataMarshal.ReadInt32(cWantedAddress + SHVDN.NativeMemory.CurrentCrimeValueOffset);
+            }
+            set
+            {
+                if (SHVDN.NativeMemory.CurrentCrimeValueOffset == 0)
+                {
+                    return;
+                }
+
+                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(_playerIndex);
+                if (cWantedAddress == IntPtr.Zero)
+                {
+                    return;
+                }
+
+                SHVDN.MemDataMarshal.WriteInt32(cWantedAddress + SHVDN.NativeMemory.CurrentCrimeValueOffset, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the pending/new crime value that will be applied when the game ticks
+        /// if <see cref="TimeWhenNewCrimeValueTakesEffect"/> is not zero and less than <see cref="Game.GameTime"/>.
+        /// </summary>
+        /// <remarks>
+        /// The game sets this value only when this <see cref="Player"/> commit a crime that will immediately increase
+        /// their wanted level such as targeting a police officer, when <c>SET_PLAYER_WANTED_LEVEL</c> (which
+        /// <see cref="SetWantedLevel"/> calls) is called and the wanted level is to increase, or when the game applies
+        /// this value to <see cref="CurrentCrimeValue"/>.
+        /// </remarks>
+        /// <value>
+        /// The pending/new crime value.
+        /// </value>
+        public int NewCrimeValue
+        {
+            get
+            {
+                if (SHVDN.NativeMemory.NewCrimeValueOffset == 0)
+                {
+                    return 0;
+                }
+
+                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(_playerIndex);
+                if (cWantedAddress == IntPtr.Zero)
+                {
+                    return 0;
+                }
+
+                return SHVDN.MemDataMarshal.ReadInt32(cWantedAddress + SHVDN.NativeMemory.NewCrimeValueOffset);
+            }
+            set
+            {
+                if (SHVDN.NativeMemory.NewCrimeValueOffset == 0)
+                {
+                    return;
+                }
+
+                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(_playerIndex);
+                if (cWantedAddress == IntPtr.Zero)
+                {
+                    return;
+                }
+
+                SHVDN.MemDataMarshal.WriteInt32(cWantedAddress + SHVDN.NativeMemory.NewCrimeValueOffset, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the game time when <see cref="NewCrimeValue"/> will be set to <see cref="CurrentCrimeValue"/>.
+        /// If zero, the game will not apply <see cref="NewCrimeValue"/>.
+        /// </summary>
+        /// <remarks>
+        /// The game sets this value only when <c>SET_PLAYER_WANTED_LEVEL</c> is called and the wanted level is to
+        /// increase or when the game applies <see cref="NewCrimeValue"/> to <see cref="CurrentCrimeValue"/> and set
+        /// this value to zero.
+        /// </remarks>
+        /// <value>
+        /// The game time when <see cref="NewCrimeValue"/> will be set to <see cref="CurrentCrimeValue"/>.
+        /// </value>
+        public int TimeWhenNewCrimeValueTakesEffect
+        {
+            get
+            {
+                if (SHVDN.NativeMemory.TimeWhenNewCrimeValueTakesEffectOffset == 0)
+                {
+                    return 0;
+                }
+
+                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(_playerIndex);
+                if (cWantedAddress == IntPtr.Zero)
+                {
+                    return 0;
+                }
+
+                return SHVDN.MemDataMarshal.ReadInt32(cWantedAddress + SHVDN.NativeMemory.TimeWhenNewCrimeValueTakesEffectOffset);
+            }
+            set
+            {
+                if (SHVDN.NativeMemory.TimeWhenNewCrimeValueTakesEffectOffset == 0)
+                {
+                    return;
+                }
+
+                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(_playerIndex);
+                if (cWantedAddress == IntPtr.Zero)
+                {
+                    return;
+                }
+
+                SHVDN.MemDataMarshal.WriteInt32(cWantedAddress + SHVDN.NativeMemory.TimeWhenNewCrimeValueTakesEffectOffset, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the last time when the search area got refocused for this <see cref="Player"/>.
+        /// When you commit a crime that refocus the search area, this value will update.
+        /// </summary>
+        /// <remarks>
+        /// The game will set this value to zero when the wanted level is zero.
+        /// </remarks>
+        public int TimeSearchLastRefocused
+        {
+            get
+            {
+                if (SHVDN.NativeMemory.CWantedTimeSearchLastRefocusedOffset == 0)
+                {
+                    return 0;
+                }
+
+                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(_playerIndex);
+                if (cWantedAddress == IntPtr.Zero)
+                {
+                    return 0;
+                }
+
+                return SHVDN.MemDataMarshal.ReadInt32(cWantedAddress
+                                                      + SHVDN.NativeMemory.CWantedTimeSearchLastRefocusedOffset);
+            }
+            set
+            {
+                if (SHVDN.NativeMemory.CWantedTimeSearchLastRefocusedOffset == 0)
+                {
+                    return;
+                }
+
+                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(_playerIndex);
+                if (cWantedAddress == IntPtr.Zero)
+                {
+                    return;
+                }
+
+                SHVDN.MemDataMarshal.WriteInt32(cWantedAddress
+                                                + SHVDN.NativeMemory.CWantedTimeSearchLastRefocusedOffset, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the last game time when this <see cref="Player"/> is spotted by the police.
+        /// The game will set this value to zero when the wanted level is zero.
+        /// </summary>
+        /// <remarks>
+        /// The game will set to the game time as long as this <see cref="Player"/> is spotted by the police each frame,
+        /// but you can make the <see cref="Player"/> getting in the hidden evasion phase up to 1 or 2 seconds if
+        /// the police does not know where the <see cref="Player"/> is.
+        /// </remarks>
+        public int TimeLastSpotted
+        {
+            get
+            {
+                if (SHVDN.NativeMemory.CWantedTimeLastSpottedOffset == 0)
+                {
+                    return 0;
+                }
+
+                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(_playerIndex);
+                if (cWantedAddress == IntPtr.Zero)
+                {
+                    return 0;
+                }
+
+                return SHVDN.MemDataMarshal.ReadInt32(cWantedAddress
+                                                      + SHVDN.NativeMemory.CWantedTimeLastSpottedOffset);
+            }
+            set
+            {
+                if (SHVDN.NativeMemory.CWantedTimeLastSpottedOffset == 0)
+                {
+                    return;
+                }
+
+                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(_playerIndex);
+                if (cWantedAddress == IntPtr.Zero)
+                {
+                    return;
+                }
+
+                SHVDN.MemDataMarshal.WriteInt32(cWantedAddress + SHVDN.NativeMemory.CWantedTimeLastSpottedOffset, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the game time when hidden evasion phase gets started.
+        /// </summary>
+        /// <remarks>
+        /// The game will set to zero when this <see cref="Player"/> is spotted by the police each frame,
+        /// but you can set small value (but not zero) to clear the wanted level when the <see cref="Player"/> is in
+        /// the hidden evasion phase if not suppressed by <c>SUPPRESS_LOSING_WANTED_LEVEL_IF_HIDDEN_THIS_FRAME</c>.
+        /// </remarks>
+        public int TimeHiddenEvasionStarted
+        {
+            get
+            {
+                if (SHVDN.NativeMemory.CWantedTimeHiddenEvasionStartedOffset == 0)
+                {
+                    return 0;
+                }
+
+                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(_playerIndex);
+                if (cWantedAddress == IntPtr.Zero)
+                {
+                    return 0;
+                }
+
+                return SHVDN.MemDataMarshal.ReadInt32(cWantedAddress
+                                                      + SHVDN.NativeMemory.CWantedTimeHiddenEvasionStartedOffset);
+            }
+            set
+            {
+                if (SHVDN.NativeMemory.CWantedTimeHiddenEvasionStartedOffset == 0)
+                {
+                    return;
+                }
+
+                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(_playerIndex);
+                if (cWantedAddress == IntPtr.Zero)
+                {
+                    return;
+                }
+
+                SHVDN.MemDataMarshal.WriteInt32(cWantedAddress
+                                                + SHVDN.NativeMemory.CWantedTimeHiddenEvasionStartedOffset, value);
+            }
+        }
+        /// <summary>
+        /// Returns <see langword="true"/> if this <see cref="Wanted"/> has a wanted level and the stars are displayed
+        /// gray to indicate that cops are searching.
+        /// </summary>
+        /// <remarks>
+        /// Technically, this property returns <see langword="true"/> when the flag for stars graying out is set
+        /// and <see cref="TimeLastSpotted"/> has more value by more than <c>1000</c> or <c>2000</c> (depending on
+        /// an unknown state).
+        /// than <see cref="Game.GameTime"/>.
+        /// </remarks>
+        public bool HasGrayedOutStars => Function.Call<bool>(Hash.ARE_PLAYER_STARS_GREYED_OUT, _playerIndex);
+
+        /// <summary>
+        /// Gets a value that indicates whether this <see cref="Player"/> is ignored by the police.
+        /// </summary>
+        /// <value>
+        /// <see langword="true"/> if this <see cref="Player"/> is ignored by the police; otherwise,
+        /// <see langword="false"/>.
+        /// </value>
+        public bool PoliceBackOff
+        {
+            get
+            {
+                if (SHVDN.NativeMemory.CWantedIgnorePlayerFlagOffset == 0)
+                {
+                    return false;
+                }
+
+                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(_playerIndex);
+                if (cWantedAddress == IntPtr.Zero)
+                {
+                    return false;
+                }
+
+                return SHVDN.MemDataMarshal.IsBitSet(cWantedAddress + SHVDN.NativeMemory.CWantedIgnorePlayerFlagOffset,
+                    16);
+            }
+        }
+
+        /// <summary>
+        /// Sets <see cref="PoliceBackOff"/> to a specified value. Also stops every law enforcement vehicles that has
+        /// a NPC driver by setting the velocity to the zero vector if set to <see langword="true"/>.
+        /// </summary>
+        /// <param name="value">
+        /// <see langword="true"/> if this <see cref="Player"/> should be ignored by the police; otherwise,
+        /// <see langword="false"/>.
+        /// </param>
+        public void SetPoliceIgnorePlayer(bool value)
+        {
+            Function.Call(Hash.SET_POLICE_IGNORE_PLAYER, _playerIndex, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value that indicates whether this <see cref="Player"/> is ignored by everyone.
+        /// </summary>
+        /// <value>
+        /// <see langword="true"/> if this <see cref="Player"/> is ignored by everyone; otherwise,
+        /// <see langword="false"/>.
+        /// </value>
+        public bool EverybodyBackOff
+        {
+            get
+            {
+                if (SHVDN.NativeMemory.CWantedIgnorePlayerFlagOffset == 0)
+                {
+                    return false;
+                }
+
+                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(_playerIndex);
+                if (cWantedAddress == IntPtr.Zero)
+                {
+                    return false;
+                }
+
+                return SHVDN.MemDataMarshal.IsBitSet(cWantedAddress + SHVDN.NativeMemory.CWantedIgnorePlayerFlagOffset,
+                    18);
+            }
+        }
+
+        /// <summary>
+        /// Sets <see cref="EverybodyBackOff"/> to a specified value. Also stops every law enforcement vehicles that has
+        /// a NPC driver by setting the velocity to the zero vector if set to <see langword="true"/>.
+        /// </summary>
+        /// <param name="value">
+        /// <see langword="true"/> if this <see cref="Player"/> should be ignored by everyone; otherwise,
+        /// <see langword="false"/>.
+        /// </param>
+        public void SetEveryoneIgnorePlayer(bool value)
+        {
+            Function.Call(Hash.SET_EVERYONE_IGNORE_PLAYER, _playerIndex, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value that indicates whether cops will be dispatched for this <see cref="Player"/>.
+        /// </summary>
+        /// <value>
+        /// <see langword="true"/> if cops will be dispatched; otherwise, <see langword="false"/>.
+        /// </value>
+        public bool DispatchesCopsForPlayer
+        {
+            get
+            {
+                if (SHVDN.NativeMemory.CWantedIgnorePlayerFlagOffset == 0)
+                {
+                    return false;
+                }
+
+                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(_playerIndex);
+                if (cWantedAddress == IntPtr.Zero)
+                {
+                    return false;
+                }
+
+                return !SHVDN.MemDataMarshal.IsBitSet(cWantedAddress
+                                                      + SHVDN.NativeMemory.CWantedIgnorePlayerFlagOffset, 23);
+            }
+            set => Function.Call(Hash.SET_DISPATCH_COPS_FOR_PLAYER, _playerIndex, value);
+        }
+
+        /// <summary>
+        /// Sets the wanted level for this <see cref="Player"/> but without refocusing the search area.
+        /// </summary>
+        /// <remarks>
+        /// When the previous wanted level is zero, you cannot avoid refocusing the search area with this method.
+        /// </remarks>
+        public void SetWantedLevelNoRefocusSearchArea(int wantedLevel)
+        {
+            if (SHVDN.NativeMemory.CurrentCrimeValueOffset == 0 || SHVDN.NativeMemory.CurrentWantedLevelOffset == 0)
+            {
+                return;
+            }
+
+            IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(_playerIndex);
+            if (cWantedAddress == IntPtr.Zero)
+            {
+                return;
+            }
+
+            int currentWantedLevel = SHVDN.MemDataMarshal.ReadInt32(cWantedAddress
+                                                                    + SHVDN.NativeMemory.CurrentWantedLevelOffset);
+
+            if (wantedLevel <= 0 || wantedLevel >= currentWantedLevel)
+            {
+                // Just call SET_PLAYER_WANTED_LEVEL and SET_PLAYER_WANTED_LEVEL_NOW, because setting to the current
+                // wanted level or above won't refocus the search area (the crime value will be reset)
+                Function.Call(Hash.SET_PLAYER_WANTED_LEVEL, _playerIndex, wantedLevel, false);
+                Function.Call(Hash.SET_PLAYER_WANTED_LEVEL_NOW, _playerIndex, false);
+                return;
+            }
+
+            // Clamps and/or sets the wanted level just like SET_PLAYER_WANTED_LEVEL does
+            int wantedLevelToApply = wantedLevel;
+            if (wantedLevelToApply >= 6)
+            {
+                wantedLevelToApply = 5;
+            }
+
+            // This additional crime value is hardcoded in a function that is called by SET_PLAYER_WANTED_LEVEL
+            const int ADDITIONAL_CRIME_VALUE = 20;
+            int threshold = Function.Call<int>(Hash.GET_WANTED_LEVEL_THRESHOLD, _playerIndex, wantedLevelToApply);
+
+            CurrentCrimeValue = threshold + ADDITIONAL_CRIME_VALUE;
+            SHVDN.MemDataMarshal.WriteInt32(cWantedAddress + SHVDN.NativeMemory.CurrentWantedLevelOffset,
+                wantedLevelToApply);
+
+            // Set the pending crime value just like SET_PLAYER_WANTED_LEVEL does (`SET_PLAYER_WANTED_LEVEL_NOW` does
+            // not clear the value)
+            NewCrimeValue = threshold + ADDITIONAL_CRIME_VALUE;
+        }
+
+        /// <summary>
+        /// Reports a crime for this <see cref="Player"/>.
+        /// </summary>
+        /// <param name="crimeToReport">The crime time to report.</param>
+        /// <param name="crimeValue">
+        /// If left at zero, the crime will get evaluated.
+        /// It not zero, the crime value will be overridden to specify an amount (can be both positive or negative).
+        /// </param>
+        /// <remarks>
+        /// Clearing the wanted level will disable to increase the crime value for commiting crimes for 2 seconds.
+        /// </remarks>
+        public void ReportCrime(CrimeType crimeToReport, int crimeValue = 0)
+            => Function.Call(Hash.REPORT_CRIME, _playerIndex, (int)crimeToReport, crimeValue);
+
+        /// <summary>
+        /// Forces this <see cref="Player"/> to get spotted by police.
+        /// </summary>
+        /// <remarks>
+        /// Unlike when you commit a crime that refocuses the search area, this method also updates
+        /// <see cref="TimeLastSpotted"/>.
+        /// </remarks>
+        public void ReportPoliceSpottingPlayer() => Function.Call(Hash.REPORT_POLICE_SPOTTED_PLAYER, _playerIndex);
+        /// <summary>
+        /// Force hidden evasion to start for this <see cref="Player"/>, making wanted stars flashing and cops using
+        /// vision cones to search for the player.
+        /// You can use this method at any point that police know where this player is.
+        /// </summary>
+        public void ForceStartHiddenEvasion() => Function.Call(Hash.FORCE_START_HIDDEN_EVASION, _playerIndex);
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds `Wanted` and `DispatchData` classes so `Player` class won't get too many responsibilities so fast. We definitely know there are `CWanted` and `CDispatchData` even, so we can be confident with how to separate such responsibilities thanks to the source code leak of the game.

Also removes properties and methods that are not present in v3.6.0 and mark ones that are present in v3.6.0 as obsolete with info about alternative ones.

We could have deduce the presence of `CWanted` in the source code of the GTA V without the leak from how that class is present in 3D Era games, but we couldn't have 100% sure what native functions don't access to the class at all.