### PR TITLE
feat(api-v3): add missing entries to `HudColor` enum

### DIFF
--- a/source/scripting_v3/GTA.UI/HudColor.cs
+++ b/source/scripting_v3/GTA.UI/HudColor.cs
@@ -232,5 +232,29 @@ namespace GTA.UI
         TechGreenDark,
         TechRed,
         TechGreenVeryDark,
+        /// <summary>
+        /// Represents a placeholder entry for future use.
+        /// </summary>
+        Placeholder01,
+        ///<inheritdoc cref="Placeholder01"/>
+        Placeholder02,
+        ///<inheritdoc cref="Placeholder01"/>
+        Placeholder03,
+        ///<inheritdoc cref="Placeholder01"/>
+        Placeholder04,
+        ///<inheritdoc cref="Placeholder01"/>
+        Placeholder05,
+        ///<inheritdoc cref="Placeholder01"/>
+        Placeholder06,
+        ///<inheritdoc cref="Placeholder01"/>
+        Placeholder07,
+        ///<inheritdoc cref="Placeholder01"/>
+        Placeholder08,
+        ///<inheritdoc cref="Placeholder01"/>
+        Placeholder09,
+        ///<inheritdoc cref="Placeholder01"/>
+        Placeholder10,
+
+        JunkEnergy,
     }
 }


### PR DESCRIPTION
As described before, the placeholder enums are defined by R*.