### PR TITLE
fix(api-v3): fix `ParachuteLandingType` alignment shift

### DIFF
--- a/source/scripting_v3/GTA/Entities/Peds/ParachuteLandingType.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/ParachuteLandingType.cs
@@ -13,7 +13,7 @@ namespace GTA
         /// <summary>
         /// Ped is not in a valid parachute landing state.
         /// </summary>
-        Invalid,
+        Invalid = -1,
         Slow,
         /// <summary>
         /// Ped is landing at regular speed (they are stumbling).


### PR DESCRIPTION
The bug was caused by the first entry of the enum having a value of 0 instead of -1 causing the entire enum to be shifted by 1.