### PR TITLE
[BUG FIX] MonthDayFlags.New(int, int, YearFlags) allowing invalid data.

### DIFF
--- a/source/scripting_v3/GTA.Chrono/MonthDayFlags.cs
+++ b/source/scripting_v3/GTA.Chrono/MonthDayFlags.cs
@@ -39,7 +39,7 @@ namespace GTA.Chrono
 
         internal static MonthDayFlags? New(int month, int day, YearFlags flags)
         {
-            if (month < 1 && month > 12 && day < 1 && day > 31)
+            if (month < 1 || month > 12 || day < 1 || day > 31)
             {
                 return null;
             }


### PR DESCRIPTION
The bug is caused by the validating if statement where the AND ( && ) operator was used instead of the OR operator ( || ).

https://github.com/scripthookvdotnet/scripthookvdotnet/blob/37a8dd617172c96aed7fe2243293e6494114ccb1/source/scripting_v3/GTA.Chrono/MonthDayFlags.cs#L42