### PR TITLE
feat(api-v3): implement facial animation methods

### DIFF
--- a/source/scripting_v3/GTA/Entities/Peds/CommonPedFacialAnimation.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/CommonPedFacialAnimation.cs
@@ -1,0 +1,80 @@
+namespace GTA
+{
+    /// <summary>
+    /// An enumeration of common facial animations that can be applied to all peds, as long as the facial animation <see cref="ClipSet"/> of the specified <see cref="Ped"/> is set to the "base" (default) variant.
+    /// </summary>
+    public enum CommonPedFacialAnimation
+    {
+        Burning,
+        Coughing,
+        Dead1,
+        Dead2,
+        Die1,
+        Die2,
+        Electrocuted,
+        Effort,
+        MeleeEffort1,
+        MeleeEffort2,
+        MeleeEffort3,
+        MoodAiming,
+        MoodAngry,
+        MoodDrivefast,
+        MoodDrunk,
+        MoodExcited,
+        MoodFrustrated,
+        MoodHappy,
+        MoodInjured,
+        MoodNormal,
+        MoodSleeping,
+        MoodSkydive,
+        MoodStressed,
+        MoodTalking,
+        Pain1,
+        Pain2,
+        Pain3,
+        Pain4,
+        Pain5,
+        Pain6
+    }
+
+    public static class CommonPedFacialAnimationExtensions
+    {
+        public static string GetAnimationName(this CommonPedFacialAnimation animation)
+        {
+            return animation switch
+            {
+                CommonPedFacialAnimation.Burning => "burning_1",
+                CommonPedFacialAnimation.Coughing => "coughing_1",
+                CommonPedFacialAnimation.Dead1 => "dead_1",
+                CommonPedFacialAnimation.Dead2 => "dead_2",
+                CommonPedFacialAnimation.Die1 => "die_1",
+                CommonPedFacialAnimation.Die2 => "die_2",
+                CommonPedFacialAnimation.Electrocuted => "electrocuted_1",
+                CommonPedFacialAnimation.Effort => "effort_1",
+                CommonPedFacialAnimation.MeleeEffort1 => "melee_effort_1",
+                CommonPedFacialAnimation.MeleeEffort2 => "melee_effort_2",
+                CommonPedFacialAnimation.MeleeEffort3 => "melee_effort_3",
+                CommonPedFacialAnimation.MoodAiming => "mood_aiming_1",
+                CommonPedFacialAnimation.MoodAngry => "mood_angry_1",
+                CommonPedFacialAnimation.MoodDrivefast => "mood_drivefast_1",
+                CommonPedFacialAnimation.MoodDrunk => "mood_drunk_1",
+                CommonPedFacialAnimation.MoodExcited => "mood_excited_1",
+                CommonPedFacialAnimation.MoodFrustrated => "mood_frustrated_1",
+                CommonPedFacialAnimation.MoodHappy => "mood_happy_1",
+                CommonPedFacialAnimation.MoodInjured => "mood_injured_1",
+                CommonPedFacialAnimation.MoodNormal => "mood_normal_1",
+                CommonPedFacialAnimation.MoodSleeping => "mood_sleeping_1",
+                CommonPedFacialAnimation.MoodSkydive => "mood_skydive_1",
+                CommonPedFacialAnimation.MoodStressed => "mood_stressed_1",
+                CommonPedFacialAnimation.MoodTalking => "mood_talking_1",
+                CommonPedFacialAnimation.Pain1 => "pain_1",
+                CommonPedFacialAnimation.Pain2 => "pain_2",
+                CommonPedFacialAnimation.Pain3 => "pain_3",
+                CommonPedFacialAnimation.Pain4 => "pain_4",
+                CommonPedFacialAnimation.Pain5 => "pain_5",
+                CommonPedFacialAnimation.Pain6 => "pain_6",
+                _ => "",
+            };
+        }
+    }
+}

--- a/source/scripting_v3/GTA/Entities/Peds/Ped.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Ped.cs
@@ -2881,6 +2881,75 @@ namespace GTA
         }
 
         /// <summary>
+        /// Overrides the facial idle animation for this <see cref="Ped"/> with the specified <see cref="CrClipAsset"/>.
+        /// </summary>
+        /// <param name="clipAsset">The <see cref="CrClipAsset"/> to use as the facial idle animation.</param>
+        /// <remarks>
+        /// <b>Note:</b> If the <see cref="CrClipDictionary"/> of the specified <see cref="CrClipAsset"/> is not suitable for this <see cref="Ped"/>, this method will have no effect.
+        /// </remarks>
+        public void SetFacialIdleAnimationOverride(CrClipAsset clipAsset)
+            => Function.Call(Hash.SET_FACIAL_IDLE_ANIM_OVERRIDE, Handle, clipAsset.ClipName, clipAsset.ClipDictionary.Name);
+
+        /// <summary>
+        /// Overrides the facial idle animation for this <see cref="Ped"/> with the specified animation name, using the current facial animation <see cref="ClipSet"/> of this <see cref="Ped"/>.
+        /// </summary>
+        /// <param name="animName">The name of the facial idle animation to apply.</param>
+        /// <remarks>
+        /// <b>Note:</b> If the current facial animation <see cref="ClipSet"/> of this <see cref="Ped"/> does not contain the specified animation, the override will not take effect.
+        /// </remarks>
+        public void SetFacialIdleAnimationOverride(string animName)
+            => Function.Call(Hash.SET_FACIAL_IDLE_ANIM_OVERRIDE, Handle, animName, null);
+
+        /// <summary>
+        /// Overrides the facial idle animation for this <see cref="Ped"/> with the specified animation, using the current facial animation <see cref="ClipSet"/> of this <see cref="Ped"/>.
+        /// </summary>
+        /// <param name="anim">The facial idle animation to apply.</param>
+        public void SetFacialIdleAnimationOverride(CommonPedFacialAnimation anim)
+            => SetFacialIdleAnimationOverride(anim.GetAnimationName());
+
+        /// <summary>
+        /// Sets the facial clipset this <see cref="Ped"/> should use.
+        /// </summary>
+        /// <param name="clipSet">The <see cref="ClipSet"/> to use.</param>
+        /// <remarks>The specified <see cref="ClipSet"/> must be loaded before calling this method.</remarks>
+        public void SetFacialClipset(ClipSet clipSet)
+            => Function.Call(Hash.SET_FACIAL_CLIPSET, Handle, clipSet.Name);
+
+        /// <summary>
+        /// Plays the specified facial animation on this <see cref="Ped"/>.
+        /// </summary>
+        /// <param name="clipAsset">The <see cref="CrClipAsset"/> to use as the facial animation.</param>
+        /// <remarks>
+        /// <para><b>Note:</b> If the <see cref="CrClipDictionary"/> of the specified <see cref="CrClipAsset"/> is not suitable for this <see cref="Ped"/>, this method will have no effect.</para>
+        /// The specified <see cref="CrClipAsset"/> must be loaded before calling this method, or the animation will not play.
+        /// </remarks>
+        public void PlayFacialAnimation(CrClipAsset clipAsset)
+            => Function.Call(Hash.PLAY_FACIAL_ANIM, Handle, clipAsset.ClipName, clipAsset.ClipDictionary.Name);
+
+        /// <summary>
+        /// Plays the specified facial animation for this <see cref="Ped"/>, using the current facial animation <see cref="ClipSet"/> of this <see cref="Ped"/>.
+        /// </summary>
+        /// <param name="animName">The name of the facial animation to apply.</param>
+        /// <remarks>
+        /// <b>Note:</b> If the current facial animation <see cref="ClipSet"/> of this <see cref="Ped"/> does not contain the specified animation, this method will have no effect.
+        /// </remarks>
+        public void PlayFacialAnimation(string animName)
+            => Function.Call(Hash.PLAY_FACIAL_ANIM, Handle, animName, null);
+
+        /// <summary>
+        /// Plays the specified facial animation for this <see cref="Ped"/>, using the current facial animation <see cref="ClipSet"/> of this <see cref="Ped"/>.
+        /// </summary>
+        /// <param name="anim">The facial animation to apply.</param>
+        public void PlayFacialAnimation(CommonPedFacialAnimation anim)
+            => PlayFacialAnimation(anim.GetAnimationName());
+
+        /// <summary>
+        /// Clears any facial idle animation override set on this <see cref="Ped"/> and restores the default facial idle animation.
+        /// </summary>
+        public void ClearFacialIdleAnimationOverride()
+            => Function.Call(Hash.CLEAR_FACIAL_IDLE_ANIM_OVERRIDE, Handle);
+
+        /// <summary>
         /// Sets the movement clipset this <see cref="Ped"/> should use.
         /// Do not forget to stream in/load the clipset you want to load, or the method silently will fail.
         /// </summary>


### PR DESCRIPTION
New pull request based on requested changes in #1658.

I have implemented methods to modify the facial animation of a ped, including:
- Playing facial animations
- Overriding the idle facial animation
- Resetting the idle facial animation

I have added an enum "CommonPedFacialAnimation" that includes facial animations which can be applied to any ped, as long as the facial animation clipset of that Ped is set to the "base" (default) variant. F.e.: "facials@gen_female@base"

After further testing: 
Methods that change the facial animation of a Ped have no effect if the specified anim dictionary is not suitable for the Ped. 
F.e.: I personally understand "facials@p_m_two@base" as "base variant of facials for player male two". Those will have no effect on Franklin, as they are meant for player two (Trevor).

Providing null as the dicitionary will result in the current clipset of the ped being used.
