### PR TITLE
feat(api-v3)!: make `MaxValue` and `MinValue` readonly in `GameClockData`

### DIFF
--- a/source/scripting_v3/GTA.Chrono/GameClockDate.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDate.cs
@@ -64,14 +64,14 @@ namespace GTA.Chrono
         /// <value>
         /// The largest possible value of <see cref="GameClockTime"/>, which is December 31, 2147483647 CE.
         /// </value>
-        public static GameClockDate MaxValue = new(int.MaxValue, OrdFlagsForMaxDate);
+        public static readonly GameClockDate MaxValue = new(int.MaxValue, OrdFlagsForMaxDate);
         /// <summary>
         /// Represents the smallest possible value of a <see cref="GameClockDate"/>.
         /// </summary>
         /// <value>
         /// The smallest possible value of <see cref="GameClockTime"/>, which is January 1, -2147483648 BCE.
         /// </value>
-        public static GameClockDate MinValue = new(int.MinValue, OrdFlagsForMinDate);
+        public static readonly GameClockDate MinValue = new(int.MinValue, OrdFlagsForMinDate);
 
         /// <summary>
         /// Returns the year part of this <see cref="GameClockDate"/>. The returned value is an integer in the range of


### PR DESCRIPTION
Based on the XML documentation and plain logic, I assume that `GameClockData.MinValue` and `GameClockData.MaxValue` were never supposed to be writable to.

https://github.com/scripthookvdotnet/scripthookvdotnet/blob/main/source/scripting_v3/GTA.Chrono/GameClockDate.cs#L61-#L74

Normally, I would mark this as a **breaking change**, but realistically speaking, why would anyone ever write to these fields?