### PR TITLE
feat(api-v3): enum for ProfileSettings including Game.GetProfileSetting(ProfileSettings); WIP

### DIFF
--- a/source/scripting_v3/GTA/ControllerControlType.cs
+++ b/source/scripting_v3/GTA/ControllerControlType.cs
@@ -1,0 +1,19 @@
+
+namespace GTA
+{
+    public enum ControllerControlType
+    {
+        Standard = 0,
+        Alternate,
+        Southpaw,
+        AlternatePlusSouthpaw,
+        StandardFPS,
+        AlternateFPS,
+        SouthpawFPS,
+        AlternatePlusSouthpawFPS,
+        StandardFPS2,
+        AlternateFPS2,
+        SouthpawFPS2,
+        AlternatePlusSouthpawFPS2,
+    }
+}

--- a/source/scripting_v3/GTA/Game.cs
+++ b/source/scripting_v3/GTA/Game.cs
@@ -77,7 +77,6 @@ namespace GTA
         {
             get
             {
-                ProfileSettings p = ProfileSettings.ControllerControlConfig;
                 int handle = SHVDN.NativeMemory.GetLocalPlayerIndex();
 
                 if (s_cachedPlayer == null || handle != s_cachedPlayer.Handle)

--- a/source/scripting_v3/GTA/Game.cs
+++ b/source/scripting_v3/GTA/Game.cs
@@ -77,6 +77,7 @@ namespace GTA
         {
             get
             {
+                ProfileSettings p = ProfileSettings.ControllerControlConfig;
                 int handle = SHVDN.NativeMemory.GetLocalPlayerIndex();
 
                 if (s_cachedPlayer == null || handle != s_cachedPlayer.Handle)
@@ -446,12 +447,12 @@ namespace GTA
         /// <summary>
         /// Gets the current targeting mode of the local player.
         /// </summary>
-        public static PlayerTargetingMode PlayerTargetingMode => (PlayerTargetingMode)GetProfileSetting(0);
+        public static PlayerTargetingMode PlayerTargetingMode => (PlayerTargetingMode)GetProfileSetting(ProfileSettings.TargetingMode);
 
         /// <summary>
         /// Gets a value indicating whether the controller vibration is enabled.
         /// </summary>
-        public static bool IsVibrationEnabled => GetProfileSetting(2) != 0;
+        public static bool IsVibrationEnabled => GetProfileSetting(ProfileSettings.ControllerVibration) != 0;
 
         /// <summary>
         /// Gets an analog value of a <see cref="Control"/> input in the range of [0, 255].
@@ -739,6 +740,7 @@ namespace GTA
             return Function.Call<int>(Hash.GET_PROFILE_SETTING, index);
         }
 
+        public static int GetProfileSetting(ProfileSettings settings) => GetProfileSetting((int)settings);
 
         /// <summary>
         /// Searches the address space of the current process for a memory pattern.

--- a/source/scripting_v3/GTA/Game.cs
+++ b/source/scripting_v3/GTA/Game.cs
@@ -446,12 +446,12 @@ namespace GTA
         /// <summary>
         /// Gets the current targeting mode of the local player.
         /// </summary>
-        public static PlayerTargetingMode PlayerTargetingMode => (PlayerTargetingMode)GetProfileSetting(ProfileSettings.TargetingMode);
+        public static PlayerTargetingMode PlayerTargetingMode => (PlayerTargetingMode)GetProfileSetting(ProfileSetting.TargetingMode);
 
         /// <summary>
         /// Gets a value indicating whether the controller vibration is enabled.
         /// </summary>
-        public static bool IsVibrationEnabled => GetProfileSetting(ProfileSettings.ControllerVibration) != 0;
+        public static bool IsVibrationEnabled => GetProfileSetting(ProfileSetting.ControllerVibration) != 0;
 
         /// <summary>
         /// Gets an analog value of a <see cref="Control"/> input in the range of [0, 255].
@@ -746,7 +746,7 @@ namespace GTA
         /// <param name="profile">The ProfileSetting</param>
         /// <returns>The integer value associated with the specified index of the profile setting.</returns>
         /// <remarks>If the profile settings does not exist, this will return 0.</remarks>
-        public static int GetProfileSetting(ProfileSettings profile) => GetProfileSetting((int)profile);
+        public static int GetProfileSetting(ProfileSetting profile) => GetProfileSetting((int)profile);
 
         /// <summary>
         /// Searches the address space of the current process for a memory pattern.

--- a/source/scripting_v3/GTA/Game.cs
+++ b/source/scripting_v3/GTA/Game.cs
@@ -734,12 +734,19 @@ namespace GTA
         /// </summary>
         /// <param name="index">The index of the profile setting values.</param>
         /// <returns>The integer value associated with the specified index of the profile setting.</returns>
+        /// <remarks>If the profile settings does not exist, this will return 0.</remarks>
         public static int GetProfileSetting(int index)
         {
             return Function.Call<int>(Hash.GET_PROFILE_SETTING, index);
         }
 
-        public static int GetProfileSetting(ProfileSettings settings) => GetProfileSetting((int)settings);
+        /// <summary>
+        /// Gets a value associated with the specified profile setting.
+        /// </summary>
+        /// <param name="profile">The ProfileSetting</param>
+        /// <returns>The integer value associated with the specified index of the profile setting.</returns>
+        /// <remarks>If the profile settings does not exist, this will return 0.</remarks>
+        public static int GetProfileSetting(ProfileSettings profile) => GetProfileSetting((int)profile);
 
         /// <summary>
         /// Searches the address space of the current process for a memory pattern.

--- a/source/scripting_v3/GTA/ProfileSetting.cs
+++ b/source/scripting_v3/GTA/ProfileSetting.cs
@@ -121,6 +121,9 @@ namespace GTA
         /// </summary>
         LegacyDisplayGamma = 210,
 
+        /// <summary>
+        /// Unknown
+        /// </summary>
         ControllerCinematicShooting = 211,
 
         /// <summary>
@@ -163,10 +166,13 @@ namespace GTA
         DisplayCameraHeight = 220,
 
         /// <summary>
-        /// Indicates whether the Big Radar is enabled (1 = Enabled, 0 = Disabled).
+        /// Indicates whether the Big Radar should be used (1 = Enabled, 0 = Disabled).
         /// </summary>
         DisplayBigRadar = 221,
 
+        /// <summary>
+        /// Unknown
+        /// </summary>
         DisplayBigRadarNames = 222,
 
         /// <summary>

--- a/source/scripting_v3/GTA/ProfileSetting.cs
+++ b/source/scripting_v3/GTA/ProfileSetting.cs
@@ -97,12 +97,14 @@ namespace GTA
         /// Indicates whether the HUD is enabled (1: Enabled, 0: Disabled).
         /// </summary>
         DisplayHudMode = 205,
+
         DisplayLanguage = 206,
 
         /// <summary>
         /// Indicates whether the GPS is enabled (1: Enabled, 0: Disabled).
         /// </summary>
         DisplayGps = 207,
+
         /// <summary>
         /// Indicates whether the Autosaving feature is enabled (1: Enabled, 0: Disabled).
         /// </summary>
@@ -239,6 +241,7 @@ namespace GTA
         /// The volume of Music in SP (Range 0-10, 0: Quietest, 10: Loudest).
         /// </summary>
         AudioMusicLevel = 301,
+
         AudioVoiceOutput = 302,
 
         /// <summary>
@@ -255,25 +258,34 @@ namespace GTA
         /// The volume of Music in MP (Range 0-10, 0: Quietest, 10: Loudest).
         /// </summary>
         AudioMusicLevelInMp = 306,
+
         AudioInteractiveMusic = 307,
 
         /// <summary>
         /// The amount of "Boost" applied to dialogue in-game (Range 0-10, 0: No-Boost, 10: Most-Boost).
         /// </summary>
         AudioDialogueBoost = 308,
+
         AudioVoiceSpeakers = 309,
+
         AudioSsFront = 310,
+
         AudioSsRear = 311,
+
         AudioCtrlSpeaker = 312,
+
         AudioCtrlSpeakerVol = 313,
+
         AudioPulseHeadset = 314,
+
         AudioCtrlSpeakerHeadphone = 315,
 
 		AudioUrPlaymode = 316,
-		AudioUrAutoscan = 317,
+
+        AudioUrAutoscan = 317,
 
         /// <summary>
-        /// Indicates whether audio should be muted if GTA is not in focus (0: Unmuted, 1: Mute-Audio).
+        /// Indicates whether audio should be muted if GTA is not in focus (0: Play Audio, 1: Mute Audio).
         /// </summary>
 		AudioMuteOnFocusLoss = 318,
 
@@ -281,7 +293,9 @@ namespace GTA
         /// Indicates whether the recticle should be shown on screen (0: Show, 1: Hide).
         /// </summary>
         DisplayReticule = 412,
+
         ControllerConfig = 413,
+
         DisplayFlickerFilter = 414,
 
         /// <summary>
@@ -299,7 +313,9 @@ namespace GTA
 
         //600-678 Are for the Ambisonic decoder
         AmbisonicDecoder = 600,
+
         AmbisonicDecoderEnd = 677,
+
         AmbisonicDecoderType = 678,
 
         /// <summary>
@@ -309,7 +325,9 @@ namespace GTA
         /// An integer representing the graphics level. (Range 0-4, 0: Low, 1: Medium, 2: High, 3: Ultra, 4: Custom).
         /// </returns>
         PcGraphicsLevel = 700,
+
         PcSystemLevel = 701,
+
         PcAudioLevel = 702,
 
         /// <summary>.
@@ -321,6 +339,7 @@ namespace GTA
         /// If merged with <see cref="PcLastHardwareStatsUploadPosixtimeLow32"/> represents the last time hardware stats were uploaded.
         /// </summary>
         PcLastHardwareStatsUploadPosixtimeHigh32 = 711,
+
         /// <summary>
         /// If merged with <see cref="PcLastHardwareStatsUploadPosixtimeHigh32"/> represents the last time hardware stats were uploaded.
         /// </summary>
@@ -350,6 +369,7 @@ namespace GTA
         /// Represents the index of the VoiceChat input device.
         /// </summary>
         PcVoiceInputDevice = 724,
+
         PcVoiceChatMode = 725,
 
         /// <summary>
@@ -373,8 +393,11 @@ namespace GTA
         PcVoiceMusicVolume = 729,
 
         MouseType = 750,
+
         MouseSub = 751,
+
         MouseDrive = 752,
+
         MouseFly = 753,
 
         /// <summary>

--- a/source/scripting_v3/GTA/ProfileSetting.cs
+++ b/source/scripting_v3/GTA/ProfileSetting.cs
@@ -202,11 +202,12 @@ namespace GTA
         NewDisplayLanguage = 228,
 
         /// <summary>
-        /// Represents the first person aim type on mouse and keyboard (0: Normal, 1: Iron Sights)
+        /// Represents the first person aim type on mouse and keyboard (0: Normal, 1: Iron Sights).
         /// </summary>
         FpsDefaultAimType = 229,
         FpsPersistantView = 230,
         FpsFieldOfView = 231,
+
         FpsLookSensitivity = 232,
         FpsAimSensitivity = 233,
         FpsRagdoll = 234,
@@ -357,7 +358,7 @@ namespace GTA
         PcVoiceMicVolume = 726,
 
         /// <summary>
-        /// Represents the sensitivity of the VoiceChat microphone (Range 0-10, 0: Most-Sensitive, 10: Most-Insensitive).
+        /// Represents the sensitivity of the VoiceChat microphone (Range 0-10, 0: Most-Sensitive, 10: Least-Sensitive).
         /// </summary>
         PcVoiceMicSensitivity = 727,
 
@@ -375,18 +376,49 @@ namespace GTA
         MouseSub = 751,
         MouseDrive = 752,
         MouseFly = 753,
+
+        /// <summary>
+        /// Represents your MOUSE base sensitivity when walking around (Range 0-20, 0: Slowest, 200: Fastest).
+        /// </summary>
         MouseOnFootScale = 754,
+
+        /// <summary>
+        /// Represents the multiplier applied to your MOUSE base sensitivity when driving around (Range 0-200, 0: Slowest, 100: Normal, 200: Fastest).
+        /// </summary>
         MouseDrivingScale = 755,
+
+        /// <summary>
+        /// Represents the multiplier applied to your MOUSE base sensitivity when flying in an aircraft (Range 0-200, 0: Slowest, 100: Normal, 200: Fastest).
+        /// </summary>
         MousePlaneScale = 756,
+
+        /// <summary>
+        /// Represents the multiplier applied to your MOUSE base sensitivity when flying in a helicopter (Range 0-200, 0: Slowest, 100: Normal, 200: Fastest).
+        /// </summary>
         MouseHeliScale = 757,
 
         /// <summary>
         /// Indicates whether you need to hold down the aim button or press it once to aim (0: Hold, 1: Toggle).
         /// </summary>
         KbmToggleAim = 758,
+
         KbmAltVehMouseControls = 759,
+
+        /// <summary>
+        /// Represents the multiplier applied to your MOUSE base sensitivity when diving in a submarine (Range 0-200, 0: Slowest, 100: Normal, 200: Fastest).
+        /// </summary>
         MouseSubScale = 760,
+
+        /// <summary>
+        /// Represents how much the game smoothes out mouse input (Range 0-10, 0: No Smoothing, 10: Max Smoothing).
+        /// </summary>
+        ///
+        /// FIne aiming control
         MouseWeightScale = 761,
+
+        /// <summary>
+        /// Indicates whether fine aiming control is used (0: Disabled, 1: Enabled).
+        /// </summary>
         MouseAcceleration = 762,
 
         /// <summary>

--- a/source/scripting_v3/GTA/ProfileSetting.cs
+++ b/source/scripting_v3/GTA/ProfileSetting.cs
@@ -119,7 +119,7 @@ namespace GTA
         /// <summary>
         /// Legacy version of <see cref="DisplayGamma"/>, exact game version is unknown.
         /// </summary>
-        LegacyDoNotUseDisplayGamma = 210,
+        LegacyDisplayGamma = 210,
 
         ControllerCinematicShooting = 211,
 
@@ -163,22 +163,34 @@ namespace GTA
         DisplayCameraHeight = 220,
 
         /// <summary>
-        /// Indicates whether the big radar is enabled (1 = Enabled, 0 = Disabled).
+        /// Indicates whether the Big Radar is enabled (1 = Enabled, 0 = Disabled).
         /// </summary>
         DisplayBigRadar = 221,
 
         DisplayBigRadarNames = 222,
+
+        /// <summary>
+        /// Indicates whether the control for the Handbreak is switched with the one for Hydraulics / Duck (0 = Normal, 1 = Switched).
+        /// </summary>
         ControllerDuckHandbrake = 223,
+
+        /// <summary>
+        /// Indicates whether Depth Of Field Effects are enabled In-Game (0 = Disabled, 1 = Enabled).
+        /// </summary>
         DisplayDof = 224,
+
+        /// <summary>
+        /// Represents the controller controls for Drive-Bys (0 = Aim, 1 = Aim + Fire).
+        /// </summary>
         ControllerDriveby = 225,
 
         /// <summary>
-        /// Indicates whether screen kill effects are enabled (1 = Enabled, 0 = Disabled).
+        /// Indicates whether Screen Kill Effects are enabled (1 = Enabled, 0 = Disabled).
         /// </summary>
         DisplayScreenKillFx = 226,
 
         /// <summary>
-        /// Represents whether the game uses metric or imperial units (0 = Imperial, 1 = Metric).
+        /// Represents the measurement system the game uses (0 = Imperial, 1 = Metric).
         /// </summary>
         MeasurementSystem = 227,
         NewDisplayLanguage = 228,
@@ -203,6 +215,9 @@ namespace GTA
 
         // Gen9 is using values 246-250. Do not use these.
 
+        /// <summary>
+        /// Indicates whether the TextChat in MP should be shown (0: Hidden, 1: Shown)
+        /// </summary>
         DisplayTextChat = 251,
 
         /// <summary>
@@ -215,11 +230,15 @@ namespace GTA
         /// </summary>
         AudioMusicLevel = 301,
         AudioVoiceOutput = 302,
+
+        /// <summary>
+        /// An unknown parameter, returns one most of the time.
+        /// </summary>
         AudioGpsSpeech = 303,
-        AudioHighDynamicRange = 304,
 
-
-
+        /// <summary>
+        /// Represents the index of the output device used for game audio.
+        /// </summary>
         AudioSpeakerOutput = 305,
 
         /// <summary>
@@ -268,8 +287,8 @@ namespace GTA
         /// </summary>
         NumSingleplayerGamesStarted = 450,
 
+        //600-678 Are for the Ambisonic decoder
         AmbisonicDecoder = 600,
-        //...All these values are used for the Ambisonic decoder 
         AmbisonicDecoderEnd = 677,
         AmbisonicDecoderType = 678,
 
@@ -277,16 +296,24 @@ namespace GTA
         /// Represents the graphics quality level for PC.
         /// </summary>
         /// <returns>
-        /// An integer representing the graphics level in the inclusive (Range 0-4).
-        /// (0 = Low, 1 = Medium, 2 = High, 3 = Ultra, 4 = Custom)
+        /// An integer representing the graphics level. (Range 0-4, 0 = Low, 1 = Medium, 2 = High, 3 = Ultra, 4 = Custom).
         /// </returns>
         PcGraphicsLevel = 700,
         PcSystemLevel = 701,
         PcAudioLevel = 702,
 
+        /// <summary>.
+        /// Indicates whether the game ignores the suggested VRAM limit (0: Disabled, 1: Enabled)
+        /// </summary>
         PcGfxVidOverride = 710,
 
-        PcLastHardwareStatsUploadPosixtimeHigh32 = 711, //s64 value for the last successful hardware stats upload.
+        /// <summary>
+        /// If merged with <see cref="PcLastHardwareStatsUploadPosixtimeLow32"/> represents the last time hardware stats were uploaded.
+        /// </summary>
+        PcLastHardwareStatsUploadPosixtimeHigh32 = 711,
+        /// <summary>
+        /// If merged with <see cref="PcLastHardwareStatsUploadPosixtimeHigh32"/> represents the last time hardware stats were uploaded.
+        /// </summary>
         PcLastHardwareStatsUploadPosixtimeLow32 = 712,
 
         /// <summary>
@@ -343,29 +370,73 @@ namespace GTA
         MouseDrivingScale = 755,
         MousePlaneScale = 756,
         MouseHeliScale = 757,
+
+        /// <summary>
+        /// Indicates whether you need to hold down the aim button or press it once to aim (0: Hold, 1: Toggle).
+        /// </summary>
         KbmToggleAim = 758,
         KbmAltVehMouseControls = 759,
         MouseSubScale = 760,
         MouseWeightScale = 761,
         MouseAcceleration = 762,
 
+        /// <summary>
+        /// Indicates whether Phone Alerts should be shown (0: OFF, 1: ON).
+        /// </summary>
         FeedPhone = 800,
+
+        /// <summary>
+        /// Indicates whether Stats Alerts should be shown (0: OFF, 1: ON).
+        /// </summary>
         FeedStats = 801,
+
+        /// <summary>
+        /// Indicates whether Crew Updates should be shown (0: OFF, 1: ON).
+        /// </summary>
         FeedCrew = 802,
+
+        /// <summary>
+        /// Indicates whether Friend Updates should be shown (0: OFF, 1: ON).
+        /// </summary>
         FeedFriends = 803,
+
+        /// <summary>
+        /// Indicates whether R* Game Service notifications should be shown (0: OFF, 1: ON).
+        /// </summary>
         FeedSocial = 804,
+
+        /// <summary>
+        /// Indicates whether Store notifications should be shown (0: OFF, 1: ON).
+        /// </summary>
         FeedStore = 805,
+
+        /// <summary>
+        /// Indicates whether Tooltips should be shown (0: OFF, 1: ON).
+        /// </summary>
         FeedTooptip = 806,
+
+        /// <summary>
+        /// Represents the delay with notifications are shown (Range 0-9, 0: No Delay, 1: 1 Minute, 2: 2Minutes, 3: 3Minutes, 4: 4Minutes, 5: 5Minutes, 6: 10Minutes, 7: 15Minutes, 8: 30Minutes, 9: 1 Hour).
+        /// </summary>
         FeedDelay = 807,
 
+        /// <summary>
+        /// Indicates what the game should boot if the landing page is disabled (0: Singleplayer, 1: Multiplayer).
+        /// </summary>
+        /// <remarks>
+        /// Value is ignored if <see cref="LandingPage"/> is set to 1.
+        /// </remarks>
         StartUpFlow = 810,
+
+        /// <summary>
+        /// Indicates whether the Game should show the landing page on start or directly boot into SP or MP (0: Boot into <see cref="StartUpFlow"/>, 1: Show-Landing-Page).
+        /// </summary>
         LandingPage = 811,
 
         /// <summary>
-        /// Indicates whether the player is entitled to special edition content ( 0: Not-Entitled, 1: Entitled)
+        /// Indicates whether the player is entitled to special edition content (0: Not-Entitled, 1: Entitled).
         /// </summary>
         GamerHasSpecialeditionContent = 866,
-
 
         /// <summary>
         /// Indicates that the Rockstar Online Services is not available but the client is still connected to the platform network (0: Running, 1: ROS Down).
@@ -373,7 +444,7 @@ namespace GTA
         RosWentDownNotNet = 901,
 
         /// <summary>
-        /// Indicates whether the player has finished the prologue mission (0 = Not-Completed, 1 = Completed)
+        /// Indicates whether the player has finished the prologue mission (0: Not-Completed, 1: Completed).
         /// </summary>
         PrologueComplete = 903,
 
@@ -404,7 +475,7 @@ namespace GTA
         ReplayMemLimit = 956,
 
         /// <summary>
-        /// Indicates whether the replay mode is enabled (1 = Enabled, 0 = Disabled).
+        /// Indicates whether the replay mode is enabled (1: Enabled, 0: Disabled).
         /// </summary>
         ReplayMode = 957,
 
@@ -413,17 +484,33 @@ namespace GTA
         VideoUploadPause = 959,
 
         /// <summary>
-        /// Indicates the visibility of uploaded videos to YouTube (0: Public, 1: Unlisted, 2: Private)
+        /// Indicates the visibility of uploaded videos to YouTube (0: Public, 1: Unlisted, 2: Private).
         /// </summary>
         VideoUploadPrivacy = 960,
 
-        RockstarEditorTooltip = 961,
-        VideoExportGraphicsUpgrade = 962,
         /// <summary>
-        /// Indicates whether the  R* Editor tutorials have been seen. (1 = Seen, 0 = Not-Seen)
+        /// Indicates whether tooltips should be shown for the R* Editor (0: Hide, 1: Show).
+        /// </summary>
+        RockstarEditorTooltip = 961,
+
+        /// <summary>
+        /// Indicates whether the Graphic settings should be upgraded for replay exports (0: Use-Current, 1: Upgrade-Graphics).
+        /// </summary>
+        VideoExportGraphicsUpgrade = 962,
+
+        /// <summary>
+        /// Indicates whether the  R* Editor tutorials have been seen (1: Seen, 0: Not-Seen).
         /// </summary>
         RockstarEditorTutorialFlags = 963,
+
+        /// <summary>
+        /// Indicates whether an Action Replay should be automatically saved on death (0: Continue, 1: Save Replay).
+        /// </summary>
         ReplayAutoSaveRecording = 964,
+
+        /// <summary>
+        /// Represents the amount of videos created with the R* Editor.
+        /// </summary>
         ReplayVideosCreated = 965,
     };
 }

--- a/source/scripting_v3/GTA/ProfileSetting.cs
+++ b/source/scripting_v3/GTA/ProfileSetting.cs
@@ -9,17 +9,17 @@ namespace GTA
         InvalidProfileSetting = -1,
 
         /// <summary>
-        /// Represents the Controller Targeting Mode (0 = Assisted Aim - Full, 1 = Assisted Aim - Partial, 2 = Free Aim - Assisted, 3 = Free Aim).
+        /// Represents the Controller Targeting Mode (0: Assisted Aim - Full, 1: Assisted Aim - Partial, 2: Free Aim - Assisted, 3: Free Aim).
         /// </summary>
         TargetingMode = 0,
 
         /// <summary>
-        /// Indicates whether the controller axis is inverted (1 = Enabled, 0 = Disabled).
+        /// Indicates whether the controller axis is inverted (1: Enabled, 0: Disabled).
         /// </summary>
         AxisInversion = 1,
 
         /// <summary>
-        /// Indicates whether controller vibration is enabled (1 = Enabled, 0 = Disabled).
+        /// Indicates whether controller vibration is enabled (1: Enabled, 0: Disabled).
         /// </summary>
         ControllerVibration = 2,
 
@@ -29,22 +29,22 @@ namespace GTA
         ControllerControlConfig = 12,
 
         /// <summary>
-        /// Represents the 3rd person controller aim sensitivity (Range 0-14, 0 = Slowest, 14 = Highest).
+        /// Represents the 3rd person controller aim sensitivity (Range 0-14, 0: Slowest, 14: Highest).
         /// </summary>
         ControllerAimSensitivity = 13,
 
         /// <summary>
-        /// Represents the 3rd person controller look-around sensitivity (Range 0-14, 0 = Slowest, 14 = Highest).
+        /// Represents the 3rd person controller look-around sensitivity (Range 0-14, 0: Slowest, 14: Highest).
         /// </summary>
         LookAroundSensitivity = 14,
 
         /// <summary>
-        /// Indicates whether mouse controls are inverted (1 = Enabled, 0 = Disabled)
+        /// Indicates whether mouse controls are inverted (1: Enabled, 0: Disabled)
         /// </summary>
 		MouseInversion = 15,
 
         /// <summary>
-        /// Indicates whether you can move around with your controller while zoomed in (1 = Enabled, 0 = Disabled).
+        /// Indicates whether you can move around with your controller while zoomed in (1: Enabled, 0: Disabled).
         /// </summary>
         ControllerAllowMovementWhenZoomed = 16,
 
@@ -54,62 +54,62 @@ namespace GTA
         ControllerControlConfigFps = 20,
 
         /// <summary>
-        /// Indicates whether the mouse axis is inverted while flying (1 = Enabled, 0 = Disabled).
+        /// Indicates whether the mouse axis is inverted while flying (1: Enabled, 0: Disabled).
         /// </summary>
 		MouseInversionFlying = 21,
 
         /// <summary>
-        /// Indicates whether the mouse axis is inverted while in a submarine (1 = Enabled, 0 = Disabled).
+        /// Indicates whether the mouse axis is inverted while in a submarine (1: Enabled, 0: Disabled).
         /// </summary>
         MouseInversionSub = 22,
 
         /// <summary>
-        /// Indicates how fast the camera centers itself to the car while driving, (Range 0-10). (0 = Slowest, 10 = Fastest).
+        /// Indicates how fast the camera centers itself to the car while driving, (Range 0-10). (0: Slowest, 10: Fastest).
         /// </summary>
 		MouseAutocenterCar = 23,
 
         /// <summary>
-        /// Indicates how fast the camera centers itself to the bike while driving, (Range 0-10). (0 = Slowest, 10 = Fastest).
+        /// Indicates how fast the camera centers itself to the bike while driving, (Range 0-10). (0: Slowest, 10: Fastest).
         /// </summary>
         MouseAutocenterBike = 24,
 
         /// <summary>
-        /// Indicates how fast the camera centers itself to the aircraft while flying, (Range 0-10). (0 = Slowest, 10 = Fastest).
+        /// Indicates how fast the camera centers itself to the aircraft while flying, (Range 0-10). (0: Slowest, 10: Fastest).
         /// </summary>
         MouseAutocenterPlane = 25,
 
         /// <summary>
-        /// Represents the mouse flying control type (0 = Roll/Pitch, 1 = Yaw/Pitch).
+        /// Represents the mouse flying control type (0: Roll/Pitch, 1: Yaw/Pitch).
         /// </summary>
 		MouseSwapRollYawFlying = 26,
 
         /// <summary>
-        /// Indicates whether subtitles are enabled (1 = Enabled, 0 = Disabled).
+        /// Indicates whether subtitles are enabled (1: Enabled, 0: Disabled).
         /// </summary>
         DisplaySubtitles = 203,
 
         /// <summary>
-        /// Represents the radar mode, range 0 - 2, (0 = Off, 1 = On, 2 = Blip).
+        /// Represents the radar mode, range 0 - 2, (0: Off, 1: On, 2: Blip).
         /// </summary>
         DisplayRadarMode = 204,
 
         /// <summary>
-        /// Indicates whether the HUD is enabled (1 = Enabled, 0 = Disabled).
+        /// Indicates whether the HUD is enabled (1: Enabled, 0: Disabled).
         /// </summary>
         DisplayHudMode = 205,
         DisplayLanguage = 206,
 
         /// <summary>
-        /// Indicates whether the GPS is enabled (1 = Enabled, 0 = Disabled).
+        /// Indicates whether the GPS is enabled (1: Enabled, 0: Disabled).
         /// </summary>
         DisplayGps = 207,
         /// <summary>
-        /// Indicates whether the Autosaving feature is enabled (1 = Enabled, 0 = Disabled).
+        /// Indicates whether the Autosaving feature is enabled (1: Enabled, 0: Disabled).
         /// </summary>
         DisplayAutosaveMode = 208,
 
         /// <summary>
-        /// Indicates where the camera is placed while in a vehicle and 1st person. (1 = Hood, 0 = Player)
+        /// Indicates where the camera is placed while in a vehicle and 1st person. (1: Hood, 0: Player)
         /// </summary>
         DisplayHandbrakeCam = 209,
 
@@ -136,12 +136,12 @@ namespace GTA
         DisplaySafezoneSize = 212,
 
         /// <summary>
-        /// Represents the display gama / brightness (Range 0-30, 0 = Darkest, 30 = Brightest).
+        /// Represents the display gama / brightness (Range 0-30, 0: Darkest, 30: Brightest).
         /// </summary>
         DisplayGamma = 213,
 
         /// <summary>
-        /// Represented an unknown display setting in past versions.
+        /// Represented an unknown display setting used in past versions.
         /// </summary>
         DisplayLegacyUnused1 = 214,
 
@@ -161,12 +161,12 @@ namespace GTA
         DisplayLegacyUnused6 = 219,
 
         /// <summary>
-        /// Represents the camera height while driving (0 = Low, 1 = High).
+        /// Represents the camera height while driving (0: Low, 1: High).
         /// </summary>
         DisplayCameraHeight = 220,
 
         /// <summary>
-        /// Indicates whether the Big Radar should be used (1 = Enabled, 0 = Disabled).
+        /// Indicates whether the Big Radar should be used (1: Enabled, 0: Disabled).
         /// </summary>
         DisplayBigRadar = 221,
 
@@ -176,31 +176,34 @@ namespace GTA
         DisplayBigRadarNames = 222,
 
         /// <summary>
-        /// Indicates whether the control for the Handbreak is switched with the one for Hydraulics / Duck (0 = Normal, 1 = Switched).
+        /// Indicates whether the control for the Handbreak is switched with the one for Hydraulics / Duck (0: Normal, 1: Switched).
         /// </summary>
         ControllerDuckHandbrake = 223,
 
         /// <summary>
-        /// Indicates whether Depth Of Field Effects are enabled In-Game (0 = Disabled, 1 = Enabled).
+        /// Indicates whether Depth Of Field Effects are enabled In-Game (0: Disabled, 1: Enabled).
         /// </summary>
         DisplayDof = 224,
 
         /// <summary>
-        /// Represents the controller controls for Drive-Bys (0 = Aim, 1 = Aim + Fire).
+        /// Represents the controller controls for Drive-Bys (0: Aim, 1: Aim + Fire).
         /// </summary>
         ControllerDriveby = 225,
 
         /// <summary>
-        /// Indicates whether Screen Kill Effects are enabled (1 = Enabled, 0 = Disabled).
+        /// Indicates whether Screen Kill Effects are enabled (1: Enabled, 0: Disabled).
         /// </summary>
         DisplayScreenKillFx = 226,
 
         /// <summary>
-        /// Represents the measurement system the game uses (0 = Imperial, 1 = Metric).
+        /// Represents the measurement system the game uses (0: Imperial, 1: Metric).
         /// </summary>
         MeasurementSystem = 227,
         NewDisplayLanguage = 228,
 
+        /// <summary>
+        /// Represents the first person aim type on mouse and keyboard (0: Normal, 1: Iron Sights)
+        /// </summary>
         FpsDefaultAimType = 229,
         FpsPersistantView = 230,
         FpsFieldOfView = 231,
@@ -227,12 +230,12 @@ namespace GTA
         DisplayTextChat = 251,
 
         /// <summary>
-        /// The volume of SFX in-game (Range 0-10, 0 = Quietest, 10 = Loudest).
+        /// The volume of SFX in-game (Range 0-10, 0: Quietest, 10: Loudest).
         /// </summary>
         AudioSfxLevel = 300,
 
         /// <summary>
-        /// The volume of Music in SP (Range 0-10, 0 = Quietest, 10 = Loudest).
+        /// The volume of Music in SP (Range 0-10, 0: Quietest, 10: Loudest).
         /// </summary>
         AudioMusicLevel = 301,
         AudioVoiceOutput = 302,
@@ -248,13 +251,13 @@ namespace GTA
         AudioSpeakerOutput = 305,
 
         /// <summary>
-        /// The volume of Music in MP (Range 0-10, 0 = Quietest, 10 = Loudest).
+        /// The volume of Music in MP (Range 0-10, 0: Quietest, 10: Loudest).
         /// </summary>
         AudioMusicLevelInMp = 306,
         AudioInteractiveMusic = 307,
 
         /// <summary>
-        /// The amount of "Boost" applied to dialogue in-game (Range 0-10, 0 = No-Boost, 10 = Most-Boost).
+        /// The amount of "Boost" applied to dialogue in-game (Range 0-10, 0: No-Boost, 10: Most-Boost).
         /// </summary>
         AudioDialogueBoost = 308,
         AudioVoiceSpeakers = 309,
@@ -269,7 +272,7 @@ namespace GTA
 		AudioUrAutoscan = 317,
 
         /// <summary>
-        /// Indicates whether audio should be muted if GTA is not in focus (0 = Do-Not-Mute, 1 = Mute-Audio).
+        /// Indicates whether audio should be muted if GTA is not in focus (0: Unmuted, 1: Mute-Audio).
         /// </summary>
 		AudioMuteOnFocusLoss = 318,
 
@@ -281,7 +284,7 @@ namespace GTA
         DisplayFlickerFilter = 414,
 
         /// <summary>
-        /// Indicates the size of the recticle (Range 0-10, 0 = Smallest, 10 = Largest)
+        /// Indicates the size of the recticle (Range 0-10, 0: Smallest, 10: Largest)
         /// </summary>
         /// <remarks>
         /// Only applies to the simple recticle!
@@ -302,7 +305,7 @@ namespace GTA
         /// Represents the graphics quality level for PC.
         /// </summary>
         /// <returns>
-        /// An integer representing the graphics level. (Range 0-4, 0 = Low, 1 = Medium, 2 = High, 3 = Ultra, 4 = Custom).
+        /// An integer representing the graphics level. (Range 0-4, 0: Low, 1: Medium, 2: High, 3: Ultra, 4: Custom).
         /// </returns>
         PcGraphicsLevel = 700,
         PcSystemLevel = 701,
@@ -333,12 +336,12 @@ namespace GTA
         PcVoiceOutputDevice = 721,
 
         /// <summary>
-        /// Represents the volume of the VoiceChat (Range 0-10, 0 = Quietest, 10 = Loudest).
+        /// Represents the volume of the VoiceChat (Range 0-10, 0: Quietest, 10: Loudest).
         /// </summary>
         PcVoiceOutputVolume = 722,
 
         /// <summary>
-        /// Indicates the activation method of the Microphone (1 = VoiceActivated, 0 = PushToTalk).
+        /// Indicates the activation method of the Microphone (1: VoiceActivated, 0: PushToTalk).
         /// </summary>
         PcVoiceTalkEnabled = 723,
 
@@ -349,22 +352,22 @@ namespace GTA
         PcVoiceChatMode = 725,
 
         /// <summary>
-        /// Represents the volume of the VoiceChat (Range 0-10, 0 = Quietest, 10 = Loudest).
+        /// Represents the volume of the VoiceChat (Range 0-10, 0: Quietest, 10: Loudest).
         /// </summary>
         PcVoiceMicVolume = 726,
 
         /// <summary>
-        /// Represents the sensitivity of the VoiceChat microphone (Range 0-10, 0 = Most-Sensitive, 10-Most-Insensitive).
+        /// Represents the sensitivity of the VoiceChat microphone (Range 0-10, 0: Most-Sensitive, 10: Most-Insensitive).
         /// </summary>
         PcVoiceMicSensitivity = 727,
 
         /// <summary>
-        /// Represents the volume of SFX sounds while people are talking in VoiceChat (Range 0-10, 0 = Quietest, 10 = Loudest).
+        /// Represents the volume of SFX sounds while people are talking in VoiceChat (Range 0-10, 0: Quietest, 10: Loudest).
         /// </summary>
         PcVoiceSoundVolume = 728,
 
         /// <summary>
-        /// Represents the volume of Music while people are talking in VoiceChat (Range 0-10, 0 = Quietest, 10 = Loudest).
+        /// Represents the volume of Music while people are talking in VoiceChat (Range 0-10, 0: Quietest, 10: Loudest).
         /// </summary>
         PcVoiceMusicVolume = 729,
 
@@ -430,7 +433,7 @@ namespace GTA
         /// Indicates what the game should boot if the landing page is disabled (0: Singleplayer, 1: Multiplayer).
         /// </summary>
         /// <remarks>
-        /// Value is ignored if <see cref="LandingPage"/> is set to 1.
+        /// Value is ignored if <see cref="LandingPage"/> is set to <value>1</value>.
         /// </remarks>
         StartUpFlow = 810,
 

--- a/source/scripting_v3/GTA/ProfileSetting.cs
+++ b/source/scripting_v3/GTA/ProfileSetting.cs
@@ -7,16 +7,19 @@ namespace GTA
         /// Used to indicate that a profile setting value is missing or not applicable.
         /// </summary>
         InvalidProfileSetting = -1,
+
         /// <summary>
-        /// Represents the Controller Targeting Mode. Ranges from 0-3 (0 = Assisted Aim - Full, 1 = Assisted Aim - Partial, 2 = Free Aim - Assisted, 3 = Free Aim).
+        /// Represents the Controller Targeting Mode (0 = Assisted Aim - Full, 1 = Assisted Aim - Partial, 2 = Free Aim - Assisted, 3 = Free Aim).
         /// </summary>
         TargetingMode = 0,
+
         /// <summary>
-        /// Indicates whether the controller axis is inverted (1 = enabled, 0 = disabled).
+        /// Indicates whether the controller axis is inverted (1 = Enabled, 0 = Disabled).
         /// </summary>
         AxisInversion = 1,
+
         /// <summary>
-        /// Indicates whether controller vibration is enabled (1 = enabled, 0 = disabled).
+        /// Indicates whether controller vibration is enabled (1 = Enabled, 0 = Disabled).
         /// </summary>
         ControllerVibration = 2,
 
@@ -24,22 +27,24 @@ namespace GTA
         /// Represents the 3rd person controller control type, see <see cref="GTA.ControllerControlType"/>.
         /// </summary>
         ControllerControlConfig = 12,
+
         /// <summary>
-        /// Represents the 3rd person controller aim sensitivity, range 0 - 14.
+        /// Represents the 3rd person controller aim sensitivity (Range 0-14, 0 = Slowest, 14 = Highest).
         /// </summary>
         ControllerAimSensitivity = 13,
+
         /// <summary>
-        /// Represents the 3rd person controller look-around sensitivity, range 0 - 14.
+        /// Represents the 3rd person controller look-around sensitivity (Range 0-14, 0 = Slowest, 14 = Highest).
         /// </summary>
         LookAroundSensitivity = 14,
 
         /// <summary>
-        /// Indicates whether mouse controls are inverted (1 = enabled, 0 = disabled)
+        /// Indicates whether mouse controls are inverted (1 = Enabled, 0 = Disabled)
         /// </summary>
 		MouseInversion = 15,
 
         /// <summary>
-        /// Indicated whether you can move around with your controller while zoomed in (1 = enabled, 0 = disabled).
+        /// Indicates whether you can move around with your controller while zoomed in (1 = Enabled, 0 = Disabled).
         /// </summary>
         ControllerAllowMovementWhenZoomed = 16,
 
@@ -49,25 +54,27 @@ namespace GTA
         ControllerControlConfigFps = 20,
 
         /// <summary>
-        /// Indicates whether the mouse axis is inverted while flying (1 = enabled, 0 = disabled).
+        /// Indicates whether the mouse axis is inverted while flying (1 = Enabled, 0 = Disabled).
         /// </summary>
 		MouseInversionFlying = 21,
 
         /// <summary>
-        /// Indicates whether the mouse axis is inverted while in a submarine (1 = enabled, 0 = disabled).
+        /// Indicates whether the mouse axis is inverted while in a submarine (1 = Enabled, 0 = Disabled).
         /// </summary>
         MouseInversionSub = 22,
 
         /// <summary>
-        /// Indicates how fast the camera centers itself to the car while driving, range 0 - 10. (0 = slowest, 10 = fastest).
+        /// Indicates how fast the camera centers itself to the car while driving, (Range 0-10). (0 = Slowest, 10 = Fastest).
         /// </summary>
 		MouseAutocenterCar = 23,
+
         /// <summary>
-        /// Indicates how fast the camera centers itself to the bike while driving, range 0 - 10. (0 = slowest, 10 = fastest).
+        /// Indicates how fast the camera centers itself to the bike while driving, (Range 0-10). (0 = Slowest, 10 = Fastest).
         /// </summary>
         MouseAutocenterBike = 24,
+
         /// <summary>
-        /// Indicates how fast the camera centers itself to the aircraft while flying, range 0 - 10. (0 = slowest, 10 = fastest).
+        /// Indicates how fast the camera centers itself to the aircraft while flying, (Range 0-10). (0 = Slowest, 10 = Fastest).
         /// </summary>
         MouseAutocenterPlane = 25,
 
@@ -77,32 +84,32 @@ namespace GTA
 		MouseSwapRollYawFlying = 26,
 
         /// <summary>
-        /// Indicates whether subtitles are enabled (1 = enabled, 0 = disabled).
+        /// Indicates whether subtitles are enabled (1 = Enabled, 0 = Disabled).
         /// </summary>
         DisplaySubtitles = 203,
 
         /// <summary>
-        /// Represents the radar mode, range 0 - 2, (0 = Off, 1 = On, 2 = Blip)
+        /// Represents the radar mode, range 0 - 2, (0 = Off, 1 = On, 2 = Blip).
         /// </summary>
         DisplayRadarMode = 204,
 
         /// <summary>
-        /// Indicates whether the HUD is enabled (1 = enabled, 0 = disabled).
+        /// Indicates whether the HUD is enabled (1 = Enabled, 0 = Disabled).
         /// </summary>
         DisplayHudMode = 205,
         DisplayLanguage = 206,
 
         /// <summary>
-        /// Indicates whether the GPS is enabled (1 = enabled, 0 = disabled).
+        /// Indicates whether the GPS is enabled (1 = Enabled, 0 = Disabled).
         /// </summary>
         DisplayGps = 207,
         /// <summary>
-        /// Indicates whether the Autosaving feature is enabled (1 = enabled, 0 = disabled).
+        /// Indicates whether the Autosaving feature is enabled (1 = Enabled, 0 = Disabled).
         /// </summary>
         DisplayAutosaveMode = 208,
 
         /// <summary>
-        /// Indicates where the camera is placed while in a vehicle and 1st person. (1 = hood, 0 = player)
+        /// Indicates where the camera is placed while in a vehicle and 1st person. (1 = Hood, 0 = Player)
         /// </summary>
         DisplayHandbrakeCam = 209,
 
@@ -117,7 +124,7 @@ namespace GTA
         ControllerCinematicShooting = 211,
 
         /// <summary>
-        /// Represents the display safezone size, range 0 - 10.
+        /// Represents the display safezone size (Range 0-10).
         /// </summary>
         /// <remarks>
         /// The safezone is the area the game places HUD elements in.
@@ -126,7 +133,7 @@ namespace GTA
         DisplaySafezoneSize = 212,
 
         /// <summary>
-        /// Represents the display gama / brightness, 0 - 30.
+        /// Represents the display gama / brightness (Range 0-30, 0 = Darkest, 30 = Brightest).
         /// </summary>
         DisplayGamma = 213,
 
@@ -151,12 +158,12 @@ namespace GTA
         DisplayLegacyUnused6 = 219,
 
         /// <summary>
-        /// Represents the camera height while driving (0 = low, 1 = high).
+        /// Represents the camera height while driving (0 = Low, 1 = High).
         /// </summary>
         DisplayCameraHeight = 220,
 
         /// <summary>
-        /// Indicates whether the big radar is enabled (1 = enabled, 0 = disabled).
+        /// Indicates whether the big radar is enabled (1 = Enabled, 0 = Disabled).
         /// </summary>
         DisplayBigRadar = 221,
 
@@ -166,12 +173,12 @@ namespace GTA
         ControllerDriveby = 225,
 
         /// <summary>
-        /// Indicates whether screen kill effects are enabled (1 = enabled, 0 = disabled).
+        /// Indicates whether screen kill effects are enabled (1 = Enabled, 0 = Disabled).
         /// </summary>
         DisplayScreenKillFx = 226,
 
         /// <summary>
-        /// Represents whether the game uses metric or imperial units (0 = imperial, 1 = metric).
+        /// Represents whether the game uses metric or imperial units (0 = Imperial, 1 = Metric).
         /// </summary>
         MeasurementSystem = 227,
         NewDisplayLanguage = 228,
@@ -198,14 +205,32 @@ namespace GTA
 
         DisplayTextChat = 251,
 
+        /// <summary>
+        /// The volume of SFX in-game (Range 0-10, 0 = Quietest, 10 = Loudest).
+        /// </summary>
         AudioSfxLevel = 300,
+
+        /// <summary>
+        /// The volume of Music in SP (Range 0-10, 0 = Quietest, 10 = Loudest).
+        /// </summary>
         AudioMusicLevel = 301,
         AudioVoiceOutput = 302,
         AudioGpsSpeech = 303,
         AudioHighDynamicRange = 304,
+
+
+
         AudioSpeakerOutput = 305,
+
+        /// <summary>
+        /// The volume of Music in MP (Range 0-10, 0 = Quietest, 10 = Loudest).
+        /// </summary>
         AudioMusicLevelInMp = 306,
         AudioInteractiveMusic = 307,
+
+        /// <summary>
+        /// The amount of "Boost" applied to dialogue in-game (Range 0-10, 0 = No-Boost, 10 = Most-Boost).
+        /// </summary>
         AudioDialogueBoost = 308,
         AudioVoiceSpeakers = 309,
         AudioSsFront = 310,
@@ -215,14 +240,27 @@ namespace GTA
         AudioPulseHeadset = 314,
         AudioCtrlSpeakerHeadphone = 315,
 
-        //RSG_PC
 		AudioUrPlaymode = 316,
 		AudioUrAutoscan = 317,
+
+        /// <summary>
+        /// Indicates whether audio should be muted if GTA is not in focus (0 = Do-Not-Mute, 1 = Mute-Audio).
+        /// </summary>
 		AudioMuteOnFocusLoss = 318,
 
+        /// <summary>
+        /// Indicates whether the recticle should be shown on screen (0: Show, 1: Hide).
+        /// </summary>
         DisplayReticule = 412,
         ControllerConfig = 413,
         DisplayFlickerFilter = 414,
+
+        /// <summary>
+        /// Indicates the size of the recticle (Range 0-10, 0 = Smallest, 10 = Largest)
+        /// </summary>
+        /// <remarks>
+        /// Only applies to the simple recticle!
+        /// </remarks>
         DisplayReticuleSize = 415,
 
         /// <summary>
@@ -231,7 +269,7 @@ namespace GTA
         NumSingleplayerGamesStarted = 450,
 
         AmbisonicDecoder = 600,
-        //...All these values are used for the ambisonic decoder 
+        //...All these values are used for the Ambisonic decoder 
         AmbisonicDecoderEnd = 677,
         AmbisonicDecoderType = 678,
 
@@ -239,7 +277,7 @@ namespace GTA
         /// Represents the graphics quality level for PC.
         /// </summary>
         /// <returns>
-        /// An integer representing the graphics level in the inclusive range 0 - 4
+        /// An integer representing the graphics level in the inclusive (Range 0-4).
         /// (0 = Low, 1 = Medium, 2 = High, 3 = Ultra, 4 = Custom)
         /// </returns>
         PcGraphicsLevel = 700,
@@ -251,15 +289,50 @@ namespace GTA
         PcLastHardwareStatsUploadPosixtimeHigh32 = 711, //s64 value for the last successful hardware stats upload.
         PcLastHardwareStatsUploadPosixtimeLow32 = 712,
 
+        /// <summary>
+        /// Indicates whether the user has enabled VoiceChat. 
+        /// </summary>
         PcVoiceEnabled = 720,
+
+        /// <summary>
+        /// Represents the index of the VoiceChat output device.
+        /// </summary>
         PcVoiceOutputDevice = 721,
+
+        /// <summary>
+        /// Represents the volume of the VoiceChat (Range 0-10, 0 = Quietest, 10 = Loudest).
+        /// </summary>
         PcVoiceOutputVolume = 722,
+
+        /// <summary>
+        /// Indicates the activation method of the Microphone (1 = VoiceActivated, 0 = PushToTalk).
+        /// </summary>
         PcVoiceTalkEnabled = 723,
+
+        /// <summary>
+        /// Represents the index of the VoiceChat input device.
+        /// </summary>
         PcVoiceInputDevice = 724,
         PcVoiceChatMode = 725,
+
+        /// <summary>
+        /// Represents the volume of the VoiceChat (Range 0-10, 0 = Quietest, 10 = Loudest).
+        /// </summary>
         PcVoiceMicVolume = 726,
+
+        /// <summary>
+        /// Represents the sensitivity of the VoiceChat microphone (Range 0-10, 0 = Most-Sensitive, 10-Most-Insensitive).
+        /// </summary>
         PcVoiceMicSensitivity = 727,
+
+        /// <summary>
+        /// Represents the volume of SFX sounds while people are talking in VoiceChat (Range 0-10, 0 = Quietest, 10 = Loudest).
+        /// </summary>
         PcVoiceSoundVolume = 728,
+
+        /// <summary>
+        /// Represents the volume of Music while people are talking in VoiceChat (Range 0-10, 0 = Quietest, 10 = Loudest).
+        /// </summary>
         PcVoiceMusicVolume = 729,
 
         MouseType = 750,
@@ -289,55 +362,65 @@ namespace GTA
         LandingPage = 811,
 
         /// <summary>
-        /// Indicates whether the player is entitled to special edition content
+        /// Indicates whether the player is entitled to special edition content ( 0: Not-Entitled, 1: Entitled)
         /// </summary>
         GamerHasSpecialeditionContent = 866,
 
-        FacebookLinkedHint = 899, // Returns a value != 0 if the last Facebook App Permissions call returned successful.
-        FacebookUpdates = 900,
 
-        RosWentDownNotNet = 901, // this is set to TRUE when the ROS link goes down but not the platform network conection
         /// <summary>
-        /// Indicates whether the player had posted the "Bought GTAV" action/object to facebook.
+        /// Indicates that the Rockstar Online Services is not available but the client is still connected to the platform network (0: Running, 1: ROS Down).
         /// </summary>
-        FacebookPostedBoughtGame = 902,
-        PrologueComplete = 903,
-        FacebookPostedAllVehiclesDriven = 904,
-        EulaVersion = 905,
+        RosWentDownNotNet = 901,
+
         /// <summary>
-        /// Represents the version of the Terms-Of-Service
+        /// Indicates whether the player has finished the prologue mission (0 = Not-Completed, 1 = Completed)
+        /// </summary>
+        PrologueComplete = 903,
+
+        /// <summary>
+        /// Represents the version of the Eula.
+        /// </summary>
+        EulaVersion = 905,
+
+        /// <summary>
+        /// Represents the version of the Terms-Of-Service.
         /// </summary>
         TosVersion = 907,
+
+        /// <summary>
+        /// Represents the version of the Privacy-Agreement.
+        /// </summary>
         PrivacyVersion = 908,
-        JobActivityIdChar0 = 909, //Id of the UGC activity started so we know if the player has pulled the plug.
-        JobActivityIdChar1 = 910, //Id of the UGC activity started so we know if the player has pulled the plug.
-        JobActivityIdChar2 = 911, //Id of the UGC activity started so we know if the player has pulled the plug.
-        JobActivityIdChar3 = 912, //Id of the UGC activity started so we know if the player has pulled the plug.
-        JobActivityIdChar4 = 913, //Id of the UGC activity started so we know if the player has pulled the plug.
-        FreemodePrologueCompleteChar0 = 914, //Returns a value !=0 if the prologue was done.
-        FreemodePrologueCompleteChar1 = 915, //Returns a value !=0 if the prologue was done.
-        FreemodePrologueCompleteChar2 = 916, //Returns a value !=0 if the prologue was done.
-        FreemodePrologueCompleteChar3 = 917, //Returns a value !=0 if the prologue was done.
-        FreemodePrologueCompleteChar4 = 918, //Returns a value !=0 if the prologue was done.
 
         /// <summary>
         /// Indicates whether Franklin unlocked the companion system of Chop.
         /// </summary>
         SpChopMissionComplete = 939,
 
-        FreemodeStrandProgressionStatusChar0 = 940,
-        FreemodeStrandProgressionStatusChar1 = 941,
-
+        /// <summary>
+        /// Indicates how much storage is allocated to the Rockstar Editor, ranges from 0 to 10.
+        /// 0: 250MB, 1: 500MB, 2: 750MB, 3: 1GB, 4: 1.5GB, 5: 2GB, 6: 5GB, 7: 10GB, 8: 15GB, 9: 25GB, 10: 50GB.
+        /// </summary>
         ReplayMemLimit = 956,
+
+        /// <summary>
+        /// Indicates whether the replay mode is enabled (1 = Enabled, 0 = Disabled).
+        /// </summary>
         ReplayMode = 957,
+
         ReplayAutoResumeRecording = 958,
 
         VideoUploadPause = 959,
+
+        /// <summary>
+        /// Indicates the visibility of uploaded videos to YouTube (0: Public, 1: Unlisted, 2: Private)
+        /// </summary>
         VideoUploadPrivacy = 960,
+
         RockstarEditorTooltip = 961,
         VideoExportGraphicsUpgrade = 962,
         /// <summary>
-        /// Indicates whether the  R* Editor tutorials have been seen. (1 = seen, 0 = not seen)
+        /// Indicates whether the  R* Editor tutorials have been seen. (1 = Seen, 0 = Not-Seen)
         /// </summary>
         RockstarEditorTutorialFlags = 963,
         ReplayAutoSaveRecording = 964,

--- a/source/scripting_v3/GTA/ProfileSetting.cs
+++ b/source/scripting_v3/GTA/ProfileSetting.cs
@@ -1,6 +1,6 @@
 namespace GTA
 {
-    public enum ProfileSettings
+    public enum ProfileSetting
     {
         /// <summary>
         /// Represents an invalid or uninitialized profile setting.

--- a/source/scripting_v3/GTA/ProfileSetting.cs
+++ b/source/scripting_v3/GTA/ProfileSetting.cs
@@ -130,15 +130,28 @@ namespace GTA
         /// </summary>
         DisplayGamma = 213,
 
+        /// <summary>
+        /// Represented an unknown display setting in past versions.
+        /// </summary>
         DisplayLegacyUnused1 = 214,
+
+        /// <inheritdoc cref="DisplayLegacyUnused1"/>
         DisplayLegacyUnused2 = 215,
+
+        /// <inheritdoc cref="DisplayLegacyUnused1"/>
         DisplayLegacyUnused3 = 216,
+
+        /// <inheritdoc cref="DisplayLegacyUnused1"/>
         DisplayLegacyUnused4 = 217,
+
+        /// <inheritdoc cref="DisplayLegacyUnused1"/>
         DisplayLegacyUnused5 = 218,
+
+        /// <inheritdoc cref="DisplayLegacyUnused1"/>
         DisplayLegacyUnused6 = 219,
 
         /// <summary>
-        /// Represents the camera height while driving (0 = low, 1 = high)
+        /// Represents the camera height while driving (0 = low, 1 = high).
         /// </summary>
         DisplayCameraHeight = 220,
 
@@ -146,14 +159,20 @@ namespace GTA
         /// Indicates whether the big radar is enabled (1 = enabled, 0 = disabled).
         /// </summary>
         DisplayBigRadar = 221,
+
         DisplayBigRadarNames = 222,
         ControllerDuckHandbrake = 223,
         DisplayDof = 224,
         ControllerDriveby = 225,
+
         /// <summary>
-        /// Internal name: DisplaySkfx
+        /// Indicates whether screen kill effects are enabled (1 = enabled, 0 = disabled).
         /// </summary>
         DisplayScreenKillFx = 226,
+
+        /// <summary>
+        /// Represents whether the game uses metric or imperial units (0 = imperial, 1 = metric).
+        /// </summary>
         MeasurementSystem = 227,
         NewDisplayLanguage = 228,
 
@@ -269,8 +288,10 @@ namespace GTA
         StartUpFlow = 810,
         LandingPage = 811,
 
-        GamerPlayedLastGen = 865, // Indicates if the player has played last gen, 1 - 360, 3 - ps3.
-        GamerHasSpecialeditionContent = 866,  // Indicates if the player is entitled to special edition content
+        /// <summary>
+        /// Indicates whether the player is entitled to special edition content
+        /// </summary>
+        GamerHasSpecialeditionContent = 866,
 
         FacebookLinkedHint = 899, // Returns a value != 0 if the last Facebook App Permissions call returned successful.
         FacebookUpdates = 900,

--- a/source/scripting_v3/GTA/ProfileSettings.cs
+++ b/source/scripting_v3/GTA/ProfileSettings.cs
@@ -1,0 +1,307 @@
+namespace GTA
+{
+    public enum ProfileSettings
+    {
+        /// <summary>
+        /// Represents an invalid or uninitialized profile setting.
+        /// Used to indicate that a profile setting value is missing or not applicable.
+        /// </summary>
+        InvalidProfileSetting = -1,
+        /// <summary>
+        /// Represents the Controller Targeting Mode. Ranges from 0-3 (0 = Assisted Aim - Full, 1 = Assisted Aim - Partial, 2 = Free Aim - Assisted, 3 = Free Aim).
+        /// </summary>
+        TargetingMode = 0,
+        /// <summary>
+        /// Indicates whether the controller axis is inverted ( 1 = enabled, 0 = disabled).
+        /// </summary>
+        AxisInversion = 1,
+        /// <summary>
+        /// Indicates whether controller vibration is enabled (1 = enabled, 0 = disabled).
+        /// </summary>
+        ControllerVibration = 2,
+
+        /// <summary>
+        /// Represents the 3rd person controller control type, see <see cref="GTA.ControllerControlType"/>.
+        /// </summary>
+        ControllerControlConfig = 12,
+        /// <summary>
+        /// Represents the 3rd person controller aim sensitivity, range 0 - 14.
+        /// </summary>
+        ControllerAimSensitivity = 13,
+        /// <summary>
+        /// Represents the 3rd person controller look-around sensitivity, range 0 - 14.
+        /// </summary>
+        LookAroundSensitivity = 14,
+
+        /// <summary>
+        /// Indicates whether mouse controls are inverted (1 = enabled, 0 = disabled)
+        /// </summary>
+		MouseInversion = 15,
+
+        /// <summary>
+        /// Indicated whether you can move around with your controller while zoomed in (1 = enabled, 0 = disabled).
+        /// </summary>
+        ControllerAllowMovementWhenZoomed = 16,
+
+        /// <summary>
+        /// Represents the 1st person controller control type, see <see cref="GTA.ControllerControlType"/>.
+        /// </summary>
+        ControllerControlConfigFps = 20,
+
+        /// <summary>
+        /// Indicates whether the mouse axis is inverted while flying (1 = enabled, 0 = disabled).
+        /// </summary>
+		MouseInversionFlying = 21,
+        /// <summary>
+        /// Indicates whether the mouse axis is inverted while in a submarine (1 = enabled, 0 = disabled).
+        /// </summary>
+        MouseInversionSub = 22,
+
+        /// <summary>
+        /// Indicates how fast the camera centers itself to the car while driving, range 0 - 10. (0 = slowest, 10 = fastest).
+        /// </summary>
+		MouseAutocenterCar = 23,
+        /// <summary>
+        /// Indicates how fast the camera centers itself to the bike while driving, range 0 - 10. (0 = slowest, 10 = fastest).
+        /// </summary>
+        MouseAutocenterBike = 24,
+        /// <summary>
+        /// Indicates how fast the camera centers itself to the aircraft while flying, range 0 - 10. (0 = slowest, 10 = fastest).
+        /// </summary>
+        MouseAutocenterPlane = 25,
+
+        /// <summary>
+        /// Represents the mouse flying control type (0 = Roll/Pitch, 1 = Yaw/Pitch).
+        /// </summary>
+		MouseSwapRollYawFlying = 26,
+
+        /// <summary>
+        /// Indicates whether subtitles are enabled (1 = enabled, 0 = disabled).
+        /// </summary>
+        DisplaySubtitles = 203,
+
+        /// <summary>
+        /// Represents the radar mode, range 0 - 2, (0 = Off, 1 = On, 2 = Blip)
+        /// </summary>
+        DisplayRadarMode = 204,
+
+        /// <summary>
+        /// Indicates whether the HUD is enabled (1 = enabled, 0 = disabled).
+        /// </summary>
+        DisplayHudMode = 205,
+        DisplayLanguage = 206,
+
+        /// <summary>
+        /// Indicates whether the GPS is enabled (1 = enabled, 0 = disabled).
+        /// </summary>
+        DisplayGps = 207,
+        /// <summary>
+        /// Indicates whether the Autosaving feature is enabled (1 = enabled, 0 = disabled).
+        /// </summary>
+        DisplayAutosaveMode = 208,
+        DisplayHandbrakeCam = 209,
+
+        /// <summary>
+        /// Legacy version of <see cref="DisplayGamma"/>, exact game version is unknown.
+        /// </summary>
+        LegacyDoNotUseDisplayGamma = 210,
+
+        ControllerCinematicShooting = 211,
+
+        /// <summary>
+        /// Represents the display safezone size, range 0 - 10.
+        /// </summary>
+        DisplaySafezoneSize = 212,
+
+        /// <summary>
+        /// Represents the display gama / brightness, 0 - 30.
+        /// </summary>
+        DisplayGamma = 213,
+
+        DisplayLegacyUnused1 = 214,
+        DisplayLegacyUnused2 = 215,
+        DisplayLegacyUnused3 = 216,
+        DisplayLegacyUnused4 = 217,
+        DisplayLegacyUnused5 = 218,
+        DisplayLegacyUnused6 = 219,
+
+        /// <summary>
+        /// Represents the camera height while driving (0 = low, 1 = high)
+        /// </summary>
+        DisplayCameraHeight = 220,
+        /// <summary>
+        /// Indicates whether the big radar is enabled (1 = enabled, 0 = disabled).
+        /// </summary>
+        DisplayBigRadar = 221,
+        DisplayBigRadarNames = 222,
+        ControllerDuckHandbrake = 223,
+        DisplayDof = 224,
+        ControllerDriveby = 225,
+        /// <summary>
+        /// Internal name: DisplaySkfx
+        /// </summary>
+        DisplayScreenKillFx = 226,
+        MeasurementSystem = 227,
+        NewDisplayLanguage = 228,
+
+        FpsDefaultAimType = 229,
+        FpsPersistantView = 230,
+        FpsFieldOfView = 231,
+        FpsLookSensitivity = 232,
+        FpsAimSensitivity = 233,
+        FpsRagdoll = 234,
+        FpsCombatroll = 235,
+        FpsHeadbob = 236,
+        FpsThirdPersonCover = 237,
+        FpsAimDeadzone = 238,
+        FpsAimAcceleration = 239,
+        AimDeadzone = 240,
+        AimAcceleration = 241,
+        FpsAutoLevel = 242,
+        HoodCamera = 243,
+        FpsVehAutoCenter = 244,
+        FpsRelativeVehicleCameraDrivebyAiming = 245,
+
+        // Gen9 is using values 246-250. Do not use these.
+
+        DisplayTextChat = 251,
+
+        AudioSfxLevel = 300,
+        AudioMusicLevel = 301,
+        AudioVoiceOutput = 302,
+        AudioGpsSpeech = 303,
+        AudioHighDynamicRange = 304,
+        AudioSpeakerOutput = 305,
+        AudioMusicLevelInMp = 306,
+        AudioInteractiveMusic = 307,
+        AudioDialogueBoost = 308,
+        AudioVoiceSpeakers = 309,
+        AudioSsFront = 310,
+        AudioSsRear = 311,
+        AudioCtrlSpeaker = 312,
+        AudioCtrlSpeakerVol = 313,
+        AudioPulseHeadset = 314,
+        AudioCtrlSpeakerHeadphone = 315,
+
+        //RSG_PC
+		AudioUrPlaymode = 316,
+		AudioUrAutoscan = 317,
+		AudioMuteOnFocusLoss = 318,
+
+        DisplayReticule = 412,
+        ControllerConfig = 413,
+        DisplayFlickerFilter = 414,
+        DisplayReticuleSize = 415,
+
+        /// <summary>
+        /// Represents the number of times the player has started a singleplayer game.
+        /// </summary>
+        NumSingleplayerGamesStarted = 450,
+
+        AmbisonicDecoder = 600,
+        //...All these values are used for the ambisonic decoder 
+        AmbisonicDecoderEnd = 677,
+        AmbisonicDecoderType = 678,
+
+        /// <summary>
+        /// Represents the graphics quality level for PC.
+        /// </summary>
+        /// <returns>
+        /// An integer representing the graphics level in the inclusive range 0 - 4
+        /// (0 = Low, 1 = Medium, 2 = High, 3 = Ultra, 4 = Custom)
+        /// </returns>
+        PcGraphicsLevel = 700,
+        PcSystemLevel = 701,
+        PcAudioLevel = 702,
+
+        PcGfxVidOverride = 710,
+
+        //xxxxxxxx-xxxxxxxx-xxxxxxx-xxxxxxxx-xxxxxxxx-xxxxxxxx-xxxxxxx-xxxxxxx
+        PcLastHardwareStatsUploadPosixtimeHigh32 = 711, //s64 value for the last successful hardware stats upload.
+        PcLastHardwareStatsUploadPosixtimeLow32 = 712,
+
+        PcVoiceEnabled = 720,
+        PcVoiceOutputDevice = 721,
+        PcVoiceOutputVolume = 722,
+        PcVoiceTalkEnabled = 723,
+        PcVoiceInputDevice = 724,
+        PcVoiceChatMode = 725,
+        PcVoiceMicVolume = 726,
+        PcVoiceMicSensitivity = 727,
+        PcVoiceSoundVolume = 728,
+        PcVoiceMusicVolume = 729,
+
+        MouseType = 750,
+        MouseSub = 751,
+        MouseDrive = 752,
+        MouseFly = 753,
+        MouseOnFootScale = 754,
+        MouseDrivingScale = 755,
+        MousePlaneScale = 756,
+        MouseHeliScale = 757,
+        KbmToggleAim = 758,
+        KbmAltVehMouseControls = 759,
+        MouseSubScale = 760,
+        MouseWeightScale = 761,
+        MouseAcceleration = 762,
+
+        FeedPhone = 800,
+        FeedStats = 801,
+        FeedCrew = 802,
+        FeedFriends = 803,
+        FeedSocial = 804,
+        FeedStore = 805,
+        FeedTooptip = 806,
+        FeedDelay = 807,
+
+        StartUpFlow = 810,
+        LandingPage = 811,
+
+        GamerPlayedLastGen = 865, // Indicates if the player has played last gen, 1 - 360, 3 - ps3.
+        GamerHasSpecialeditionContent = 866,  // Indicates if the player is entitled to special edition content
+
+        FacebookLinkedHint = 899, // Returns a value != 0 if the last Facebook App Permissions call returned successful.
+        FacebookUpdates = 900,
+
+        RosWentDownNotNet = 901, // this is set to TRUE when the ROS link goes down but not the platform network conection
+        /// <summary>
+        /// Indicates whether the player had posted the "Bought GTAV" action/object to facebook.
+        /// </summary>
+        FacebookPostedBoughtGame = 902,
+        PrologueComplete = 903,
+        FacebookPostedAllVehiclesDriven = 904,
+        EulaVersion = 905,
+        TosVersion = 907,
+        PrivacyVersion = 908,
+        JobActivityIdChar0 = 909, //Id of the UGC activity started so we know if the player has pulled the plug.
+        JobActivityIdChar1 = 910, //Id of the UGC activity started so we know if the player has pulled the plug.
+        JobActivityIdChar2 = 911, //Id of the UGC activity started so we know if the player has pulled the plug.
+        JobActivityIdChar3 = 912, //Id of the UGC activity started so we know if the player has pulled the plug.
+        JobActivityIdChar4 = 913, //Id of the UGC activity started so we know if the player has pulled the plug.
+        FreemodePrologueCompleteChar0 = 914, //Returns a value !=0 if the prologue was done.
+        FreemodePrologueCompleteChar1 = 915, //Returns a value !=0 if the prologue was done.
+        FreemodePrologueCompleteChar2 = 916, //Returns a value !=0 if the prologue was done.
+        FreemodePrologueCompleteChar3 = 917, //Returns a value !=0 if the prologue was done.
+        FreemodePrologueCompleteChar4 = 918, //Returns a value !=0 if the prologue was done.
+
+        /// <summary>
+        /// Indicates whether Franklin unlocked the companion system of Chop.
+        /// </summary>
+        SpChopMissionComplete = 939,
+
+        FreemodeStrandProgressionStatusChar0 = 940,
+        FreemodeStrandProgressionStatusChar1 = 941,
+
+        ReplayMemLimit = 956,
+        ReplayMode = 957,
+        ReplayAutoResumeRecording = 958,
+
+        VideoUploadPause = 959,
+        VideoUploadPrivacy = 960,
+        RockstarEditorTooltip = 961,
+        VideoExportGraphicsUpgrade = 962,
+        RockstarEditorTutorialFlags = 963, // s32 of flags representing if R* Editor tutorials have been seen
+        ReplayAutoSaveRecording = 964,
+        ReplayVideosCreated = 965,
+    };
+}

--- a/source/scripting_v3/GTA/ProfileSettings.cs
+++ b/source/scripting_v3/GTA/ProfileSettings.cs
@@ -12,7 +12,7 @@ namespace GTA
         /// </summary>
         TargetingMode = 0,
         /// <summary>
-        /// Indicates whether the controller axis is inverted ( 1 = enabled, 0 = disabled).
+        /// Indicates whether the controller axis is inverted (1 = enabled, 0 = disabled).
         /// </summary>
         AxisInversion = 1,
         /// <summary>

--- a/source/scripting_v3/GTA/ProfileSettings.cs
+++ b/source/scripting_v3/GTA/ProfileSettings.cs
@@ -216,7 +216,6 @@ namespace GTA
 
         PcGfxVidOverride = 710,
 
-        //xxxxxxxx-xxxxxxxx-xxxxxxx-xxxxxxxx-xxxxxxxx-xxxxxxxx-xxxxxxx-xxxxxxx
         PcLastHardwareStatsUploadPosixtimeHigh32 = 711, //s64 value for the last successful hardware stats upload.
         PcLastHardwareStatsUploadPosixtimeLow32 = 712,
 
@@ -300,7 +299,10 @@ namespace GTA
         VideoUploadPrivacy = 960,
         RockstarEditorTooltip = 961,
         VideoExportGraphicsUpgrade = 962,
-        RockstarEditorTutorialFlags = 963, // s32 of flags representing if R* Editor tutorials have been seen
+        /// <summary>
+        /// Indicates whether the  R* Editor tutorials have been seen. (1 = seen, 0 = not seen)
+        /// </summary>
+        RockstarEditorTutorialFlags = 963,
         ReplayAutoSaveRecording = 964,
         ReplayVideosCreated = 965,
     };

--- a/source/scripting_v3/GTA/ProfileSettings.cs
+++ b/source/scripting_v3/GTA/ProfileSettings.cs
@@ -52,6 +52,7 @@ namespace GTA
         /// Indicates whether the mouse axis is inverted while flying (1 = enabled, 0 = disabled).
         /// </summary>
 		MouseInversionFlying = 21,
+
         /// <summary>
         /// Indicates whether the mouse axis is inverted while in a submarine (1 = enabled, 0 = disabled).
         /// </summary>
@@ -99,7 +100,14 @@ namespace GTA
         /// Indicates whether the Autosaving feature is enabled (1 = enabled, 0 = disabled).
         /// </summary>
         DisplayAutosaveMode = 208,
+
+        /// <summary>
+        /// Indicates where the camera is placed while in a vehicle and 1st person. (1 = hood, 0 = player)
+        /// </summary>
         DisplayHandbrakeCam = 209,
+
+        /// <inheritdoc cref="DisplayHandbrakeCam"/>
+        DisplayHoodCam = DisplayHandbrakeCam,
 
         /// <summary>
         /// Legacy version of <see cref="DisplayGamma"/>, exact game version is unknown.
@@ -111,6 +119,10 @@ namespace GTA
         /// <summary>
         /// Represents the display safezone size, range 0 - 10.
         /// </summary>
+        /// <remarks>
+        /// The safezone is the area the game places HUD elements in.
+        /// The larger the safe zone, the smaller the area where hud elements are placed.
+        /// </remarks>
         DisplaySafezoneSize = 212,
 
         /// <summary>
@@ -129,6 +141,7 @@ namespace GTA
         /// Represents the camera height while driving (0 = low, 1 = high)
         /// </summary>
         DisplayCameraHeight = 220,
+
         /// <summary>
         /// Indicates whether the big radar is enabled (1 = enabled, 0 = disabled).
         /// </summary>
@@ -270,6 +283,9 @@ namespace GTA
         PrologueComplete = 903,
         FacebookPostedAllVehiclesDriven = 904,
         EulaVersion = 905,
+        /// <summary>
+        /// Represents the version of the Terms-Of-Service
+        /// </summary>
         TosVersion = 907,
         PrivacyVersion = 908,
         JobActivityIdChar0 = 909, //Id of the UGC activity started so we know if the player has pulled the plug.


### PR DESCRIPTION
Pretty self explanatory, still working on Docs.

I was thinking of adding a ProfileSettings helper class to make some stuff easier.
For example, there are two Int32 variables (PcLastHardwareStatsUploadPosixtimeHigh32 and PcLastHardwareStatsUploadPosixtimeLow32) that together represent an Int64.