### PR TITLE
feat(api-v3): add missing versions to `VersionConstsForGameVersion` and `GameVersionNotSupportedException`

### DIFF
--- a/source/scripting_v3/GTA/GameVersionNotSupportedException.cs
+++ b/source/scripting_v3/GTA/GameVersionNotSupportedException.cs
@@ -106,6 +106,15 @@ namespace GTA
             { VersionConstsForGameVersion.v1_0_3274_0, GameVersion.v1_0_3274_0 },
             { VersionConstsForGameVersion.v1_0_3323_0, GameVersion.v1_0_3323_0 },
             { VersionConstsForGameVersion.v1_0_3337_0, GameVersion.v1_0_3337_0 },
+            { VersionConstsForGameVersion.v1_0_3351_0, GameVersion.v1_0_3351_0 },
+            { VersionConstsForGameVersion.v1_0_3407_0, GameVersion.V1_0_3407_0 },
+            { VersionConstsForGameVersion.v1_0_3411_0, GameVersion.V1_0_3411_0 },
+            { VersionConstsForGameVersion.v1_0_3442_0, GameVersion.V1_0_3442_0 },
+            { VersionConstsForGameVersion.v1_0_3504_0, GameVersion.V1_0_3504_0 },
+            { VersionConstsForGameVersion.v1_0_3521_0, GameVersion.V1_0_3521_0 },
+            { VersionConstsForGameVersion.v1_0_3570_0, GameVersion.V1_0_3570_0 },
+            { VersionConstsForGameVersion.v1_0_3586_0, GameVersion.V1_0_3586_0 },
+            { VersionConstsForGameVersion.v1_0_3717_0, GameVersion.V1_0_3717_0 },
         };
 
         internal GameVersionNotSupportedException(Version minSupportedGameVersion, string className, string propertyOrMethodName) : base(BuildErrorMessage(minSupportedGameVersion, className, propertyOrMethodName))

--- a/source/scripting_v3/GTA/VersionConstsForGameVersion.cs
+++ b/source/scripting_v3/GTA/VersionConstsForGameVersion.cs
@@ -66,5 +66,14 @@ namespace GTA
         internal static readonly Version v1_0_3274_0 = new(1, 0, 3274, 0);
         internal static readonly Version v1_0_3323_0 = new(1, 0, 3323, 0);
         internal static readonly Version v1_0_3337_0 = new(1, 0, 3337, 0);
+        internal static readonly Version v1_0_3351_0 = new(1, 0, 3351, 0);
+        internal static readonly Version v1_0_3407_0 = new(1, 0, 3407, 0);
+        internal static readonly Version v1_0_3411_0 = new(1, 0, 3411, 0);
+        internal static readonly Version v1_0_3442_0 = new(1, 0, 3442, 0);
+        internal static readonly Version v1_0_3504_0 = new(1, 0, 3504, 0);
+        internal static readonly Version v1_0_3521_0 = new(1, 0, 3521, 0);
+        internal static readonly Version v1_0_3570_0 = new(1, 0, 3570, 0);
+        internal static readonly Version v1_0_3586_0 = new(1, 0, 3586, 0);
+        internal static readonly Version v1_0_3717_0 = new(1, 0, 3717, 0);
     }
 }


### PR DESCRIPTION
Btw, is it intended that starting from b3407, entries in the `GameVersion` enum are prefixed with a capital V instead of a lowercase one?