### PR TITLE
feat(api-v3): add getters for 12 fields, resolve #1623

### DIFF
--- a/source/scripting_v3/GTA/Entities/Peds/Ped.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Ped.cs
@@ -2731,8 +2731,8 @@ namespace GTA
         /// </summary>
         public bool NeverLeavesGroup
         {
-            set => Function.Call(Hash.SET_PED_NEVER_LEAVES_GROUP, Handle, value);
             get => GetConfigFlag(PedConfigFlagToggles.NeverLeavesGroup);
+            set => Function.Call(Hash.SET_PED_NEVER_LEAVES_GROUP, Handle, value);
         }
 
         /// <summary>


### PR DESCRIPTION

STILL A DRAFT AS I STILL NEED DO TEST

Simplified the GETTERS of two fields(CanBeTargetted, CanSufferCriticalHits) like mentioned in #1623.

**Fields with added GET**

- CanPlayGestures
- CanBeDraggedOutOfVehicle
- CanBeShotInVehicle
- CanSwitchWeapon
- CanWearHelmet
- DiesInstantlyInWater
- DrownsInSinkingVehicle
- DrownsInWater
- IsEnemy
- IsPriorityTargetForEnemy
- NeverLeavesGroup
- StaysInVehicleWhenJacked


1. All docs were updated accordingly
2. I double checked where to use ResetFlag and where to use ConfigFlag
3. Dispite the title of Commit a3a7bf3 no setter was added!