### PR TITLE
chore(api-v2,api-v3): make the description show in file explorer and add an identifying (matching) product name

### DIFF
--- a/source/scripting_v2/ScriptHookVDotNet_APIv2.csproj
+++ b/source/scripting_v2/ScriptHookVDotNet_APIv2.csproj
@@ -26,15 +26,15 @@
     <FileVersion>2.11.6</FileVersion>
     <AssemblyVersion>2.11.6</AssemblyVersion>
     <Authors>crosire &amp; kagikn &amp; contributors</Authors>
-		<AssemblyTitle>The developer SDK for ScriptHookVDotNet v2 scripts for Grand Theft Auto V</AssemblyTitle>
-		<Product>ScriptHookVDotNet</Product>
+    <AssemblyTitle>ScriptHookVDotNet v2 API</AssemblyTitle>
+    <Product>ScriptHookVDotNet</Product>
     <Company></Company>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/scripthookvdotnet/scripthookvdotnet</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
     <PackageReleaseNotes>https://github.com/scripthookvdotnet/scripthookvdotnet/releases</PackageReleaseNotes>
-    <Description>The developer SDK for ScriptHookVDotNet v2 scripts for Grand Theft Auto V</Description>
+    <Description>ScriptHookVDotNet v2 API</Description>
     <Copyright>Copyright © 2015 crosire &amp; kagikn</Copyright>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>

--- a/source/scripting_v3/ScriptHookVDotNet_APIv3.csproj
+++ b/source/scripting_v3/ScriptHookVDotNet_APIv3.csproj
@@ -26,15 +26,15 @@
     <FileVersion>3.6.0</FileVersion>
     <AssemblyVersion>3.6.0</AssemblyVersion>
     <Authors>crosire &amp; kagikn &amp; contributors</Authors>
-		<AssemblyTitle>The developer SDK for ScriptHookVDotNet v3 scripts for Grand Theft Auto V</AssemblyTitle>
-		<Product>ScriptHookVDotNet</Product>
+    <AssemblyTitle>ScriptHookVDotNet v3 API</AssemblyTitle>
+    <Product>ScriptHookVDotNet</Product>
     <Company></Company>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <RepositoryUrl>https://github.com/scripthookvdotnet/scripthookvdotnet</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
     <PackageReleaseNotes>https://github.com/scripthookvdotnet/scripthookvdotnet/releases</PackageReleaseNotes>
-    <Description>The developer SDK for ScriptHookVDotNet v3 scripts for Grand Theft Auto V</Description>
+    <Description>ScriptHookVDotNet v3 API</Description>
     <Copyright>Copyright © 2015 crosire &amp; kagikn</Copyright>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>


### PR DESCRIPTION
Allows the file explorer to show the description (full description on Windows 10 likely only on file hover) and adds 'Product name' as a matching name for both DLLs.
<img width="363" height="509" alt="image" src="https://github.com/user-attachments/assets/cecf74a0-4d95-4046-af95-ebe7c24b9a2f" />
