### PR TITLE
perf(core): remove duplicate pattern for `PedIntelligenceDecisionMakerHashOffset`

### DIFF
--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -2552,13 +2552,6 @@ namespace SHVDN
                     FiringPatternOffset = *(int*)(address + 19);
                 }
 
-                address = MemScanner.FindPatternBmh("\x48\x85\xC0\x74\x7F\xF6\x80\x00\x00\x00\x00\x02\x75\x76", "xxxxxxx????xxx");
-                if (address != null)
-                {
-                    byte* setDecisionMakerHashFuncAddr = *(int*)(address + 0x18) + address + 0x1C;
-                    PedIntelligenceDecisionMakerHashOffset = *(int*)(setDecisionMakerHashFuncAddr + 0x1C);
-                }
-
                 address = MemScanner.FindPatternBmh("\xC1\xE8\x09\xA8\x01\x74\xAE\x0F\x28\xA3\x00\x00\x00\x00\x49\x8B\x47\x30\xF3\x0F\x10\x81", "xxxxxxxxxx??xxxxxxxxxx");
                 if (address != null)
                 {


### PR DESCRIPTION
In `NativeMemory`.`Ped`, the same pattern(`\x48\x85\xC0\x74\x7F\xF6\x80\x00\x00\x00\x00\x02\x75\x76`, `xxxxxxx????xxx`) is used twice in the same function, assigning the same value twice:

https://github.com/scripthookvdotnet/scripthookvdotnet/blob/32bbc7a01158a062f5bab8c4b8fb58e2fb65c60a/source/core/NativeMemory.cs#L2410-L2420
https://github.com/scripthookvdotnet/scripthookvdotnet/blob/32bbc7a01158a062f5bab8c4b8fb58e2fb65c60a/source/core/NativeMemory.cs#L2555-L2560

Both snippets perform the same operations for assigning `PedIntelligenceDecisionMakerHashOffset`, with the difference that the  first one, assigns more values.

This PR simple removes the second redundant snippet.

**Note:**

The same pattern is used again (https://github.com/scripthookvdotnet/scripthookvdotnet/blob/32bbc7a01158a062f5bab8c4b8fb58e2fb65c60a/source/core/NativeMemory.cs#L562-L567) in the `static` constructor of `NativeMemory`, this could be further optimized.