### PR TITLE
fear(api-v3): update `VehicleMissionType` enum

### DIFF
--- a/source/scripting_v3/GTA/Entities/Vehicles/VehicleMissionType.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/VehicleMissionType.cs
@@ -3,6 +3,8 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
     public enum VehicleMissionType
@@ -17,14 +19,22 @@ namespace GTA
         Follow = 7,
         Flee = 8,
         Circle = 9,
-        Escort = 12,
+        EscortLeft = 10,
+        EscortRight = 11,
+        EscortRear = 12,
+        EscortFront = 13,
         GoToRacing = 14,
         FollowRecording = 15,
         PoliceBehaviour = 16,
+        ParkPerpendicular = 17,
+        ParkParallel = 18,
         Land = 19,
         LandAndWait = 20,
         Crash = 21,
         PullOver = 22,
-        HeliProtect = 23
+        HeliProtect = 23,
+
+        [Obsolete("Use VehicleMissionType.EscortRear instead.")]
+        Escort = EscortRear,
     }
 }


### PR DESCRIPTION
Marked **Escort** as obsolete as it is not completly accurate

Reference:
(commands.sch, Line 7-32)
<img width="555" height="512" alt="image" src="https://github.com/user-attachments/assets/a7fcf4e4-0b75-4004-807f-c76e2cb04a68" />
