### PR TITLE
feat(api-v3): add missing `LicensePlateStyle` entries

### DIFF
--- a/source/scripting_v3/GTA/Entities/Vehicles/LicensePlateStyle.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/LicensePlateStyle.cs
@@ -13,12 +13,12 @@ namespace GTA
         YellowOnBlack = 1,
         YellowOnBlue = 2,
         NorthYankton = 5,
-        ECola = 7,
-        LasVenturas = 8,
-        LibertyCity = 9,
-        LSCarMeet = 10,
-        LSPanic = 11,
-        LSPounders = 12,
-        Sprunk = 13
+        ECola = 6,
+        LasVenturas = 7,
+        LibertyCity = 8,
+        LSCarMeet = 9,
+        LSPanic = 10,
+        LSPounders = 11,
+        Sprunk = 12
     }
 }


### PR DESCRIPTION

Reference:
https://github.com/DurtyFree/gta-v-data-dumps/blob/master/vehicleColors.json#L1916-L2076

(also private testing)