### PR TITLE
refactor(api-v3): use `ConfigFlag` helpers for `CanFlyThroughWindscreen`

### DIFF
--- a/source/scripting_v3/GTA/Entities/Peds/Ped.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Ped.cs
@@ -1734,10 +1734,13 @@ namespace GTA
             set => Function.Call(Hash.SET_PED_CAN_BE_KNOCKED_OFF_VEHICLE, Handle, !value);
         }
 
+        /// <summary>
+        /// Gets or sets whether this <see cref="Ped"/> will fly through the windscreen when hit by a vehicle.
+        /// </summary>
         public bool CanFlyThroughWindscreen
         {
-            get => Function.Call<bool>(Hash.GET_PED_CONFIG_FLAG, Handle, 32, true);
-            set => Function.Call(Hash.SET_PED_CONFIG_FLAG, Handle, 32, value);
+            get => GetConfigFlag(PedConfigFlagToggles.WillFlyThroughWindscreen);
+            set => SetConfigFlag(PedConfigFlagToggles.WillFlyThroughWindscreen, value);
         }
 
         /// <summary>


### PR DESCRIPTION
Replaces direct native calls in CanFlyThroughWindscreen with GetConfigFlag and SetConfigFlag using the PedConfigFlagToggles enum for improved clarity and consistency.

This would also resolve #1623
