### PR TITLE
refactor(core,api-v3): seperate structs and enums from `NativeMemory`

### DIFF
--- a/source/core/Enums/CScriptResourceTypeNameIndex.cs
+++ b/source/core/Enums/CScriptResourceTypeNameIndex.cs
@@ -1,0 +1,9 @@
+namespace SHVDN
+{
+    internal enum CScriptResourceTypeNameIndex : ushort
+    {
+        Checkpoint = 6,
+        RelGroup = 20,
+        ScaleformMovie = 21,
+    }
+}

--- a/source/core/Enums/EntityTypeInternal.cs
+++ b/source/core/Enums/EntityTypeInternal.cs
@@ -1,0 +1,12 @@
+namespace SHVDN
+{
+    internal enum EntityTypeInternal
+    {
+        Invalid = 0,
+        Building = 1,
+        AnimatedBuilding = 2,
+        Vehicle = 3,
+        Ped = 4,
+        Object = 5
+    }
+}

--- a/source/core/Enums/ModelInfoClassType.cs
+++ b/source/core/Enums/ModelInfoClassType.cs
@@ -1,0 +1,13 @@
+namespace SHVDN
+{
+    internal enum ModelInfoClassType
+    {
+        Invalid = 0,
+        Object = 1,
+        Mlo = 2,
+        Time = 3,
+        Weapon = 4,
+        Vehicle = 5,
+        Ped = 6
+    }
+}

--- a/source/core/Enums/PoolType.cs
+++ b/source/core/Enums/PoolType.cs
@@ -1,0 +1,9 @@
+namespace SHVDN
+{
+    internal enum PoolType
+    {
+        Generic,
+        Vehicle,
+        Projectile,
+    }
+}

--- a/source/core/Enums/Vehicle/VehicleFlag1.cs
+++ b/source/core/Enums/Vehicle/VehicleFlag1.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace SHVDN
+{
+    [Flags]
+    public enum VehicleFlag1 : ulong
+    {
+        Big = 0x2,
+        IsVan = 0x20,
+        CanStandOnTop = 0x10000000,
+        LawEnforcement = 0x80000000,
+        EmergencyService = 0x100000000,
+        AllowsRappel = 0x8000000000,
+        IsElectric = 0x80000000000,
+        IsOffroadVehicle = 0x1000000000000,
+        IsBus = 0x400000000000000,
+    }
+}

--- a/source/core/Enums/Vehicle/VehicleFlag2.cs
+++ b/source/core/Enums/Vehicle/VehicleFlag2.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace SHVDN
+{
+    [Flags]
+    public enum VehicleFlag2 : ulong
+    {
+        IsTank = 0x200,
+        HasBulletProofGlass = 0x1000,
+        HasLowriderHydraulics = 0x80000000000000,
+        HasLowriderDonkHydraulics = 0x800000000000000,
+    }
+}

--- a/source/core/Enums/Vehicle/VehiclePathNodeProperties.cs
+++ b/source/core/Enums/Vehicle/VehiclePathNodeProperties.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace SHVDN
+{
+    [Flags]
+    public enum VehiclePathNodeProperties
+    {
+        None = 0,
+        OffRoad = 1,
+        OnPlayersRoad = 2,
+        NoBigVehicles = 4,
+        SwitchedOff = 8,
+        TunnelOrInterior = 16,
+        LeadsToDeadEnd = 32,
+        /// <summary>
+        /// <see cref="Boat"/> takes precedence over this flag.
+        /// </summary>
+        Highway = 64,
+        Junction = 128,
+        /// <summary>
+        /// Cannot be used with <see cref="GiveWay"/>, because vehicle nodes can have either traffic-light or give-way feature as a special function but cannot have both of them.
+        /// </summary>
+        TrafficLight = 256,
+        /// <summary>
+        /// Cannot be used with <see cref="TrafficLight"/>, because vehicle nodes can have either traffic-light or give-way feature as a special function but cannot have both of them.
+        /// </summary>
+        GiveWay = 512,
+        /// <summary>
+        /// Cannot be used with <see cref="Highway"/>.
+        /// </summary>
+        Boat = 1024,
+
+        // GET_VEHICLE_NODE_PROPERTIES will not set any of the values below set as flags
+        DontAllowGps = 2048,
+    }
+}

--- a/source/core/Enums/Vehicle/VehicleStructClassType.cs
+++ b/source/core/Enums/Vehicle/VehicleStructClassType.cs
@@ -1,0 +1,22 @@
+namespace SHVDN
+{
+    internal enum VehicleStructClassType
+    {
+        None = -1,
+        Automobile = 0x0,
+        Plane = 0x1,
+        Trailer = 0x2,
+        QuadBike = 0x3,
+        SubmarineCar = 0x5,
+        AmphibiousAutomobile = 0x6,
+        AmphibiousQuadBike = 0x7,
+        Heli = 0x8,
+        Blimp = 0x9,
+        Autogyro = 0xA,
+        Bike = 0xB,
+        Bicycle = 0xC,
+        Boat = 0xD,
+        Train = 0xE,
+        Submarine = 0xF
+    }
+}

--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -1054,83 +1054,6 @@ namespace SHVDN
 
         #endregion
 
-        #region -- YSC Script Data --
-
-        [StructLayout(LayoutKind.Explicit)]
-        private struct YscScriptHeader
-        {
-            [FieldOffset(0x10)]
-            internal byte** codeBlocksOffset;
-            [FieldOffset(0x1C)]
-            internal int codeLength;
-            [FieldOffset(0x24)]
-            internal int localCount;
-            [FieldOffset(0x2C)]
-            internal int nativeCount;
-            [FieldOffset(0x30)]
-            internal long* localOffset;
-            [FieldOffset(0x40)]
-            internal long* nativeOffset;
-            [FieldOffset(0x58)]
-            internal int nameHash;
-
-            internal int CodePageCount()
-            {
-                return (codeLength + 0x3FFF) >> 14;
-            }
-            internal int GetCodePageSize(int page)
-            {
-                return (page < 0 || page >= CodePageCount() ? 0 : (page == CodePageCount() - 1) ? codeLength & 0x3FFF : 0x4000);
-            }
-            internal IntPtr GetCodePageAddress(int page)
-            {
-                return new IntPtr(codeBlocksOffset[page]);
-            }
-        }
-
-        [StructLayout(LayoutKind.Explicit)]
-        private struct YscScriptTableItem
-        {
-            [FieldOffset(0x0)]
-            internal YscScriptHeader* header;
-            [FieldOffset(0xC)]
-            internal int hash;
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            internal bool IsLoaded()
-            {
-                return header != null;
-            }
-        }
-
-        [StructLayout(LayoutKind.Explicit)]
-        private struct YscScriptTable
-        {
-            [FieldOffset(0x0)]
-            internal YscScriptTableItem* TablePtr;
-            [FieldOffset(0x18)]
-            internal uint count;
-
-            internal YscScriptTableItem* FindScript(int hash)
-            {
-                if (TablePtr == null)
-                {
-                    return null; //table initialisation hasn't happened yet
-                }
-                for (int i = 0; i < count; i++)
-                {
-                    if (TablePtr[i].hash == hash)
-                    {
-                        return &TablePtr[i];
-                    }
-                }
-                return null;
-            }
-        }
-
-
-        #endregion
-
         #region -- Decorator Data --
 
         private static byte* s_isDecoratorLocked;
@@ -1442,33 +1365,6 @@ namespace SHVDN
 
         #region -- CPhysical Data --
 
-        // the size is at least 0x10 in all game versions
-        [StructLayout(LayoutKind.Explicit, Size = 0x10)]
-        private struct CAttacker
-        {
-            [FieldOffset(0x0)]
-            internal ulong attackerEntityAddress;
-            [FieldOffset(0x8)]
-            internal int weaponHash;
-            [FieldOffset(0xC)]
-            internal int gameTime;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public struct EntityDamageRecordForReturnValue
-        {
-            public int attackerEntityHandle;
-            public int weaponHash;
-            public int gameTime;
-
-            public EntityDamageRecordForReturnValue(int attackerEntityHandle, int weaponHash, int gameTime)
-            {
-                this.attackerEntityHandle = attackerEntityHandle;
-                this.weaponHash = weaponHash;
-                this.gameTime = gameTime;
-            }
-        }
-
         public static bool IsIndexOfEntityDamageRecordValid(IntPtr entityAddress, uint index)
         {
             if (NativeMemory.CAttackerArrayOfEntityOffset == 0 ||
@@ -1671,16 +1567,6 @@ namespace SHVDN
             }
 
             return new IntPtr(targetCEntityAddress);
-        }
-
-        private enum EntityTypeInternal
-        {
-            Invalid = 0,
-            Building = 1,
-            AnimatedBuilding = 2,
-            Vehicle = 3,
-            Ped = 4,
-            Object = 5
         }
 
         #endregion
@@ -2898,20 +2784,6 @@ namespace SHVDN
 
         #region -- Screen Data --
 
-        [StructLayout(LayoutKind.Explicit, Size = 0x30)]
-        internal struct ScreenInfo
-        {
-            // these fields should be in pixel coordinates
-            [FieldOffset(0x14)]
-            internal uint left;
-            [FieldOffset(0x18)]
-            internal uint right;
-            [FieldOffset(0x1C)]
-            internal uint top;
-            [FieldOffset(0x20)]
-            internal uint bottom;
-        }
-
         private static int* s_physicalScrenWidthAddr;
         private static int* s_physicalScrenHeightAddr;
         private static IntPtr s_screenInfoAddr;
@@ -2960,85 +2832,6 @@ namespace SHVDN
         #endregion
 
         #region -- Model Info --
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct HashNode
-        {
-            internal int hash;
-            internal ushort data;
-            internal ushort padding;
-            internal HashNode* next;
-        }
-
-        private enum ModelInfoClassType
-        {
-            Invalid = 0,
-            Object = 1,
-            Mlo = 2,
-            Time = 3,
-            Weapon = 4,
-            Vehicle = 5,
-            Ped = 6
-        }
-
-        private enum VehicleStructClassType
-        {
-            None = -1,
-            Automobile = 0x0,
-            Plane = 0x1,
-            Trailer = 0x2,
-            QuadBike = 0x3,
-            SubmarineCar = 0x5,
-            AmphibiousAutomobile = 0x6,
-            AmphibiousQuadBike = 0x7,
-            Heli = 0x8,
-            Blimp = 0x9,
-            Autogyro = 0xA,
-            Bike = 0xB,
-            Bicycle = 0xC,
-            Boat = 0xD,
-            Train = 0xE,
-            Submarine = 0xF
-        }
-        [Flags]
-        public enum VehicleFlag1 : ulong
-        {
-            Big = 0x2,
-            IsVan = 0x20,
-            CanStandOnTop = 0x10000000,
-            LawEnforcement = 0x80000000,
-            EmergencyService = 0x100000000,
-            AllowsRappel = 0x8000000000,
-            IsElectric = 0x80000000000,
-            IsOffroadVehicle = 0x1000000000000,
-            IsBus = 0x400000000000000,
-        }
-        [Flags]
-        public enum VehicleFlag2 : ulong
-        {
-            IsTank = 0x200,
-            HasBulletProofGlass = 0x1000,
-            HasLowriderHydraulics = 0x80000000000000,
-            HasLowriderDonkHydraulics = 0x800000000000000,
-        }
-
-        [StructLayout(LayoutKind.Explicit, Size = 0x400)]
-        private struct CModelList
-        {
-            [FieldOffset(0x0)]
-            internal fixed uint modelMemberIndices[0x100];
-        }
-
-        [StructLayout(LayoutKind.Explicit, Size = 0xB8)]
-        private struct PedPersonality
-        {
-            [FieldOffset(0x7C)]
-            internal bool isMale;
-            [FieldOffset(0x7D)]
-            internal bool isHuman;
-            [FieldOffset(0x7F)]
-            internal bool isGang;
-        }
 
         private static int s_vehicleMakeNameOffsetInModelInfo;
         private static int s_vehicleTypeOffsetInModelInfo;
@@ -3403,179 +3196,6 @@ namespace SHVDN
 
         #region -- Entity Pools --
 
-        // Note: actually this struct is supposed to point the same struct type as `FwBasePool` in this source code
-        // file, but needs to be careful when refactoring.
-        [StructLayout(LayoutKind.Explicit)]
-        private struct FwScriptGuidPool
-        {
-            // The max count value should be at least 3072 as long as ScriptHookV is installed.
-            // Without ScriptHookV, the default value is hardcoded and may be different between different game versions (the value is 300 in b372 and 700 in b2824).
-            // The default value (when running without ScriptHookV) can be found by searching the dumped exe or the game memory with "D7 A8 11 73" (0x7311A8D7).
-            [FieldOffset(0x10)]
-            internal uint maxCount;
-            [FieldOffset(0x14)]
-            internal int itemSize;
-            [FieldOffset(0x18)]
-            internal int firstEmptySlot;
-            [FieldOffset(0x1C)]
-            internal int emptySlots;
-            [FieldOffset(0x20)]
-            internal uint itemCount;
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            internal bool IsFull()
-            {
-                return maxCount - (itemCount & 0x3FFFFFFF) <= 256;
-            }
-        }
-
-        /// <summary>
-        /// Represents <c>rage::sysMemPoolAllocator</c>, which all of the
-        /// <c>rage::sysMemPoolAllocator::PoolWrapper&lt;typename T&gt;</c> have as the sole field via an pointer.
-        /// </summary>
-        /// <remarks>
-        /// Possible (without limitation) <c>typename T</c>s of
-        /// <c>rage::sysMemPoolAllocator::PoolWrapper&lt;typename T&gt;</c> are <c>CTask</c>, <c>CTaskInfo</c>,
-        /// <c>CVehicle</c>, <c>audVehicleAudioEntity</c>, and <c>void *</c>.
-        /// </remarks>
-        [StructLayout(LayoutKind.Explicit)]
-        private struct RageSysMemPoolAllocator
-        {
-            // m_pool at offset 0x0 takes 0x60 byte
-            // (type: "rage::atIteratablePool<rage::sysMemPoolAllocator::PoolNode>").
-            [FieldOffset(0x00)]
-            internal ulong* poolAddress;
-            [FieldOffset(0x08)]
-            internal uint size;
-            [FieldOffset(0x30)]
-            internal uint* bitArray;
-
-            // m_freeList at 0x60 takes 0x18 bytes (type: "rage::inlist<rage::sysMemPoolAllocator::FreeNode,8>").
-            // The struct contains m_head, m_tail and m_size fields.
-            [FieldOffset(0x60)]
-            internal uint itemCount;
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            internal bool IsValid(uint i)
-            {
-                return ((bitArray[i >> 5] >> ((int)i & 0x1F)) & 1) != 0;
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            internal ulong GetAddress(uint i)
-            {
-                return poolAddress[i];
-            }
-        }
-
-        /// <summary>
-        /// Represents <c>rage::fwBasePool</c>, which all of the <c>rage::fwPool&lt;typename T&gt;</c> types has as
-        /// the sole field.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// The <c>rage::fwBasePool</c> takes 0x30 bytes without a vtable pointer in production builds, but that in
-        /// a debug build around v1.0.2699.0 takes 0x68 bytes with a vtable pointer and additional debug fields.
-        /// </para>
-        /// <para>
-        /// All of <c>rage::fwPool&lt;typename T&gt;</c> types (at least 243 types) has the same layout but with
-        /// different element type (at least the return type of <c>GetSlot(int)</c> differs by type parameter).
-        /// </para>
-        /// </remarks>
-        [StructLayout(LayoutKind.Explicit)]
-        private struct FwBasePool
-        {
-            [FieldOffset(0x00)]
-            public ulong poolStartAddress;
-            [FieldOffset(0x08)]
-            public IntPtr byteArray;
-            [FieldOffset(0x10)]
-            public uint size;
-            [FieldOffset(0x14)]
-            public uint itemSize;
-
-            // The "first" index should be at 0x18 and The "last" index should be at 0x1C in production builds
-            // according to the layout in a debug build around v1.0.2699.0, but the "first" and the "last" aren't
-            // related to about the order.
-
-            // WARNING: according to `rage::fwBasePoolTracker::GetNoOfUsedSpaces`, this field is supposed to be read
-            // by reading as a 4-byte value, applying left shift by 2 and SIGNED right shift (`SAR` in assembly code)
-            // by 2, and then return the calculated value.
-            [FieldOffset(0x20)]
-            public ushort itemCount;
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public bool IsValid(uint index)
-            {
-                return Mask(index) != 0;
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public bool IsHandleValid(int handle)
-            {
-                uint handleUInt = (uint)handle;
-                uint index = handleUInt >> 8;
-                return GetCounter(index) == (handleUInt & 0xFFu);
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public ulong GetAddress(uint index)
-            {
-                return ((Mask(index) & (poolStartAddress + index * itemSize)));
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public IntPtr GetAddressFromHandle(int handle)
-            {
-                return IsHandleValid(handle) ? new IntPtr((long)GetAddress((uint)handle >> 8)) : IntPtr.Zero;
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public int GetGuidHandleByIndex(uint index)
-            {
-                return IsValid(index) ? (int)((index << 8) + GetCounter(index)) : 0;
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public int GetGuidHandleFromAddress(ulong address)
-            {
-                if (address < poolStartAddress || address >= poolStartAddress + size * itemSize)
-                {
-                    return 0;
-                }
-
-                ulong offset = address - poolStartAddress;
-                if (offset % itemSize != 0)
-                {
-                    return 0;
-                }
-
-                uint indexOfPool = (uint)(offset / itemSize);
-                return (int)((indexOfPool << 8) + GetCounter(indexOfPool));
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            private byte GetCounter(uint index)
-            {
-                unsafe
-                {
-                    byte* byteArrayPtr = (byte*)byteArray.ToPointer();
-                    return (byte)(byteArrayPtr[index] & 0x7F);
-                }
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            private ulong Mask(uint index)
-            {
-                unsafe
-                {
-                    byte* byteArrayPtr = (byte*)byteArray.ToPointer();
-                    long num1 = byteArrayPtr[index] & 0x80;
-                    return (ulong)(~((num1 | -num1) >> 63));
-                }
-            }
-        }
-
         private static ulong* s_fwScriptGuidPoolAddress;
         private static ulong* s_pedPoolAddress;
         private static ulong* s_objectPoolAddress;
@@ -3596,13 +3216,6 @@ namespace SHVDN
 
         internal sealed class FwScriptGuidPoolTask : IScriptTask
         {
-            internal enum PoolType
-            {
-                Generic,
-                Vehicle,
-                Projectile,
-            }
-
             #region Fields
             internal PoolType _poolType;
             internal IntPtr _poolAddress;
@@ -3959,7 +3572,7 @@ namespace SHVDN
 
             var poolAllocator = new IntPtr(*(RageSysMemPoolAllocator**)(*NativeMemory.s_vehiclePoolAddress));
 
-            var task = new FwScriptGuidPoolTask(FwScriptGuidPoolTask.PoolType.Vehicle, poolAllocator, modelHashes);
+            var task = new FwScriptGuidPoolTask(PoolType.Vehicle, poolAllocator, modelHashes);
             ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
 
             return task._resultHandles;
@@ -3973,7 +3586,7 @@ namespace SHVDN
 
             var poolAllocator = new IntPtr(*(RageSysMemPoolAllocator**)(*NativeMemory.s_vehiclePoolAddress));
 
-            var task = new FwScriptGuidPoolTask(FwScriptGuidPoolTask.PoolType.Vehicle, poolAllocator, position, radius * radius, modelHashes);
+            var task = new FwScriptGuidPoolTask(PoolType.Vehicle, poolAllocator, position, radius * radius, modelHashes);
             ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
 
             return task._resultHandles;
@@ -3994,7 +3607,7 @@ namespace SHVDN
                 return Array.Empty<int>();
             }
 
-            var task = new FwScriptGuidPoolTask(FwScriptGuidPoolTask.PoolType.Projectile, new IntPtr(NativeMemory.s_projectilePoolAddress));
+            var task = new FwScriptGuidPoolTask(PoolType.Projectile, new IntPtr(NativeMemory.s_projectilePoolAddress));
             ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
 
             return task._resultHandles;
@@ -4006,7 +3619,7 @@ namespace SHVDN
                 return Array.Empty<int>();
             }
 
-            var task = new FwScriptGuidPoolTask(FwScriptGuidPoolTask.PoolType.Projectile,
+            var task = new FwScriptGuidPoolTask(PoolType.Projectile,
                 new IntPtr(NativeMemory.s_projectilePoolAddress), position, radius * radius);
             ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
 
@@ -4019,7 +3632,7 @@ namespace SHVDN
                 return Array.Empty<int>();
             }
 
-            var task = new FwScriptGuidPoolTask(FwScriptGuidPoolTask.PoolType.Projectile,
+            var task = new FwScriptGuidPoolTask(PoolType.Projectile,
                 new IntPtr(NativeMemory.s_projectilePoolAddress),
                 address => GetAsCProjectileRocket(address) != IntPtr.Zero);
             ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
@@ -4033,7 +3646,7 @@ namespace SHVDN
                 return Array.Empty<int>();
             }
 
-            var task = new FwScriptGuidPoolTask(FwScriptGuidPoolTask.PoolType.Projectile,
+            var task = new FwScriptGuidPoolTask(PoolType.Projectile,
                 new IntPtr(NativeMemory.s_projectilePoolAddress), position, radius * radius,
                 predicate: address => GetAsCProjectileRocket(address) != IntPtr.Zero);
             ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
@@ -4047,7 +3660,7 @@ namespace SHVDN
                 return Array.Empty<int>();
             }
 
-            var task = new FwScriptGuidPoolTask(FwScriptGuidPoolTask.PoolType.Projectile,
+            var task = new FwScriptGuidPoolTask(PoolType.Projectile,
                 new IntPtr(NativeMemory.s_projectilePoolAddress),
                 address => GetAsCProjectileThrown(address) != IntPtr.Zero);
             ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
@@ -4061,7 +3674,7 @@ namespace SHVDN
                 return Array.Empty<int>();
             }
 
-            var task = new FwScriptGuidPoolTask(FwScriptGuidPoolTask.PoolType.Projectile,
+            var task = new FwScriptGuidPoolTask(PoolType.Projectile,
                 new IntPtr(NativeMemory.s_projectilePoolAddress), position, radius * radius,
                 predicate: address => GetAsCProjectileThrown(address) != IntPtr.Zero);
             ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
@@ -4078,7 +3691,7 @@ namespace SHVDN
                 return Array.Empty<int>();
             }
 
-            var task = new FwScriptGuidPoolTask(FwScriptGuidPoolTask.PoolType.Generic, fwBasePool);
+            var task = new FwScriptGuidPoolTask(PoolType.Generic, fwBasePool);
             ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
 
             return task._resultHandles;
@@ -4092,7 +3705,7 @@ namespace SHVDN
                 return Array.Empty<int>();
             }
 
-            var task = new FwScriptGuidPoolTask(FwScriptGuidPoolTask.PoolType.Generic, fwBasePool, modelHashes);
+            var task = new FwScriptGuidPoolTask(PoolType.Generic, fwBasePool, modelHashes);
             ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
 
             return task._resultHandles;
@@ -4106,7 +3719,7 @@ namespace SHVDN
                 return Array.Empty<int>();
             }
 
-            var task = new FwScriptGuidPoolTask(FwScriptGuidPoolTask.PoolType.Generic, fwBasePool, position, radius * radius, modelHashes);
+            var task = new FwScriptGuidPoolTask(PoolType.Generic, fwBasePool, position, radius * radius, modelHashes);
             ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
 
             return task._resultHandles;
@@ -4558,59 +4171,6 @@ namespace SHVDN
             private const int StartPathNodeOffsetOfCPathFind = 0x1640;
             private const int MaxCPathRegionCount = 0x400;
 
-            [StructLayout(LayoutKind.Explicit, Size = 0x70)]
-            internal struct CPathRegion
-            {
-                [FieldOffset(0x10)]
-                internal IntPtr NodeArrayPtr;
-                [FieldOffset(0x18)]
-                internal uint NodeCount;
-                [FieldOffset(0x1C)]
-                internal uint NodeCountVehicle;
-                [FieldOffset(0x20)]
-                internal uint NodeCountPed;
-                [FieldOffset(0x28)]
-                internal IntPtr NodeLinkArrayPtr;
-                [FieldOffset(0x30)]
-                internal uint NodeLinkCount;
-                [FieldOffset(0x38)]
-                internal IntPtr VirtualJunctionArrayPtr;
-                [FieldOffset(0x40)]
-                internal IntPtr HeightSampleArrayPtr;
-
-                // `CPathRegion.JunctionMap` is at 0x50, which has a `rage::CPathRegion::JunctionMapContainer`.
-                // `rage::CPathRegion::JunctionMapContainer` is practically an alias of
-                // `rage::atBinaryMap<int,unsigned int>`. `rage::atBinaryMap` internally has a bool (at the 0x0 offset)
-                // that represents whether the content is sorted before the `rage::atArray` field.
-
-                [FieldOffset(0x60)]
-                internal uint JunctionCount;
-                [FieldOffset(0x64)]
-                internal uint HeightSampleCount;
-
-                internal CPathNode* GetPathNode(uint nodeId)
-                {
-                    if (NodeArrayPtr == IntPtr.Zero && nodeId >= NodeCount)
-                    {
-                        return null;
-                    }
-
-                    return GetPathNodeUnsafe(nodeId);
-                }
-                internal CPathNode* GetPathNodeUnsafe(uint nodeId) => (CPathNode*)((ulong)NodeArrayPtr + nodeId * (uint)sizeof(CPathNode));
-
-                internal CPathNodeLink* GetPathNodeLink(uint index)
-                {
-                    if (NodeLinkArrayPtr == IntPtr.Zero && index >= NodeLinkCount)
-                    {
-                        return null;
-                    }
-
-                    return GetPathNodeLinkUnsafe(index);
-                }
-                internal CPathNodeLink* GetPathNodeLinkUnsafe(uint index) => (CPathNodeLink*)((ulong)NodeLinkArrayPtr + index * (uint)sizeof(CPathNodeLink));
-            }
-
             private static CPathRegion* GetCPathRegion(uint areaId)
             {
                 if (areaId >= MaxCPathRegionCount || s_cPathFindInstanceAddress == 0)
@@ -4619,205 +4179,6 @@ namespace SHVDN
                 }
 
                 return *(CPathRegion**)(s_cPathFindInstanceAddress + StartPathNodeOffsetOfCPathFind + areaId * 0x8);
-            }
-
-            [Flags]
-            public enum VehiclePathNodeProperties
-            {
-                None = 0,
-                OffRoad = 1,
-                OnPlayersRoad = 2,
-                NoBigVehicles = 4,
-                SwitchedOff = 8,
-                TunnelOrInterior = 16,
-                LeadsToDeadEnd = 32,
-                /// <summary>
-                /// <see cref="Boat"/> takes precedence over this flag.
-                /// </summary>
-                Highway = 64,
-                Junction = 128,
-                /// <summary>
-                /// Cannot be used with <see cref="GiveWay"/>, because vehicle nodes can have either traffic-light or give-way feature as a special function but cannot have both of them.
-                /// </summary>
-                TrafficLight = 256,
-                /// <summary>
-                /// Cannot be used with <see cref="TrafficLight"/>, because vehicle nodes can have either traffic-light or give-way feature as a special function but cannot have both of them.
-                /// </summary>
-                GiveWay = 512,
-                /// <summary>
-                /// Cannot be used with <see cref="Highway"/>.
-                /// </summary>
-                Boat = 1024,
-
-                // GET_VEHICLE_NODE_PROPERTIES will not set any of the values below set as flags
-                DontAllowGps = 2048,
-            }
-
-            [StructLayout(LayoutKind.Explicit, Size = 0x28)]
-            internal struct CPathNode
-            {
-                [FieldOffset(0x0)]
-                internal CPathNode* Next;
-                [FieldOffset(0x8)]
-                internal CPathNode* Previous;
-
-                // Note: CPathNode in the game is supposed to have rage::CNodeAddress (4-byte union, which has
-                // a regular uint32_t field and bit fields) at 0x10
-                [FieldOffset(0x10)]
-                internal ushort AreaId;
-                [FieldOffset(0x12)]
-                internal ushort NodeId;
-
-                [FieldOffset(0x14)]
-                internal uint StreetNameHash;
-
-                [FieldOffset(0x1A)]
-                internal ushort startIndexOfLinks;
-
-                // These 2 fields should be multiplied by 4 when you convert back to float
-                [FieldOffset(0x1C)]
-                internal short PositionX;
-                [FieldOffset(0x1E)]
-                internal short PositionY;
-
-                [FieldOffset(0x20)]
-                internal ushort Flags1;
-
-                // This field should be multiplied by 32 when you convert back to float
-                [FieldOffset(0x22)]
-                internal short PositionZ;
-
-                [FieldOffset(0x24)]
-                internal byte Flags2;
-                [FieldOffset(0x25)]
-                internal byte Flags3AndLinkCount;
-                [FieldOffset(0x26)]
-                internal byte Flags4;
-                // 1st to 4th bits are used for density
-                [FieldOffset(0x27)]
-                internal byte Flag5AndDensity;
-
-                internal int Density => Flag5AndDensity & 0xF;
-
-                internal int LinkCount => Flags3AndLinkCount >> 3;
-
-                // Native functions for path nodes get area IDs and node IDs from the values subtracted by one from passed values
-                // When the lower half of bits (of passed values) are equal to zero, the natives considers the null handle is passed
-                internal int GetHandleForNativeFunctions() => ((NodeId << 0x10) + AreaId + 1);
-
-                internal FVector3 UncompressedPosition => new FVector3((float)PositionX / 4, (float)PositionY / 4, (float)PositionZ / 32);
-
-                internal bool IsSwitchedOff
-                {
-                    get => (Flags2 & 0x80) != 0;
-                    set
-                    {
-                        if (value)
-                        {
-                            Flags2 |= 0x80;
-                        }
-                        else
-                        {
-                            Flags2 &= 0x7F;
-                        }
-                    }
-                }
-
-                /// <summary>
-                /// Get property flags in almost the same way as GET_VEHICLE_NODE_PROPERTIES returns flags as the 5th parameter (seems the flags the native returns will never contain the 1024 flag).
-                /// </summary>
-                internal VehiclePathNodeProperties GetPropertyFlags()
-                {
-                    // for those wondering the proper implementation in GET_VEHICLE_NODE_PROPERTIES, you can find it with "41 0F B6 40 27 83 E0 0F 89 07 41 F6 40 20 08" (tested with b372, b2699, and b2944)
-
-                    VehiclePathNodeProperties propertyFlags = VehiclePathNodeProperties.None;
-                    if ((Flags1 & 8) != 0)
-                    {
-                        propertyFlags |= VehiclePathNodeProperties.OffRoad;
-                    }
-                    if ((Flags1 & 0x10) != 0)
-                    {
-                        propertyFlags |= VehiclePathNodeProperties.OnPlayersRoad;
-                    }
-                    if ((Flags1 & 0x20) != 0)
-                    {
-                        propertyFlags |= VehiclePathNodeProperties.NoBigVehicles;
-                    }
-                    if ((Flags2 & 0x80) != 0)
-                    {
-                        propertyFlags |= VehiclePathNodeProperties.SwitchedOff;
-                    }
-                    if ((Flags4 & 0x1) != 0)
-                    {
-                        propertyFlags |= VehiclePathNodeProperties.TunnelOrInterior;
-                    }
-                    // equivalent to "if (*(uint32_t*)(CPathNode + 36) & 0x70000000)" in C or C++
-                    if ((Flag5AndDensity & 0x70) != 0)
-                    {
-                        propertyFlags |= VehiclePathNodeProperties.LeadsToDeadEnd;
-                    }
-                    // The water/boat bit takes precedence over this highway flag
-                    if (((Flags2 & 0x40) != 0 || (Flags2 & 0x20) == 0))
-                    {
-                        propertyFlags |= VehiclePathNodeProperties.Highway;
-                    }
-                    if (((Flags2 >> 8) & 1) != 0)
-                    {
-                        propertyFlags |= VehiclePathNodeProperties.Junction;
-                    }
-                    if ((Flags1 & 0xF800) == 0x7800)
-                    {
-                        propertyFlags |= VehiclePathNodeProperties.TrafficLight;
-                    }
-                    if ((Flags1 & 0xF800) == 0x8000)
-                    {
-                        propertyFlags |= VehiclePathNodeProperties.GiveWay;
-                    }
-                    if ((Flags2 & 0x20) != 0)
-                    {
-                        propertyFlags |= VehiclePathNodeProperties.Boat;
-                    }
-                    if ((Flags2 & 1) != 0)
-                    {
-                        propertyFlags |= VehiclePathNodeProperties.DontAllowGps;
-                    }
-
-                    return propertyFlags;
-                }
-
-                internal bool IsInArea(float x1, float y1, float z1, float x2, float y2, float z2)
-                {
-                    float posXUncompressed = (float)PositionX / 4;
-                    float posYUncompressed = (float)PositionY / 4;
-                    float posZUncompressed = (float)PositionZ / 32;
-
-                    if (posXUncompressed < x1 || posXUncompressed > x2)
-                    {
-                        return false;
-                    }
-                    if (posYUncompressed < y1 || posYUncompressed > y2)
-                    {
-                        return false;
-                    }
-                    if (posZUncompressed < z1 || posYUncompressed > z2)
-                    {
-                        return false;
-                    }
-
-                    return true;
-                }
-                internal bool IsInCircle(float x, float y, float z, float radius)
-                {
-                    float posXUncompressed = (float)PositionX / 4;
-                    float posYUncompressed = (float)PositionY / 4;
-                    float posZUncompressed = (float)PositionZ / 32;
-
-                    float deltaX = (float)x - posXUncompressed;
-                    float deltaY = (float)y - posYUncompressed;
-                    float deltaZ = (float)z - posZUncompressed;
-
-                    return ((deltaX * deltaX) + (deltaY * deltaY) + (deltaZ * deltaZ)) <= radius * radius;
-                }
             }
 
             public static IntPtr GetPathNodeAddress(int handle)
@@ -4904,40 +4265,6 @@ namespace SHVDN
                 }
 
                 ((CPathNode*)pathNode)->IsSwitchedOff = toggle;
-            }
-
-            [StructLayout(LayoutKind.Explicit, Size = 0x8)]
-            internal struct CPathNodeLink
-            {
-                // Same as CPathNode, this field is supposed to be a rage::CNodeAddress...
-                [FieldOffset(0x0)]
-                internal ushort AreaId;
-                [FieldOffset(0x2)]
-                internal ushort NodeId;
-
-                [FieldOffset(0x4)]
-                internal byte Flags0;
-                [FieldOffset(0x5)]
-                internal byte Flags1;
-                [FieldOffset(0x6)]
-                internal byte Flags2;
-                [FieldOffset(0x7)]
-                internal byte LinkLength;
-
-                internal int ForwardLaneCount => (Flags2 >> 5) & 7;
-                internal int BackwardLaneCount => (Flags2 >> 2) & 7;
-
-                internal void GetForwardAndBackwardCount(out int forwardCount, out int backwardCount)
-                {
-                    forwardCount = (Flags2 >> 5) & 7;
-                    backwardCount = (Flags2 >> 2) & 7;
-                }
-
-                internal void GetTargetAreaAndNodeId(out int areaId, out int nodeId)
-                {
-                    areaId = AreaId;
-                    nodeId = NodeId;
-                }
             }
 
             // Use this buffer when we get all loaded path nodes to avoid allocating new large objects for buffer space and costing a significant time, since the number of path node handles can even exceed more than 21250
@@ -5416,30 +4743,6 @@ namespace SHVDN
         #endregion
 
         #region -- CScriptResource Data --
-
-        internal enum CScriptResourceTypeNameIndex : ushort
-        {
-            Checkpoint = 6,
-            RelGroup = 20,
-            ScaleformMovie = 21,
-        }
-
-        [StructLayout(LayoutKind.Explicit)]
-        internal struct CGameScriptResource
-        {
-            [FieldOffset(0x0)]
-            internal ulong* vTable;
-            [FieldOffset(0x8)]
-            internal CScriptResourceTypeNameIndex resourceTypeNameIndex;
-            [FieldOffset(0xC)]
-            internal uint counterOfPool;
-            [FieldOffset(0x10)]
-            internal uint indexOfPool;
-            [FieldOffset(0x18)]
-            internal CGameScriptResource* next;
-            [FieldOffset(0x20)]
-            internal CGameScriptResource* prev;
-        }
 
         internal sealed class GetAllCScriptResourceHandlesTask : IScriptTask
         {
@@ -5946,28 +5249,6 @@ namespace SHVDN
 
         #region -- Weapon Info And Ammo Info --
 
-        // TODO: support size and capacity type other than ushort (uint16_t).
-        // Actually defined like rage::atArray<element_type, some_size, size_and_capacity_type> in the exe, but we
-        // assumed the template was defined with 1 type parameter before the big incident happened.
-        [StructLayout(LayoutKind.Explicit, Size = 0x10)]
-        public struct RageAtArrayPtr
-        {
-            [FieldOffset(0x0)]
-            public ulong* data;
-            [FieldOffset(0x8)]
-            public ushort size;
-            [FieldOffset(0xA)]
-            public ushort capacity;
-            // rage::atArray always has 4-byte padding at the end
-            [FieldOffset(0xC)]
-            private fixed char padding[4];
-
-            public ulong GetElementAddress(int i)
-            {
-                return data[i];
-            }
-        }
-
         private static RageAtArrayPtr* s_weaponAndAmmoInfoArrayPtr;
 
         private static HashSet<uint> s_disallowWeaponHashSetForHumanPedsOnFoot = new HashSet<uint>()
@@ -5990,90 +5271,6 @@ namespace SHVDN
         private static int s_weaponAttachPointElementSize;
 
         private static int s_weaponInfoHumanNameHashOffset;
-
-        [StructLayout(LayoutKind.Explicit, Size = 0x20)]
-        public struct ItemInfo
-        {
-            [FieldOffset(0x0)]
-            public ulong* vTable;
-            [FieldOffset(0x10)]
-            public uint nameHash;
-            [FieldOffset(0x14)]
-            public uint modelHash;
-            [FieldOffset(0x18)]
-            public uint audioHash;
-            [FieldOffset(0x1C)]
-            public uint slot;
-
-            public uint GetClassNameHash()
-            {
-                // In the b2802 or a later exe, the function returns a hash value (not a pointer value)
-                if (GetGameVersion() >= 80)
-                {
-                    // The function is for the game version b2802 or later ones.
-                    // This one directly returns a hash value (not a pointer value) unlike the previous function.
-                    var getClassNameHashFunc = (delegate* unmanaged[Stdcall]<uint>)(vTable[2]);
-                    return getClassNameHashFunc();
-                }
-
-                // The function is for game versions prior to b2802.
-                // The function uses rax and rdx registers in newer versions prior to b2802 (probably since b2189), and it uses only rax register in older versions.
-                // The function returns the address where the class name hash is in all versions prior to (the address will be the outVal address in newer versions).
-                var getClassNameAddressHashFunc = (delegate* unmanaged[Stdcall]<ulong, uint*, uint*>)(vTable[2]);
-
-                uint outVal = 0;
-                uint* returnValueAddress = getClassNameAddressHashFunc(0, &outVal);
-                return *returnValueAddress;
-            }
-        }
-
-        [StructLayout(LayoutKind.Explicit, Size = 0x48)]
-        private struct WeaponComponentInfo
-        {
-            [FieldOffset(0x0)]
-            internal ulong* vTable;
-            [FieldOffset(0x10)]
-            internal uint nameHash;
-            [FieldOffset(0x14)]
-            internal uint modelHash;
-            [FieldOffset(0x18)]
-            internal uint locNameHash;
-            [FieldOffset(0x1C)]
-            internal uint locDescHash;
-            [FieldOffset(0x40)]
-            internal bool shownOnWheel;
-            [FieldOffset(0x41)]
-            internal bool createObject;
-            [FieldOffset(0x42)]
-            internal bool applyWeaponTint;
-        }
-
-
-        /// <summary>
-        /// Represents a `<c>CWeaponComponentPoint</c>` but without the `<c>m_Components</c>` field followed by
-        /// `<c>m_AttachBoneId</c>`, where the type is <c>atFixedArray&lt;sComponent, MAX_WEAPON_COMPONENTS&gt;</c> and
-        /// `<c>MAX_WEAPON_COMPONENTS</c>` is a hardcoded `<c>i32</c>`/`<c>s32</c>` const.
-        /// </summary>
-        /// <remarks>
-        /// This struct omits the field for `<c>m_Components</c>` because its byte size can be grown in some game
-        /// updates (e.g. `<c>m_AttachBoneId</c>` takes 0x5C bytes in b2699 and takes 0x64 bytes in b3095).
-        /// </remarks>
-        [StructLayout(LayoutKind.Explicit, Size = 0x8)]
-        private struct WeaponComponentPointHeader
-        {
-            /// <summary>
-            /// The attach bone hash for the `<c>m_AttachBone</c>` field, where the type is
-            /// `<c>atHashWithStringNotFinal</c>` (basically just a `<c>u32</c>` hash).
-            /// </summary>
-            [FieldOffset(0x0)]
-            internal uint AttachBoneHash;
-            /// <summary>
-            /// The corresponding bone hierarchy id (index) for the attach bone for the `<c>m_AttachBoneId</c>` field,
-            /// where the type is `<c>eHierarchyId</c>` (a `<c>i32</c>`/`<c>s32</c>` enum).
-            /// </summary>
-            [FieldOffset(0x4)]
-            internal uint AttachBoneId;
-        }
 
         private static ItemInfo* FindItemInfoFromWeaponAndAmmoInfoArray(uint nameHash)
         {
@@ -6333,308 +5530,6 @@ namespace SHVDN
         private static int s_colliderCapacityOffset;
         private static int s_colliderCountOffset;
 
-        [StructLayout(LayoutKind.Explicit, Size = 0xC0)]
-        internal unsafe struct FragInst
-        {
-            [FieldOffset(0x68)]
-            internal FragCacheEntry* fragCacheEntry;
-            [FieldOffset(0x78)]
-            internal GtaFragType* gtaFragType;
-            [FieldOffset(0xB8)]
-            internal uint unkType;
-
-            internal FragPhysicsLod* GetAppropriateFragPhysicsLod()
-            {
-                FragPhysicsLodGroup* fragPhysicsLodGroup = gtaFragType->fragPhysicsLODGroup;
-                if (fragPhysicsLodGroup == null)
-                {
-                    return null;
-                }
-
-                switch (unkType)
-                {
-                    case 0:
-                    case 1:
-                    case 2:
-                        return fragPhysicsLodGroup->GetFragPhysicsLodByIndex((int)unkType);
-                    default:
-                        return fragPhysicsLodGroup->GetFragPhysicsLodByIndex(0);
-                }
-            }
-        }
-        [StructLayout(LayoutKind.Explicit)]
-        internal unsafe struct FragCacheEntry
-        {
-            [FieldOffset(0x178)] internal CrSkeleton* crSkeleton;
-        }
-        [StructLayout(LayoutKind.Explicit)]
-        internal struct GtaFragType
-        {
-            [FieldOffset(0x30)]
-            internal FragDrawable* fragDrawable;
-            [FieldOffset(0xF0)]
-            internal FragPhysicsLodGroup* fragPhysicsLODGroup;
-        }
-        [StructLayout(LayoutKind.Explicit)]
-        internal struct FragDrawable
-        {
-            [FieldOffset(0x18)]
-            internal CrSkeletonData* crSkeletonData;
-        }
-        [StructLayout(LayoutKind.Explicit)]
-        internal struct FragPhysicsLodGroup
-        {
-            [FieldOffset(0x10)]
-            internal fixed ulong fragPhysicsLODAddresses[3];
-
-            internal FragPhysicsLod* GetFragPhysicsLodByIndex(int index) => (FragPhysicsLod*)((ulong*)fragPhysicsLODAddresses[index]);
-        }
-        [StructLayout(LayoutKind.Explicit)]
-        internal struct FragPhysicsLod
-        {
-            [FieldOffset(0xD0)]
-            internal ulong fragTypeChildArr;
-            [FieldOffset(0x11E)]
-            internal byte fragmentGroupCount;
-
-            internal FragTypeChild* GetFragTypeChild(int index)
-            {
-                if (index >= fragmentGroupCount)
-                {
-                    return null;
-                }
-
-                return (FragTypeChild*)*((ulong*)fragTypeChildArr + index);
-            }
-        }
-
-        [StructLayout(LayoutKind.Explicit)]
-        internal struct FragTypeChild
-        {
-            [FieldOffset(0x10)]
-            internal ushort boneIndex;
-            [FieldOffset(0x12)]
-            internal ushort boneId;
-        }
-
-        [StructLayout(LayoutKind.Explicit)]
-        internal unsafe struct CrSkeleton
-        {
-            [FieldOffset(0x00)] internal CrSkeletonData* skeletonData;
-            // this field has a pointer to one matrix, not a pointer to an array of matrices for all bones
-            [FieldOffset(0x8)] internal ulong boneTransformMatrixPtr;
-            // object matrices (entity-local space)
-            [FieldOffset(0x10)] internal ulong boneObjectMatrixArrayPtr;
-            // global matrices (world space)
-            [FieldOffset(0x18)] internal ulong boneGlobalMatrixArrayPtr;
-            [FieldOffset(0x20)] internal int boneCount;
-
-            public IntPtr GetTransformMatrixAddress()
-            {
-                return new IntPtr((long)(boneTransformMatrixPtr));
-            }
-
-            public IntPtr GetBoneObjectMatrixAddress(int boneIndex)
-            {
-                return new IntPtr((long)(boneObjectMatrixArrayPtr + ((uint)boneIndex * 0x40)));
-            }
-
-            public IntPtr GetBoneGlobalMatrixAddress(int boneIndex)
-            {
-                return new IntPtr((long)(boneGlobalMatrixArrayPtr + ((uint)boneIndex * 0x40)));
-            }
-        }
-
-        [StructLayout(LayoutKind.Explicit, Size = 0x50)]
-        internal struct CrBoneData
-        {
-            // Rotation (quaternion) is between 0x0 - 0x10
-            // Translation (vector3) is between 0x10 - 0x1C
-            // Scale (vector3?) is between 0x20 - 0x2C
-            [FieldOffset(0x30)]
-            internal ushort nextSiblingBoneIndex;
-            [FieldOffset(0x32)]
-            internal ushort parentBoneIndex;
-            [FieldOffset(0x38)]
-            internal IntPtr namePtr;
-            [FieldOffset(0x42)]
-            internal ushort boneIndex;
-            [FieldOffset(0x44)]
-            internal ushort boneId;
-
-            internal string Name => namePtr == default ? null : Marshal.PtrToStringAnsi(namePtr);
-        }
-
-        [StructLayout(LayoutKind.Explicit)]
-        internal unsafe struct CrSkeletonData
-        {
-            [FieldOffset(0x10)] internal PgHashMap boneHashMap;
-            [FieldOffset(0x20)] internal CrBoneData* boneData;
-            [FieldOffset(0x5E)] internal ushort boneCount;
-
-            /// <summary>
-            /// Gets the bone index from specified bone id. Note that bone indexes are sequential values and bone ids are not sequential ones.
-            /// </summary>
-            public int GetBoneIndexByBoneId(int boneId)
-            {
-                if (boneHashMap.elementCount == 0)
-                {
-                    if (boneId < boneCount)
-                    {
-                        return boneId;
-                    }
-
-                    return -1;
-                }
-
-                if (boneHashMap.bucketCount == 0)
-                {
-                    return -1;
-                }
-
-                if (boneHashMap.Get((uint)boneId, out int returnBoneId))
-                {
-                    return returnBoneId;
-                }
-
-                return -1;
-            }
-
-            /// <summary>
-            /// Gets the bone id from specified bone index. Note that bone indexes are sequential values and bone ids are not sequential ones.
-            /// </summary>
-            internal int GetBoneIdByIndex(int boneIndex)
-            {
-                if (boneIndex < 0 || boneIndex >= boneCount)
-                {
-                    return -1;
-                }
-
-                return ((CrBoneData*)((ulong)boneData + (uint)sizeof(CrBoneData) * (uint)boneIndex))->boneId;
-            }
-
-            /// <summary>
-            /// Gets the next sibling bone index of specified bone index.
-            /// </summary>
-            internal void GetNextSiblingBoneIndexAndId(int boneIndex, out int nextSiblingBoneIndex, out int nextSiblingBoneId)
-            {
-                if (boneIndex < 0 || boneIndex >= boneCount)
-                {
-                    nextSiblingBoneIndex = -1;
-                    nextSiblingBoneId = -1;
-                    return;
-                }
-
-                var crBoneData = ((CrBoneData*)((ulong)boneData + (uint)sizeof(CrBoneData) * (uint)boneIndex));
-                ushort nextSiblingBoneIndexFetched = crBoneData->nextSiblingBoneIndex;
-                if (nextSiblingBoneIndexFetched == 0xFFFF)
-                {
-                    nextSiblingBoneIndex = -1;
-                    nextSiblingBoneId = -1;
-                    return;
-                }
-
-                int nextSiblingBoneIdFetched = GetBoneIdByIndex(nextSiblingBoneIndexFetched);
-                if (nextSiblingBoneIndexFetched == 0xFFFF)
-                {
-                    nextSiblingBoneIndex = -1;
-                    nextSiblingBoneId = -1;
-                    return;
-                }
-
-                nextSiblingBoneIndex = nextSiblingBoneIndexFetched;
-                nextSiblingBoneId = nextSiblingBoneIdFetched;
-            }
-
-            /// <summary>
-            /// Gets the next parent bone index of specified bone index.
-            /// </summary>
-            internal void GetParentBoneIndexAndId(int boneIndex, out int parentBoneIndex, out int parentBoneId)
-            {
-                if (boneIndex < 0 || boneIndex >= boneCount)
-                {
-                    parentBoneIndex = -1;
-                    parentBoneId = -1;
-                    return;
-                }
-
-                var crBoneData = ((CrBoneData*)((ulong)boneData + (uint)sizeof(CrBoneData) * (uint)boneIndex));
-                ushort nextParentBoneIndexFetched = crBoneData->parentBoneIndex;
-                if (nextParentBoneIndexFetched == 0xFFFF)
-                {
-                    parentBoneIndex = -1;
-                    parentBoneId = -1;
-                    return;
-                }
-
-                int nextParentBoneIdFetched = GetBoneIdByIndex(nextParentBoneIndexFetched);
-                if (nextParentBoneIdFetched == 0xFFFF)
-                {
-                    parentBoneIndex = -1;
-                    parentBoneId = -1;
-                    return;
-                }
-
-                parentBoneIndex = nextParentBoneIndexFetched;
-                parentBoneId = nextParentBoneIdFetched;
-            }
-
-            /// <summary>
-            /// Gets the bone name string from specified bone index.
-            /// </summary>
-            internal string GetBoneName(int boneIndex)
-            {
-                if (boneIndex < 0 || boneIndex >= boneCount)
-                {
-                    return null;
-                }
-
-                return ((CrBoneData*)((ulong)boneData + (uint)sizeof(CrBoneData) * (uint)boneIndex))->Name;
-            }
-        }
-
-        [StructLayout(LayoutKind.Sequential, Pack = 4)]
-        internal struct HashEntry
-        {
-            internal uint hash;
-            internal int data;
-            internal HashEntry* next;
-        }
-
-        [StructLayout(LayoutKind.Explicit)]
-        internal unsafe struct PgHashMap
-        {
-            [FieldOffset(0x0)]
-            internal ulong* buckets;
-            [FieldOffset(0x8)]
-            internal ushort bucketCount;
-            [FieldOffset(0xA)]
-            internal ushort elementCount;
-
-            internal ulong GetBucketAddress(int index)
-            {
-                return buckets[index];
-            }
-
-            internal bool Get(uint hash, out int value)
-            {
-                ulong* firstEntryAddr = (ulong*)GetBucketAddress((int)(hash % bucketCount));
-                for (var hashEntry = (HashEntry*)firstEntryAddr; hashEntry != null; hashEntry = hashEntry->next)
-                {
-                    if (hash != hashEntry->hash)
-                    {
-                        continue;
-                    }
-
-                    value = hashEntry->data;
-                    return true;
-                }
-
-                value = default;
-                return false;
-            }
-        }
-
         internal sealed class FragInstBreakOffAboveTask : IScriptTask
         {
             #region Fields
@@ -6857,13 +5752,6 @@ namespace SHVDN
         private static int s_cEventSwitch2NmTypeIndex;
         private static uint s_getEventTypeIndexVFuncOffset;
         private static uint s_fragInstNmGtaGetUnkValVFuncOffset;
-
-        [StructLayout(LayoutKind.Explicit, Size = 0x38)]
-        private struct CTask
-        {
-            [FieldOffset(0x34)]
-            internal ushort taskTypeIndex;
-        }
 
         public static bool IsTaskNmScriptControlOrEventSwitch2NmActive(IntPtr pedAddress)
         {

--- a/source/core/ScriptHookVDotNet.vcxproj
+++ b/source/core/ScriptHookVDotNet.vcxproj
@@ -136,8 +136,6 @@
   </ItemGroup>
   <ItemGroup>
     <CsCompile Include="Console.cs" />
-    <CsCompile Include="FVector3.cs" />
-    <CsCompile Include="ScrWeaponHudStats.cs" />
     <CsCompile Include="KeyboardEvent.cs" />
     <CsCompile Include="Log.cs" />
     <CsCompile Include="MemDataMarshal.cs" />
@@ -154,6 +152,51 @@
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="ScriptHookVDotNet.rc" />
+  </ItemGroup>
+  <ItemGroup>
+    <CsCompile Include="Enums\CScriptResourceTypeNameIndex.cs" />
+    <CsCompile Include="Enums\EntityTypeInternal.cs" />
+    <CsCompile Include="Enums\ModelInfoClassType.cs" />
+    <CsCompile Include="Enums\PoolType.cs" />
+    <CsCompile Include="Enums\Vehicle\VehicleFlag1.cs" />
+    <CsCompile Include="Enums\Vehicle\VehicleFlag2.cs" />
+    <CsCompile Include="Enums\Vehicle\VehiclePathNodeProperties.cs" />
+    <CsCompile Include="Enums\Vehicle\VehicleStructClassType.cs" />
+    <CsCompile Include="Structs\CAttacker.cs" />
+    <CsCompile Include="Structs\CGameScriptResouce.cs" />
+    <CsCompile Include="Structs\CModelList.cs" />
+    <CsCompile Include="Structs\CTask.cs" />
+    <CsCompile Include="Structs\DragDrawable.cs" />
+    <CsCompile Include="Structs\EntityDamageRecordForReturnValue.cs" />
+    <CsCompile Include="Structs\FVector3.cs" />
+    <CsCompile Include="Structs\FragCacheEntry.cs" />
+    <CsCompile Include="Structs\Frag\FragInst.cs" />
+    <CsCompile Include="Structs\Frag\FragPhysicsLod.cs" />
+    <CsCompile Include="Structs\Frag\FragPhysicsLodGroup.cs" />
+    <CsCompile Include="Structs\Frag\FragTypeChild.cs" />
+    <CsCompile Include="Structs\Frag\GtaFragType.cs" />
+    <CsCompile Include="Structs\FwBasePool.cs" />
+    <CsCompile Include="Structs\FwScriptGuidPool.cs" />
+    <CsCompile Include="Structs\HashEntry.cs" />
+    <CsCompile Include="Structs\HashNode.cs" />
+    <CsCompile Include="Structs\ItemInfo.cs" />
+    <CsCompile Include="Structs\Path\CPathNode.cs" />
+    <CsCompile Include="Structs\Path\CPathNodeLink.cs" />
+    <CsCompile Include="Structs\Path\CPathRegion.cs" />
+    <CsCompile Include="Structs\PedPersonality.cs" />
+    <CsCompile Include="Structs\PgHashMap.cs" />
+    <CsCompile Include="Structs\RageAtArrayPtr.cs" />
+    <CsCompile Include="Structs\RageSysMemPoolAllocator.cs" />
+    <CsCompile Include="Structs\ScreenInfo.cs" />
+    <CsCompile Include="Structs\ScrWeaponHudStats.cs" />
+    <CsCompile Include="Structs\Skeleton\CrBoneData.cs" />
+    <CsCompile Include="Structs\Skeleton\CrSkeleton.cs" />
+    <CsCompile Include="Structs\Skeleton\CrSkeletonData.cs" />
+    <CsCompile Include="Structs\Weapon\WeaponComponentInfo.cs" />
+    <CsCompile Include="Structs\Weapon\WeaponComponentPointHeader.cs" />
+    <CsCompile Include="Structs\Ysc\YscScriptHeader.cs" />
+    <CsCompile Include="Structs\Ysc\YscScriptTable.cs" />
+    <CsCompile Include="Structs\Ysc\YscScriptTableItem.cs" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <!-- Compile C# source files -->

--- a/source/core/ScriptHookVDotNet.vcxproj.filters
+++ b/source/core/ScriptHookVDotNet.vcxproj.filters
@@ -9,10 +9,9 @@
     <CsCompile Include="ScriptDomain.cs" />
     <CsCompile Include="StringMarshal.cs" />
     <CsCompile Include="CheapThreadSafeStopwatch.cs" />
-    <CsCompile Include="FVector3.cs" />
     <CsCompile Include="MemDataMarshal.cs" />
     <CsCompile Include="MemScanner.cs" />
-    <CsCompile Include="ScrWeaponHudStats.cs" />
+    <CsCompile Include="KeyboardEvent.cs" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="DllMain.cpp" />
@@ -23,5 +22,162 @@
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="ScriptHookVDotNet.rc" />
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="Structs">
+      <UniqueIdentifier>{a4f13c56-d1ce-48d6-aa8a-a16c50e323b3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Structs\Path">
+      <UniqueIdentifier>{12cd1bf1-85bd-4e97-80ea-fbe1b3816020}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Structs\Frag">
+      <UniqueIdentifier>{f5aa51a5-962a-485b-90ca-714d34b11b97}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Structs\Skeleton">
+      <UniqueIdentifier>{0bc9b1f9-9704-430f-bff7-8fadef8b28af}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Structs\Weapon">
+      <UniqueIdentifier>{06e15a8d-26fe-4b0a-9a99-898d8b17691d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Structs\Ysc">
+      <UniqueIdentifier>{08285d85-c75a-4315-9c4a-1912c12ca15e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Enums">
+      <UniqueIdentifier>{856d0490-9e97-4e4f-9ca5-5eb54438060c}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Enums\Vehicle">
+      <UniqueIdentifier>{2115f7f1-65dc-4378-8033-be6a402d5712}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <CsCompile Include="Structs\CAttacker.cs">
+      <Filter>Structs</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\CGameScriptResouce.cs">
+      <Filter>Structs</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\CModelList.cs">
+      <Filter>Structs</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\CTask.cs">
+      <Filter>Structs</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\DragDrawable.cs">
+      <Filter>Structs</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\EntityDamageRecordForReturnValue.cs">
+      <Filter>Structs</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\FragCacheEntry.cs">
+      <Filter>Structs</Filter>
+    </CsCompile>
+	<CsCompile Include="Structs\FVector3.cs">
+      <Filter>Structs</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\FwBasePool.cs">
+      <Filter>Structs</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\FwScriptGuidPool.cs">
+      <Filter>Structs</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\HashEntry.cs">
+      <Filter>Structs</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\HashNode.cs">
+      <Filter>Structs</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\ItemInfo.cs">
+      <Filter>Structs</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\PedPersonality.cs">
+      <Filter>Structs</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\PgHashMap.cs">
+      <Filter>Structs</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\RageAtArrayPtr.cs">
+      <Filter>Structs</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\RageSysMemPoolAllocator.cs">
+      <Filter>Structs</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\ScreenInfo.cs">
+      <Filter>Structs</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\Path\CPathNode.cs">
+      <Filter>Structs\Path</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\Path\CPathNodeLink.cs">
+      <Filter>Structs\Path</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\Path\CPathRegion.cs">
+      <Filter>Structs\Path</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\Frag\FragInst.cs">
+      <Filter>Structs\Frag</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\Frag\FragPhysicsLod.cs">
+      <Filter>Structs\Frag</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\Frag\FragPhysicsLodGroup.cs">
+      <Filter>Structs\Frag</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\Frag\FragTypeChild.cs">
+      <Filter>Structs\Frag</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\Frag\GtaFragType.cs">
+      <Filter>Structs\Frag</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\Ysc\YscScriptHeader.cs">
+      <Filter>Structs\Ysc</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\Ysc\YscScriptTable.cs">
+      <Filter>Structs\Ysc</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\Ysc\YscScriptTableItem.cs">
+      <Filter>Structs\Ysc</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\Weapon\WeaponComponentInfo.cs">
+      <Filter>Structs\Weapon</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\Weapon\WeaponComponentPointHeader.cs">
+      <Filter>Structs\Weapon</Filter>
+    </CsCompile>
+	<CsCompile Include="Structs\ScrWeaponHudStats.cs">
+      <Filter>Structs</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\Skeleton\CrBoneData.cs">
+      <Filter>Structs\Skeleton</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\Skeleton\CrSkeleton.cs">
+      <Filter>Structs\Skeleton</Filter>
+    </CsCompile>
+    <CsCompile Include="Structs\Skeleton\CrSkeletonData.cs">
+      <Filter>Structs\Skeleton</Filter>
+    </CsCompile>
+    <CsCompile Include="Enums\Vehicle\VehicleFlag1.cs">
+      <Filter>Enums\Vehicle</Filter>
+    </CsCompile>
+    <CsCompile Include="Enums\Vehicle\VehicleFlag2.cs">
+      <Filter>Enums\Vehicle</Filter>
+    </CsCompile>
+    <CsCompile Include="Enums\Vehicle\VehiclePathNodeProperties.cs">
+      <Filter>Enums\Vehicle</Filter>
+    </CsCompile>
+    <CsCompile Include="Enums\Vehicle\VehicleStructClassType.cs">
+      <Filter>Enums\Vehicle</Filter>
+    </CsCompile>
+    <CsCompile Include="Enums\CScriptResourceTypeNameIndex.cs">
+      <Filter>Enums</Filter>
+    </CsCompile>
+    <CsCompile Include="Enums\EntityTypeInternal.cs">
+      <Filter>Enums</Filter>
+    </CsCompile>
+    <CsCompile Include="Enums\ModelInfoClassType.cs">
+      <Filter>Enums</Filter>
+    </CsCompile>
+    <CsCompile Include="Enums\PoolType.cs">
+      <Filter>Enums</Filter>
+    </CsCompile>
   </ItemGroup>
 </Project>

--- a/source/core/Structs/CAttacker.cs
+++ b/source/core/Structs/CAttacker.cs
@@ -1,0 +1,16 @@
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    // the size is at least 0x10 in all game versions
+    [StructLayout(LayoutKind.Explicit, Size = 0x10)]
+    internal struct CAttacker
+    {
+        [FieldOffset(0x0)]
+        internal ulong attackerEntityAddress;
+        [FieldOffset(0x8)]
+        internal int weaponHash;
+        [FieldOffset(0xC)]
+        internal int gameTime;
+    }
+}

--- a/source/core/Structs/CGameScriptResouce.cs
+++ b/source/core/Structs/CGameScriptResouce.cs
@@ -1,0 +1,21 @@
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Explicit)]
+    internal unsafe struct CGameScriptResource
+    {
+        [FieldOffset(0x0)]
+        internal ulong* vTable;
+        [FieldOffset(0x8)]
+        internal CScriptResourceTypeNameIndex resourceTypeNameIndex;
+        [FieldOffset(0xC)]
+        internal uint counterOfPool;
+        [FieldOffset(0x10)]
+        internal uint indexOfPool;
+        [FieldOffset(0x18)]
+        internal CGameScriptResource* next;
+        [FieldOffset(0x20)]
+        internal CGameScriptResource* prev;
+    }
+}

--- a/source/core/Structs/CModelList.cs
+++ b/source/core/Structs/CModelList.cs
@@ -1,0 +1,11 @@
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Explicit, Size = 0x400)]
+    internal unsafe struct CModelList
+    {
+        [FieldOffset(0x0)]
+        internal fixed uint modelMemberIndices[0x100];
+    }
+}

--- a/source/core/Structs/CTask.cs
+++ b/source/core/Structs/CTask.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Explicit, Size = 0x38)]
+    internal struct CTask
+    {
+        [FieldOffset(0x34)]
+        internal ushort taskTypeIndex;
+    }
+}

--- a/source/core/Structs/DragDrawable.cs
+++ b/source/core/Structs/DragDrawable.cs
@@ -1,0 +1,11 @@
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Explicit)]
+    internal unsafe struct FragDrawable
+    {
+        [FieldOffset(0x18)]
+        internal CrSkeletonData* crSkeletonData;
+    }
+}

--- a/source/core/Structs/EntityDamageRecordForReturnValue.cs
+++ b/source/core/Structs/EntityDamageRecordForReturnValue.cs
@@ -1,0 +1,18 @@
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public struct EntityDamageRecordForReturnValue
+    {
+        public int attackerEntityHandle;
+        public int weaponHash;
+        public int gameTime;
+        public EntityDamageRecordForReturnValue(int attackerEntityHandle, int weaponHash, int gameTime)
+        {
+            this.attackerEntityHandle = attackerEntityHandle;
+            this.weaponHash = weaponHash;
+            this.gameTime = gameTime;
+        }
+    }
+}

--- a/source/core/Structs/FVector3.cs
+++ b/source/core/Structs/FVector3.cs
@@ -1,0 +1,29 @@
+//
+// Copyright (C) 2023 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    // This is provided to avoid unnessesary GC pressure for creating temp managed arrays when you pass methods
+    // vector 3 values to method in NativeMemory that take ones.
+    [StructLayout(LayoutKind.Explicit, Size = 0xC)]
+    public struct FVector3
+    {
+        [FieldOffset(0x0)]
+        public float X;
+        [FieldOffset(0x4)]
+        public float Y;
+        [FieldOffset(0x8)]
+        public float Z;
+
+        public FVector3(float x, float y, float z)
+        {
+            X = x;
+            Y = y;
+            Z = z;
+        }
+    }
+}

--- a/source/core/Structs/Frag/FragInst.cs
+++ b/source/core/Structs/Frag/FragInst.cs
@@ -1,0 +1,33 @@
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Explicit, Size = 0xC0)]
+    internal unsafe struct FragInst
+    {
+        [FieldOffset(0x68)]
+        internal FragCacheEntry* fragCacheEntry;
+        [FieldOffset(0x78)]
+        internal GtaFragType* gtaFragType;
+        [FieldOffset(0xB8)]
+        internal uint unkType;
+
+        internal FragPhysicsLod* GetAppropriateFragPhysicsLod()
+        {
+            FragPhysicsLodGroup* fragPhysicsLodGroup = gtaFragType->fragPhysicsLODGroup;
+            if (fragPhysicsLodGroup == null)
+            {
+                return null;
+            }
+            switch (unkType)
+            {
+                case 0:
+                case 1:
+                case 2:
+                    return fragPhysicsLodGroup->GetFragPhysicsLodByIndex((int) unkType);
+                default:
+                    return fragPhysicsLodGroup->GetFragPhysicsLodByIndex(0);
+            }
+        }
+    }
+}

--- a/source/core/Structs/Frag/FragPhysicsLod.cs
+++ b/source/core/Structs/Frag/FragPhysicsLod.cs
@@ -1,0 +1,23 @@
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Explicit)]
+    internal unsafe struct FragPhysicsLod
+    {
+        [FieldOffset(0xD0)]
+        internal ulong fragTypeChildArr;
+        [FieldOffset(0x11E)]
+        internal byte fragmentGroupCount;
+
+        internal FragTypeChild* GetFragTypeChild(int index)
+        {
+            if (index >= fragmentGroupCount)
+            {
+                return null;
+            }
+
+            return (FragTypeChild*)*((ulong*)fragTypeChildArr + index);
+        }
+    }
+}

--- a/source/core/Structs/Frag/FragPhysicsLodGroup.cs
+++ b/source/core/Structs/Frag/FragPhysicsLodGroup.cs
@@ -1,0 +1,13 @@
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Explicit)]
+    internal unsafe struct FragPhysicsLodGroup
+    {
+        [FieldOffset(0x10)]
+        internal fixed ulong fragPhysicsLODAddresses[3];
+
+        internal FragPhysicsLod* GetFragPhysicsLodByIndex(int index) => (FragPhysicsLod*)((ulong*)fragPhysicsLODAddresses[index]);
+    }
+}

--- a/source/core/Structs/Frag/FragTypeChild.cs
+++ b/source/core/Structs/Frag/FragTypeChild.cs
@@ -1,0 +1,13 @@
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Explicit)]
+    internal struct FragTypeChild
+    {
+        [FieldOffset(0x10)]
+        internal ushort boneIndex;
+        [FieldOffset(0x12)]
+        internal ushort boneId;
+    }
+}

--- a/source/core/Structs/Frag/GtaFragType.cs
+++ b/source/core/Structs/Frag/GtaFragType.cs
@@ -1,0 +1,13 @@
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Explicit)]
+    internal unsafe struct GtaFragType
+    {
+        [FieldOffset(0x30)]
+        internal FragDrawable* fragDrawable;
+        [FieldOffset(0xF0)]
+        internal FragPhysicsLodGroup* fragPhysicsLODGroup;
+    }
+}

--- a/source/core/Structs/FragCacheEntry.cs
+++ b/source/core/Structs/FragCacheEntry.cs
@@ -1,0 +1,11 @@
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Explicit)]
+    internal unsafe struct FragCacheEntry
+    {
+        [FieldOffset(0x178)]
+        internal CrSkeleton* crSkeleton;
+    }
+}

--- a/source/core/Structs/FwBasePool.cs
+++ b/source/core/Structs/FwBasePool.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+namespace SHVDN
+{
+    /// <summary>
+    /// Represents <c>rage::fwBasePool</c>, which all of the <c>rage::fwPool&lt;typename T&gt;</c> types has as
+    /// the sole field.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The <c>rage::fwBasePool</c> takes 0x30 bytes without a vtable pointer in production builds, but that in
+    /// a debug build around v1.0.2699.0 takes 0x68 bytes with a vtable pointer and additional debug fields.
+    /// </para>
+    /// <para>
+    /// All of <c>rage::fwPool&lt;typename T&gt;</c> types (at least 243 types) has the same layout but with
+    /// different element type (at least the return type of <c>GetSlot(int)</c> differs by type parameter).
+    /// </para>
+    /// </remarks>
+    [StructLayout(LayoutKind.Explicit)]
+    internal struct FwBasePool
+    {
+        [FieldOffset(0x00)]
+        public ulong poolStartAddress;
+        [FieldOffset(0x08)]
+        public IntPtr byteArray;
+        [FieldOffset(0x10)]
+        public uint size;
+        [FieldOffset(0x14)]
+        public uint itemSize;
+        // The "first" index should be at 0x18 and The "last" index should be at 0x1C in production builds
+        // according to the layout in a debug build around v1.0.2699.0, but the "first" and the "last" aren't
+        // related to about the order.
+        // WARNING: according to `rage::fwBasePoolTracker::GetNoOfUsedSpaces`, this field is supposed to be read
+        // by reading as a 4-byte value, applying left shift by 2 and SIGNED right shift (`SAR` in assembly code)
+        // by 2, and then return the calculated value.
+        [FieldOffset(0x20)]
+        public ushort itemCount;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IsValid(uint index)
+        {
+            return Mask(index) != 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool IsHandleValid(int handle)
+        {
+            uint handleUInt = (uint)handle;
+            uint index = handleUInt >> 8;
+            return GetCounter(index) == (handleUInt & 0xFFu);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ulong GetAddress(uint index)
+        {
+            return ((Mask(index) & (poolStartAddress + index * itemSize)));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public IntPtr GetAddressFromHandle(int handle)
+        {
+            return IsHandleValid(handle) ? new IntPtr((long)GetAddress((uint)handle >> 8)) : IntPtr.Zero;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int GetGuidHandleByIndex(uint index)
+        {
+            return IsValid(index) ? (int)((index << 8) + GetCounter(index)) : 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int GetGuidHandleFromAddress(ulong address)
+        {
+            if (address < poolStartAddress || address >= poolStartAddress + size * itemSize)
+            {
+                return 0;
+            }
+            ulong offset = address - poolStartAddress;
+            if (offset % itemSize != 0)
+            {
+                return 0;
+            }
+            uint indexOfPool = (uint)(offset / itemSize);
+            return (int)((indexOfPool << 8) + GetCounter(indexOfPool));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private byte GetCounter(uint index)
+        {
+            unsafe
+            {
+                byte* byteArrayPtr = (byte*)byteArray.ToPointer();
+                return (byte)(byteArrayPtr[index] & 0x7F);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private ulong Mask(uint index)
+        {
+            unsafe
+            {
+                byte* byteArrayPtr = (byte*)byteArray.ToPointer();
+                long num1 = byteArrayPtr[index] & 0x80;
+                return (ulong)(~((num1 | -num1) >> 63));
+            }
+        }
+    }
+}

--- a/source/core/Structs/FwScriptGuidPool.cs
+++ b/source/core/Structs/FwScriptGuidPool.cs
@@ -1,0 +1,31 @@
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+namespace SHVDN
+{
+    // Note: actually this struct is supposed to point the same struct type as `FwBasePool` in this source code
+    // file, but needs to be careful when refactoring.
+    [StructLayout(LayoutKind.Explicit)]
+    internal struct FwScriptGuidPool
+    {
+        // The max count value should be at least 3072 as long as ScriptHookV is installed.
+        // Without ScriptHookV, the default value is hardcoded and may be different between different game versions (the value is 300 in b372 and 700 in b2824).
+        // The default value (when running without ScriptHookV) can be found by searching the dumped exe or the game memory with "D7 A8 11 73" (0x7311A8D7).
+        [FieldOffset(0x10)]
+        internal uint maxCount;
+        [FieldOffset(0x14)]
+        internal int itemSize;
+        [FieldOffset(0x18)]
+        internal int firstEmptySlot;
+        [FieldOffset(0x1C)]
+        internal int emptySlots;
+        [FieldOffset(0x20)]
+        internal uint itemCount;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal bool IsFull()
+        {
+            return maxCount - (itemCount & 0x3FFFFFFF) <= 256;
+        }
+    }
+}

--- a/source/core/Structs/HashEntry.cs
+++ b/source/core/Structs/HashEntry.cs
@@ -1,0 +1,11 @@
+using System.Runtime.InteropServices;
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    internal unsafe struct HashEntry
+    {
+        internal uint hash;
+        internal int data;
+        internal HashEntry* next;
+    }
+}

--- a/source/core/Structs/HashNode.cs
+++ b/source/core/Structs/HashNode.cs
@@ -1,0 +1,13 @@
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal unsafe struct HashNode
+    {
+        internal int hash;
+        internal ushort data;
+        internal ushort padding;
+        internal HashNode* next;
+    }
+}

--- a/source/core/Structs/ItemInfo.cs
+++ b/source/core/Structs/ItemInfo.cs
@@ -1,0 +1,39 @@
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Explicit, Size = 0x20)]
+    public unsafe struct ItemInfo
+    {
+        [FieldOffset(0x0)]
+        public ulong * vTable;
+        [FieldOffset(0x10)]
+        public uint nameHash;
+        [FieldOffset(0x14)]
+        public uint modelHash;
+        [FieldOffset(0x18)]
+        public uint audioHash;
+        [FieldOffset(0x1C)]
+        public uint slot;
+
+        public uint GetClassNameHash()
+        {
+            // In the b2802 or a later exe, the function returns a hash value (not a pointer value)
+            if (NativeMemory.GetGameVersion() >= 80)
+            {
+                // The function is for the game version b2802 or later ones.
+                // This one directly returns a hash value (not a pointer value) unlike the previous function.
+                var getClassNameHashFunc = (delegate * unmanaged[Stdcall] < uint > )(vTable[2]);
+                return getClassNameHashFunc();
+            }
+
+            // The function is for game versions prior to b2802.
+            // The function uses rax and rdx registers in newer versions prior to b2802 (probably since b2189), and it uses only rax register in older versions.
+            // The function returns the address where the class name hash is in all versions prior to (the address will be the outVal address in newer versions).
+            var getClassNameAddressHashFunc = (delegate * unmanaged[Stdcall] < ulong, uint * , uint * > )(vTable[2]);
+            uint outVal = 0;
+            uint * returnValueAddress = getClassNameAddressHashFunc(0, & outVal);
+            return *returnValueAddress;
+        }
+    }
+}

--- a/source/core/Structs/Path/CPathNode.cs
+++ b/source/core/Structs/Path/CPathNode.cs
@@ -1,0 +1,156 @@
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Explicit, Size = 0x28)]
+    internal unsafe struct CPathNode
+    {
+        [FieldOffset(0x0)]
+        internal CPathNode* Next;
+        [FieldOffset(0x8)]
+        internal CPathNode* Previous;
+        // Note: CPathNode in the game is supposed to have rage::CNodeAddress (4-byte union, which has
+        // a regular uint32_t field and bit fields) at 0x10
+        [FieldOffset(0x10)]
+        internal ushort AreaId;
+        [FieldOffset(0x12)]
+        internal ushort NodeId;
+        [FieldOffset(0x14)]
+        internal uint StreetNameHash;
+        [FieldOffset(0x1A)]
+        internal ushort startIndexOfLinks;
+        // These 2 fields should be multiplied by 4 when you convert back to float
+        [FieldOffset(0x1C)]
+        internal short PositionX;
+        [FieldOffset(0x1E)]
+        internal short PositionY;
+        [FieldOffset(0x20)]
+        internal ushort Flags1;
+        // This field should be multiplied by 32 when you convert back to float
+        [FieldOffset(0x22)]
+        internal short PositionZ;
+        [FieldOffset(0x24)]
+        internal byte Flags2;
+        [FieldOffset(0x25)]
+        internal byte Flags3AndLinkCount;
+        [FieldOffset(0x26)]
+        internal byte Flags4;
+        // 1st to 4th bits are used for density
+        [FieldOffset(0x27)]
+        internal byte Flag5AndDensity;
+
+        internal int Density => Flag5AndDensity & 0xF;
+
+        internal int LinkCount => Flags3AndLinkCount >> 3;
+
+        // Native functions for path nodes get area IDs and node IDs from the values subtracted by one from passed values
+        // When the lower half of bits (of passed values) are equal to zero, the natives considers the null handle is passed
+        internal int GetHandleForNativeFunctions() => ((NodeId << 0x10) + AreaId + 1);
+
+        internal FVector3 UncompressedPosition => new FVector3((float) PositionX / 4, (float) PositionY / 4, (float) PositionZ / 32);
+
+        internal bool IsSwitchedOff
+        {
+            get => (Flags2 & 0x80) != 0;
+            set
+            {
+                if (value)
+                {
+                    Flags2 |= 0x80;
+                }
+                else
+                {
+                    Flags2 &= 0x7F;
+                }
+            }
+        }
+        /// <summary>
+        /// Get property flags in almost the same way as GET_VEHICLE_NODE_PROPERTIES returns flags as the 5th parameter (seems the flags the native returns will never contain the 1024 flag).
+        /// </summary>
+        internal VehiclePathNodeProperties GetPropertyFlags()
+        {
+            // for those wondering the proper implementation in GET_VEHICLE_NODE_PROPERTIES, you can find it with "41 0F B6 40 27 83 E0 0F 89 07 41 F6 40 20 08" (tested with b372, b2699, and b2944)
+            VehiclePathNodeProperties propertyFlags = VehiclePathNodeProperties.None;
+            if ((Flags1 & 8) != 0)
+            {
+                propertyFlags |= VehiclePathNodeProperties.OffRoad;
+            }
+            if ((Flags1 & 0x10) != 0)
+            {
+                propertyFlags |= VehiclePathNodeProperties.OnPlayersRoad;
+            }
+            if ((Flags1 & 0x20) != 0)
+            {
+                propertyFlags |= VehiclePathNodeProperties.NoBigVehicles;
+            }
+            if ((Flags2 & 0x80) != 0)
+            {
+                propertyFlags |= VehiclePathNodeProperties.SwitchedOff;
+            }
+            if ((Flags4 & 0x1) != 0)
+            {
+                propertyFlags |= VehiclePathNodeProperties.TunnelOrInterior;
+            }
+            // equivalent to "if (*(uint32_t*)(CPathNode + 36) & 0x70000000)" in C or C++
+            if ((Flag5AndDensity & 0x70) != 0)
+            {
+                propertyFlags |= VehiclePathNodeProperties.LeadsToDeadEnd;
+            }
+            // The water/boat bit takes precedence over this highway flag
+            if (((Flags2 & 0x40) != 0 || (Flags2 & 0x20) == 0))
+            {
+                propertyFlags |= VehiclePathNodeProperties.Highway;
+            }
+            if (((Flags2 >> 8) & 1) != 0)
+            {
+                propertyFlags |= VehiclePathNodeProperties.Junction;
+            }
+            if ((Flags1 & 0xF800) == 0x7800)
+            {
+                propertyFlags |= VehiclePathNodeProperties.TrafficLight;
+            }
+            if ((Flags1 & 0xF800) == 0x8000)
+            {
+                propertyFlags |= VehiclePathNodeProperties.GiveWay;
+            }
+            if ((Flags2 & 0x20) != 0)
+            {
+                propertyFlags |= VehiclePathNodeProperties.Boat;
+            }
+            if ((Flags2 & 1) != 0)
+            {
+                propertyFlags |= VehiclePathNodeProperties.DontAllowGps;
+            }
+            return propertyFlags;
+        }
+        internal bool IsInArea(float x1, float y1, float z1, float x2, float y2, float z2)
+        {
+            float posXUncompressed = (float) PositionX / 4;
+            float posYUncompressed = (float) PositionY / 4;
+            float posZUncompressed = (float) PositionZ / 32;
+            if (posXUncompressed < x1 || posXUncompressed > x2)
+            {
+                return false;
+            }
+            if (posYUncompressed < y1 || posYUncompressed > y2)
+            {
+                return false;
+            }
+            if (posZUncompressed < z1 || posYUncompressed > z2)
+            {
+                return false;
+            }
+            return true;
+        }
+        internal bool IsInCircle(float x, float y, float z, float radius)
+        {
+            float posXUncompressed = (float) PositionX / 4;
+            float posYUncompressed = (float) PositionY / 4;
+            float posZUncompressed = (float) PositionZ / 32;
+            float deltaX = (float) x - posXUncompressed;
+            float deltaY = (float) y - posYUncompressed;
+            float deltaZ = (float) z - posZUncompressed;
+            return ((deltaX * deltaX) + (deltaY * deltaY) + (deltaZ * deltaZ)) <= radius * radius;
+        }
+    }
+}

--- a/source/core/Structs/Path/CPathNodeLink.cs
+++ b/source/core/Structs/Path/CPathNodeLink.cs
@@ -1,0 +1,34 @@
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Explicit, Size = 0x8)]
+    internal struct CPathNodeLink
+    {
+        // Same as CPathNode, this field is supposed to be a rage::CNodeAddress...
+        [FieldOffset(0x0)]
+        internal ushort AreaId;
+        [FieldOffset(0x2)]
+        internal ushort NodeId;
+        [FieldOffset(0x4)]
+        internal byte Flags0;
+        [FieldOffset(0x5)]
+        internal byte Flags1;
+        [FieldOffset(0x6)]
+        internal byte Flags2;
+        [FieldOffset(0x7)]
+        internal byte LinkLength;
+        internal int ForwardLaneCount => (Flags2 >> 5) & 7;
+        internal int BackwardLaneCount => (Flags2 >> 2) & 7;
+        internal void GetForwardAndBackwardCount(out int forwardCount, out int backwardCount)
+        {
+            forwardCount = (Flags2 >> 5) & 7;
+            backwardCount = (Flags2 >> 2) & 7;
+        }
+        internal void GetTargetAreaAndNodeId(out int areaId, out int nodeId)
+        {
+            areaId = AreaId;
+            nodeId = NodeId;
+        }
+    }
+}

--- a/source/core/Structs/Path/CPathRegion.cs
+++ b/source/core/Structs/Path/CPathRegion.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Explicit, Size = 0x70)]
+    internal unsafe struct CPathRegion
+    {
+        [FieldOffset(0x10)]
+        internal IntPtr NodeArrayPtr;
+        [FieldOffset(0x18)]
+        internal uint NodeCount;
+        [FieldOffset(0x1C)]
+        internal uint NodeCountVehicle;
+        [FieldOffset(0x20)]
+        internal uint NodeCountPed;
+        [FieldOffset(0x28)]
+        internal IntPtr NodeLinkArrayPtr;
+        [FieldOffset(0x30)]
+        internal uint NodeLinkCount;
+        [FieldOffset(0x38)]
+        internal IntPtr VirtualJunctionArrayPtr;
+        [FieldOffset(0x40)]
+        internal IntPtr HeightSampleArrayPtr;
+        // `CPathRegion.JunctionMap` is at 0x50, which has a `rage::CPathRegion::JunctionMapContainer`.
+        // `rage::CPathRegion::JunctionMapContainer` is practically an alias of
+        // `rage::atBinaryMap<int,unsigned int>`. `rage::atBinaryMap` internally has a bool (at the 0x0 offset)
+        // that represents whether the content is sorted before the `rage::atArray` field.
+        [FieldOffset(0x60)]
+        internal uint JunctionCount;
+        [FieldOffset(0x64)]
+        internal uint HeightSampleCount;
+        internal CPathNode * GetPathNode(uint nodeId)
+        {
+            if (NodeArrayPtr == IntPtr.Zero && nodeId >= NodeCount)
+            {
+                return null;
+            }
+            return GetPathNodeUnsafe(nodeId);
+        }
+        internal CPathNode * GetPathNodeUnsafe(uint nodeId) => (CPathNode * )((ulong) NodeArrayPtr + nodeId * (uint) sizeof(CPathNode));
+        internal CPathNodeLink * GetPathNodeLink(uint index)
+        {
+            if (NodeLinkArrayPtr == IntPtr.Zero && index >= NodeLinkCount)
+            {
+                return null;
+            }
+            return GetPathNodeLinkUnsafe(index);
+        }
+        internal CPathNodeLink * GetPathNodeLinkUnsafe(uint index) => (CPathNodeLink * )((ulong) NodeLinkArrayPtr + index * (uint) sizeof(CPathNodeLink));
+    }
+}

--- a/source/core/Structs/PedPersonality.cs
+++ b/source/core/Structs/PedPersonality.cs
@@ -1,0 +1,15 @@
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Explicit, Size = 0xB8)]
+    internal struct PedPersonality
+    {
+        [FieldOffset(0x7C)]
+        internal bool isMale;
+        [FieldOffset(0x7D)]
+        internal bool isHuman;
+        [FieldOffset(0x7F)]
+        internal bool isGang;
+    }
+}

--- a/source/core/Structs/PgHashMap.cs
+++ b/source/core/Structs/PgHashMap.cs
@@ -1,0 +1,38 @@
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Explicit)]
+    internal unsafe struct PgHashMap
+    {
+        [FieldOffset(0x0)]
+        internal ulong* buckets;
+        [FieldOffset(0x8)]
+        internal ushort bucketCount;
+        [FieldOffset(0xA)]
+        internal ushort elementCount;
+
+        internal ulong GetBucketAddress(int index)
+        {
+            return buckets[index];
+        }
+
+        internal bool Get(uint hash, out int value)
+        {
+            ulong* firstEntryAddr = (ulong*)GetBucketAddress((int)(hash % bucketCount));
+            for (var hashEntry = (HashEntry*)firstEntryAddr; hashEntry != null; hashEntry = hashEntry->next)
+            {
+                if (hash != hashEntry->hash)
+                {
+                    continue;
+                }
+
+                value = hashEntry->data;
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+    }
+}

--- a/source/core/Structs/RageAtArrayPtr.cs
+++ b/source/core/Structs/RageAtArrayPtr.cs
@@ -1,0 +1,25 @@
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    // TODO: support size and capacity type other than ushort (uint16_t).
+    // Actually defined like rage::atArray<element_type, some_size, size_and_capacity_type> in the exe, but we
+    // assumed the template was defined with 1 type parameter before the big incident happened.
+    [StructLayout(LayoutKind.Explicit, Size = 0x10)]
+    public unsafe struct RageAtArrayPtr
+    {
+        [FieldOffset(0x0)]
+        public ulong * data;
+        [FieldOffset(0x8)]
+        public ushort size;
+        [FieldOffset(0xA)]
+        public ushort capacity;
+        // rage::atArray always has 4-byte padding at the end
+        [FieldOffset(0xC)]
+        private fixed char padding[4];
+        public ulong GetElementAddress(int i)
+        {
+            return data[i];
+        }
+    }
+}

--- a/source/core/Structs/RageSysMemPoolAllocator.cs
+++ b/source/core/Structs/RageSysMemPoolAllocator.cs
@@ -1,0 +1,44 @@
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+namespace SHVDN
+{
+        /// <summary>
+        /// Represents <c>rage::sysMemPoolAllocator</c>, which all of the
+        /// <c>rage::sysMemPoolAllocator::PoolWrapper&lt;typename T&gt;</c> have as the sole field via an pointer.
+        /// </summary>
+        /// <remarks>
+        /// Possible (without limitation) <c>typename T</c>s of
+        /// <c>rage::sysMemPoolAllocator::PoolWrapper&lt;typename T&gt;</c> are <c>CTask</c>, <c>CTaskInfo</c>,
+        /// <c>CVehicle</c>, <c>audVehicleAudioEntity</c>, and <c>void *</c>.
+        /// </remarks>
+        [StructLayout(LayoutKind.Explicit)]
+        internal unsafe struct RageSysMemPoolAllocator
+        {
+            // m_pool at offset 0x0 takes 0x60 byte
+            // (type: "rage::atIteratablePool<rage::sysMemPoolAllocator::PoolNode>").
+            [FieldOffset(0x00)]
+            internal ulong* poolAddress;
+            [FieldOffset(0x08)]
+            internal uint size;
+            [FieldOffset(0x30)]
+            internal uint* bitArray;
+
+            // m_freeList at 0x60 takes 0x18 bytes (type: "rage::inlist<rage::sysMemPoolAllocator::FreeNode,8>").
+            // The struct contains m_head, m_tail and m_size fields.
+            [FieldOffset(0x60)]
+            internal uint itemCount;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            internal bool IsValid(uint i)
+            {
+                return ((bitArray[i >> 5] >> ((int)i & 0x1F)) & 1) != 0;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            internal ulong GetAddress(uint i)
+            {
+                return poolAddress[i];
+            }
+        }
+}

--- a/source/core/Structs/ScrWeaponHudStats.cs
+++ b/source/core/Structs/ScrWeaponHudStats.cs
@@ -1,0 +1,26 @@
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+	[StructLayout(LayoutKind.Explicit, Size = 0x28)] // total size 40 bytes
+	public struct ScrWeaponHudStats
+    {
+        // Internally, each stat is represented by a scrValue union, which occupies 8 bytes on Win64.
+        // When populated with data from CWeaponInfo (data is stored as signed 8-bit integers),
+        // the values are implicitly converted from s8 to int when assigned to these fields.
+        [FieldOffset(0x00)] public int Damage;
+		[FieldOffset(0x08)] public int Speed;
+		[FieldOffset(0x10)] public int Capacity;
+		[FieldOffset(0x18)] public int Accuracy;
+		[FieldOffset(0x20)] public int Range;
+
+		public ScrWeaponHudStats(int damage, int speed, int capacity, int accuracy, int range)
+		{
+            Damage = damage;
+            Speed = speed;
+            Capacity = capacity;
+            Accuracy = accuracy;
+            Range = range;
+        }
+	}
+}

--- a/source/core/Structs/ScreenInfo.cs
+++ b/source/core/Structs/ScreenInfo.cs
@@ -1,0 +1,18 @@
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Explicit, Size = 0x30)]
+    internal struct ScreenInfo
+    {
+        // these fields should be in pixel coordinates
+        [FieldOffset(0x14)]
+        internal uint left;
+        [FieldOffset(0x18)]
+        internal uint right;
+        [FieldOffset(0x1C)]
+        internal uint top;
+        [FieldOffset(0x20)]
+        internal uint bottom;
+    }
+}

--- a/source/core/Structs/Skeleton/CrBoneData.cs
+++ b/source/core/Structs/Skeleton/CrBoneData.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Explicit, Size = 0x50)]
+    internal struct CrBoneData
+    {
+        // Rotation (quaternion) is between 0x0 - 0x10
+        // Translation (vector3) is between 0x10 - 0x1C
+        // Scale (vector3?) is between 0x20 - 0x2C
+        [FieldOffset(0x30)]
+        internal ushort nextSiblingBoneIndex;
+        [FieldOffset(0x32)]
+        internal ushort parentBoneIndex;
+        [FieldOffset(0x38)]
+        internal IntPtr namePtr;
+        [FieldOffset(0x42)]
+        internal ushort boneIndex;
+        [FieldOffset(0x44)]
+        internal ushort boneId;
+
+        internal string Name => namePtr == default ? null : Marshal.PtrToStringAnsi(namePtr);
+    }
+}

--- a/source/core/Structs/Skeleton/CrSkeleton.cs
+++ b/source/core/Structs/Skeleton/CrSkeleton.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Explicit)]
+    internal unsafe struct CrSkeleton
+    {
+        [FieldOffset(0x00)]
+        internal CrSkeletonData* skeletonData;
+        // this field has a pointer to one matrix, not a pointer to an array of matrices for all bones
+        [FieldOffset(0x8)]
+        internal ulong boneTransformMatrixPtr;
+        // object matrices (entity-local space)
+        [FieldOffset(0x10)]
+        internal ulong boneObjectMatrixArrayPtr;
+        // global matrices (world space)
+        [FieldOffset(0x18)]
+        internal ulong boneGlobalMatrixArrayPtr;
+        [FieldOffset(0x20)]
+        internal int boneCount;
+
+        public IntPtr GetTransformMatrixAddress()
+        {
+            return new IntPtr((long)(boneTransformMatrixPtr));
+        }
+
+        public IntPtr GetBoneObjectMatrixAddress(int boneIndex)
+        {
+            return new IntPtr((long)(boneObjectMatrixArrayPtr + ((uint)boneIndex * 0x40)));
+        }
+
+        public IntPtr GetBoneGlobalMatrixAddress(int boneIndex)
+        {
+            return new IntPtr((long)(boneGlobalMatrixArrayPtr + ((uint)boneIndex * 0x40)));
+        }
+    }
+}

--- a/source/core/Structs/Skeleton/CrSkeletonData.cs
+++ b/source/core/Structs/Skeleton/CrSkeletonData.cs
@@ -1,0 +1,135 @@
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Explicit)]
+    internal unsafe struct CrSkeletonData
+    {
+        [FieldOffset(0x10)]
+        internal PgHashMap boneHashMap;
+        [FieldOffset(0x20)]
+        internal CrBoneData* boneData;
+        [FieldOffset(0x5E)]
+        internal ushort boneCount;
+
+        /// <summary>
+        /// Gets the bone index from specified bone id. Note that bone indexes are sequential values and bone ids are not sequential ones.
+        /// </summary>
+        public int GetBoneIndexByBoneId(int boneId)
+        {
+            if (boneHashMap.elementCount == 0)
+            {
+                if (boneId < boneCount)
+                {
+                    return boneId;
+                }
+
+                return -1;
+            }
+
+            if (boneHashMap.bucketCount == 0)
+            {
+                return -1;
+            }
+
+            if (boneHashMap.Get((uint)boneId, out int returnBoneId))
+            {
+                return returnBoneId;
+            }
+
+            return -1;
+        }
+
+        /// <summary>
+        /// Gets the bone id from specified bone index. Note that bone indexes are sequential values and bone ids are not sequential ones.
+        /// </summary>
+        internal int GetBoneIdByIndex(int boneIndex)
+        {
+            if (boneIndex < 0 || boneIndex >= boneCount)
+            {
+                return -1;
+            }
+
+            return ((CrBoneData*)((ulong)boneData + (uint)sizeof(CrBoneData) * (uint)boneIndex))->boneId;
+        }
+
+        /// <summary>
+        /// Gets the next sibling bone index of specified bone index.
+        /// </summary>
+        internal void GetNextSiblingBoneIndexAndId(int boneIndex, out int nextSiblingBoneIndex, out int nextSiblingBoneId)
+        {
+            if (boneIndex < 0 || boneIndex >= boneCount)
+            {
+                nextSiblingBoneIndex = -1;
+                nextSiblingBoneId = -1;
+                return;
+            }
+
+            var crBoneData = ((CrBoneData*)((ulong)boneData + (uint)sizeof(CrBoneData) * (uint)boneIndex));
+            ushort nextSiblingBoneIndexFetched = crBoneData->nextSiblingBoneIndex;
+            if (nextSiblingBoneIndexFetched == 0xFFFF)
+            {
+                nextSiblingBoneIndex = -1;
+                nextSiblingBoneId = -1;
+                return;
+            }
+
+            int nextSiblingBoneIdFetched = GetBoneIdByIndex(nextSiblingBoneIndexFetched);
+            if (nextSiblingBoneIndexFetched == 0xFFFF)
+            {
+                nextSiblingBoneIndex = -1;
+                nextSiblingBoneId = -1;
+                return;
+            }
+
+            nextSiblingBoneIndex = nextSiblingBoneIndexFetched;
+            nextSiblingBoneId = nextSiblingBoneIdFetched;
+        }
+
+        /// <summary>
+        /// Gets the next parent bone index of specified bone index.
+        /// </summary>
+        internal void GetParentBoneIndexAndId(int boneIndex, out int parentBoneIndex, out int parentBoneId)
+        {
+            if (boneIndex < 0 || boneIndex >= boneCount)
+            {
+                parentBoneIndex = -1;
+                parentBoneId = -1;
+                return;
+            }
+
+            var crBoneData = ((CrBoneData*)((ulong)boneData + (uint)sizeof(CrBoneData) * (uint)boneIndex));
+            ushort nextParentBoneIndexFetched = crBoneData->parentBoneIndex;
+            if (nextParentBoneIndexFetched == 0xFFFF)
+            {
+                parentBoneIndex = -1;
+                parentBoneId = -1;
+                return;
+            }
+
+            int nextParentBoneIdFetched = GetBoneIdByIndex(nextParentBoneIndexFetched);
+            if (nextParentBoneIdFetched == 0xFFFF)
+            {
+                parentBoneIndex = -1;
+                parentBoneId = -1;
+                return;
+            }
+
+            parentBoneIndex = nextParentBoneIndexFetched;
+            parentBoneId = nextParentBoneIdFetched;
+        }
+
+        /// <summary>
+        /// Gets the bone name string from specified bone index.
+        /// </summary>
+        internal string GetBoneName(int boneIndex)
+        {
+            if (boneIndex < 0 || boneIndex >= boneCount)
+            {
+                return null;
+            }
+
+            return ((CrBoneData*)((ulong)boneData + (uint)sizeof(CrBoneData) * (uint)boneIndex))->Name;
+        }
+    }
+}

--- a/source/core/Structs/Weapon/WeaponComponentInfo.cs
+++ b/source/core/Structs/Weapon/WeaponComponentInfo.cs
@@ -1,0 +1,25 @@
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Explicit, Size = 0x48)]
+    internal unsafe struct WeaponComponentInfo
+    {
+        [FieldOffset(0x0)]
+        internal ulong* vTable;
+        [FieldOffset(0x10)]
+        internal uint nameHash;
+        [FieldOffset(0x14)]
+        internal uint modelHash;
+        [FieldOffset(0x18)]
+        internal uint locNameHash;
+        [FieldOffset(0x1C)]
+        internal uint locDescHash;
+        [FieldOffset(0x40)]
+        internal bool shownOnWheel;
+        [FieldOffset(0x41)]
+        internal bool createObject;
+        [FieldOffset(0x42)]
+        internal bool applyWeaponTint;
+    }
+}

--- a/source/core/Structs/Weapon/WeaponComponentPointHeader.cs
+++ b/source/core/Structs/Weapon/WeaponComponentPointHeader.cs
@@ -1,0 +1,30 @@
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    /// <summary>
+    /// Represents a `<c>CWeaponComponentPoint</c>` but without the `<c>m_Components</c>` field followed by
+    /// `<c>m_AttachBoneId</c>`, where the type is <c>atFixedArray&lt;sComponent, MAX_WEAPON_COMPONENTS&gt;</c> and
+    /// `<c>MAX_WEAPON_COMPONENTS</c>` is a hardcoded `<c>i32</c>`/`<c>s32</c>` const.
+    /// </summary>
+    /// <remarks>
+    /// This struct omits the field for `<c>m_Components</c>` because its byte size can be grown in some game
+    /// updates (e.g. `<c>m_AttachBoneId</c>` takes 0x5C bytes in b2699 and takes 0x64 bytes in b3095).
+    /// </remarks>
+    [StructLayout(LayoutKind.Explicit, Size = 0x8)]
+    internal struct WeaponComponentPointHeader
+    {
+        /// <summary>
+        /// The attach bone hash for the `<c>m_AttachBone</c>` field, where the type is
+        /// `<c>atHashWithStringNotFinal</c>` (basically just a `<c>u32</c>` hash).
+        /// </summary>
+        [FieldOffset(0x0)]
+        internal uint AttachBoneHash;
+        /// <summary>
+        /// The corresponding bone hierarchy id (index) for the attach bone for the `<c>m_AttachBoneId</c>` field,
+        /// where the type is `<c>eHierarchyId</c>` (a `<c>i32</c>`/`<c>s32</c>` enum).
+        /// </summary>
+        [FieldOffset(0x4)]
+        internal uint AttachBoneId;
+    }
+}

--- a/source/core/Structs/Ysc/YscScriptHeader.cs
+++ b/source/core/Structs/Ysc/YscScriptHeader.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Explicit)]
+    internal unsafe struct YscScriptHeader
+    {
+        [FieldOffset(0x10)]
+        internal byte** codeBlocksOffset;
+        [FieldOffset(0x1C)]
+        internal int codeLength;
+        [FieldOffset(0x24)]
+        internal int localCount;
+        [FieldOffset(0x2C)]
+        internal int nativeCount;
+        [FieldOffset(0x30)]
+        internal long* localOffset;
+        [FieldOffset(0x40)]
+        internal long* nativeOffset;
+        [FieldOffset(0x58)]
+        internal int nameHash;
+
+        internal int CodePageCount()
+        {
+            return (codeLength + 0x3FFF) >> 14;
+        }
+
+        internal int GetCodePageSize(int page)
+        {
+            return (page < 0 || page >= CodePageCount() ? 0 : (page == CodePageCount() - 1) ? codeLength & 0x3FFF : 0x4000);
+        }
+
+        internal IntPtr GetCodePageAddress(int page)
+        {
+            return new IntPtr(codeBlocksOffset[page]);
+        }
+    }
+}

--- a/source/core/Structs/Ysc/YscScriptTable.cs
+++ b/source/core/Structs/Ysc/YscScriptTable.cs
@@ -1,0 +1,28 @@
+using System.Runtime.InteropServices;
+
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Explicit)]
+    internal unsafe struct YscScriptTable
+    {
+        [FieldOffset(0x0)]
+        internal YscScriptTableItem* TablePtr;
+        [FieldOffset(0x18)]
+        internal uint count;
+        internal YscScriptTableItem* FindScript(int hash)
+        {
+            if (TablePtr == null)
+            {
+                return null; //table initialisation hasn't happened yet
+            }
+            for (int i = 0; i < count; i++)
+            {
+                if (TablePtr[i].hash == hash)
+                {
+                    return &TablePtr[i];
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/source/core/Structs/Ysc/YscScriptTableItem.cs
+++ b/source/core/Structs/Ysc/YscScriptTableItem.cs
@@ -1,0 +1,19 @@
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+namespace SHVDN
+{
+    [StructLayout(LayoutKind.Explicit)]
+    internal unsafe struct YscScriptTableItem
+    {
+        [FieldOffset(0x0)]
+        internal YscScriptHeader* header;
+        [FieldOffset(0xC)]
+        internal int hash;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal bool IsLoaded()
+        {
+            return header != null;
+        }
+    }
+}

--- a/source/scripting_v3/GTA/Entities/EntityDamageRecordCollection.cs
+++ b/source/scripting_v3/GTA/Entities/EntityDamageRecordCollection.cs
@@ -32,7 +32,7 @@ namespace GTA
                     yield break;
                 }
 
-                NativeMemory.EntityDamageRecordForReturnValue returnDamageRecord = SHVDN.NativeMemory.GetEntityDamageRecordEntryAtIndex(_owner.MemoryAddress, i);
+                SHVDN.EntityDamageRecordForReturnValue returnDamageRecord = SHVDN.NativeMemory.GetEntityDamageRecordEntryAtIndex(_owner.MemoryAddress, i);
                 Entity attackerEntity = returnDamageRecord.attackerEntityHandle != 0 ? Entity.FromHandle(returnDamageRecord.attackerEntityHandle) : null;
 
                 yield return new EntityDamageRecord(_owner, attackerEntity, (WeaponHash)returnDamageRecord.weaponHash, returnDamageRecord.gameTime);
@@ -53,12 +53,12 @@ namespace GTA
                 return Array.Empty<EntityDamageRecord>();
             }
 
-            NativeMemory.EntityDamageRecordForReturnValue[] damageEntries = SHVDN.NativeMemory.GetEntityDamageRecordEntries(address);
+            SHVDN.EntityDamageRecordForReturnValue[] damageEntries = SHVDN.NativeMemory.GetEntityDamageRecordEntries(address);
             var returnDamageRecords = new EntityDamageRecord[damageEntries.Length];
 
             for (int i = 0; i < returnDamageRecords.Length; i++)
             {
-                NativeMemory.EntityDamageRecordForReturnValue damageRecord = damageEntries[i];
+                SHVDN.EntityDamageRecordForReturnValue damageRecord = damageEntries[i];
                 Entity attackerEntity = damageRecord.attackerEntityHandle != 0 ? Entity.FromHandle(damageRecord.attackerEntityHandle) : null;
                 returnDamageRecords[i] = new EntityDamageRecord(_owner, attackerEntity, (WeaponHash)damageRecord.weaponHash, damageRecord.gameTime);
             }

--- a/source/scripting_v3/GTA/Entities/Model.cs
+++ b/source/scripting_v3/GTA/Entities/Model.cs
@@ -130,7 +130,7 @@ namespace GTA
         /// <value>
         /// <see langword="true" /> if this <see cref="Model"/> is a big vehicle; otherwise, <see langword="false" />.
         /// </value>
-        public bool IsBigVehicle => SHVDN.NativeMemory.HasVehicleFlag(Hash, SHVDN.NativeMemory.VehicleFlag1.Big);
+        public bool IsBigVehicle => SHVDN.NativeMemory.HasVehicleFlag(Hash, SHVDN.VehicleFlag1.Big);
         /// <summary>
         /// Gets a value indicating whether this <see cref="Model"/> is a bike (either a motorcycle or a bicycle).
         /// </summary>
@@ -158,7 +158,7 @@ namespace GTA
         /// <value>
         /// <see langword="true" /> if this <see cref="Model"/> is an emergency vehicle; otherwise, <see langword="false" />.
         /// </value>
-        public bool IsBus => SHVDN.NativeMemory.HasVehicleFlag(Hash, SHVDN.NativeMemory.VehicleFlag1.IsBus);
+        public bool IsBus => SHVDN.NativeMemory.HasVehicleFlag(Hash, SHVDN.VehicleFlag1.IsBus);
         /// <summary>
         /// Gets a value indicating whether this <see cref="Model"/> is a car and not an amphibious one.
         /// </summary>
@@ -179,7 +179,7 @@ namespace GTA
         /// <value>
         /// <see langword="true" /> if this <see cref="Model"/> is a donk car; otherwise, <see langword="false" />.
         /// </value>
-        public bool IsDonk => SHVDN.NativeMemory.HasVehicleFlag(Hash, SHVDN.NativeMemory.VehicleFlag2.HasLowriderDonkHydraulics);
+        public bool IsDonk => SHVDN.NativeMemory.HasVehicleFlag(Hash, SHVDN.VehicleFlag2.HasLowriderDonkHydraulics);
 
         /// <summary>
         /// Gets a value indicating whether this <see cref="Model"/> is an electric vehicle.
@@ -187,14 +187,14 @@ namespace GTA
         /// <value>
         /// <see langword="true" /> if this <see cref="Model"/> is an electric vehicle; otherwise, <see langword="false" />.
         /// </value>
-        public bool IsElectricVehicle => SHVDN.NativeMemory.HasVehicleFlag(Hash, SHVDN.NativeMemory.VehicleFlag1.IsElectric);
+        public bool IsElectricVehicle => SHVDN.NativeMemory.HasVehicleFlag(Hash, SHVDN.VehicleFlag1.IsElectric);
         /// <summary>
         /// Gets a value indicating whether this <see cref="Model"/> is an emergency vehicle.
         /// </summary>
         /// <value>
         /// <see langword="true" /> if this <see cref="Model"/> is an emergency vehicle; otherwise, <see langword="false" />.
         /// </value>
-        public bool IsEmergencyVehicle => SHVDN.NativeMemory.HasVehicleFlag(Hash, SHVDN.NativeMemory.VehicleFlag1.EmergencyService);
+        public bool IsEmergencyVehicle => SHVDN.NativeMemory.HasVehicleFlag(Hash, SHVDN.VehicleFlag1.EmergencyService);
         /// <summary>
         /// Gets a value indicating whether this <see cref="Model"/> is a female <see cref="Ped"/> model.
         /// </summary>
@@ -251,14 +251,14 @@ namespace GTA
         /// <value>
         /// <see langword="true" /> if this <see cref="Model"/> is a law enforcement vehicle; otherwise, <see langword="false" />.
         /// </value>
-        public bool IsLawEnforcementVehicle => SHVDN.NativeMemory.HasVehicleFlag(Hash, SHVDN.NativeMemory.VehicleFlag1.LawEnforcement);
+        public bool IsLawEnforcementVehicle => SHVDN.NativeMemory.HasVehicleFlag(Hash, SHVDN.VehicleFlag1.LawEnforcement);
         /// <summary>
         /// Gets a value indicating whether this <see cref="Model"/> is a regular lowrider.
         /// </summary>
         /// <value>
         /// <see langword="true" /> if this <see cref="Model"/> is a regular lowrider; otherwise, <see langword="false" />.
         /// </value>
-        public bool IsLowrider => SHVDN.NativeMemory.HasVehicleFlag(Hash, SHVDN.NativeMemory.VehicleFlag2.HasLowriderHydraulics);
+        public bool IsLowrider => SHVDN.NativeMemory.HasVehicleFlag(Hash, SHVDN.VehicleFlag2.HasLowriderHydraulics);
         /// <summary>
         /// Gets a value indicating whether this <see cref="Model"/> is a movable interior loader (also known as MLO or MILO).
         /// </summary>
@@ -294,7 +294,7 @@ namespace GTA
         /// <value>
         /// <see langword="true" /> if this <see cref="Model"/> is an off-road vehicle; otherwise, <see langword="false" />.
         /// </value>
-        public bool IsOffRoadVehicle => SHVDN.NativeMemory.HasVehicleFlag(Hash, SHVDN.NativeMemory.VehicleFlag1.IsOffroadVehicle);
+        public bool IsOffRoadVehicle => SHVDN.NativeMemory.HasVehicleFlag(Hash, SHVDN.VehicleFlag1.IsOffroadVehicle);
         /// <summary>
         /// Gets a value indicating whether this <see cref="Model"/> is a pedestrian.
         /// </summary>
@@ -343,7 +343,7 @@ namespace GTA
         /// <value>
         /// <see langword="true" /> if this <see cref="Model"/> is a tank; otherwise, <see langword="false" />.
         /// </value>
-        public bool IsTank => SHVDN.NativeMemory.HasVehicleFlag(Hash, SHVDN.NativeMemory.VehicleFlag2.IsTank);
+        public bool IsTank => SHVDN.NativeMemory.HasVehicleFlag(Hash, SHVDN.VehicleFlag2.IsTank);
         /// <summary>
         /// Gets a value indicating whether this <see cref="Model"/> is a train.
         /// </summary>
@@ -364,7 +364,7 @@ namespace GTA
         /// <value>
         /// <see langword="true" /> if this <see cref="Model"/> is a van; otherwise, <see langword="false" />.
         /// </value>
-        public bool IsVan => SHVDN.NativeMemory.HasVehicleFlag(Hash, SHVDN.NativeMemory.VehicleFlag1.IsVan);
+        public bool IsVan => SHVDN.NativeMemory.HasVehicleFlag(Hash, SHVDN.VehicleFlag1.IsVan);
         /// <summary>
         /// Gets a value indicating whether this <see cref="Model"/> is a vehicle.
         /// </summary>

--- a/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs
@@ -75,7 +75,7 @@ namespace GTA
         /// <summary>
         /// Gets a value indicating whether this <see cref="Vehicle"/> has bulletproof glass.
         /// </summary>
-        public bool HasBulletProofGlass => SHVDN.NativeMemory.HasVehicleFlag(Model.Hash, SHVDN.NativeMemory.VehicleFlag2.HasBulletProofGlass);
+        public bool HasBulletProofGlass => SHVDN.NativeMemory.HasVehicleFlag(Model.Hash, SHVDN.VehicleFlag2.HasBulletProofGlass);
 
         /// <summary>
         /// Gets a value indicating whether this <see cref="Vehicle"/> has Lowrider Hydraulics.
@@ -85,7 +85,7 @@ namespace GTA
         /// </remarks>
         public bool HasLowriderHydraulics
             => Game.FileVersion >= ExeVersionConsts.v1_0_505_2
-            && SHVDN.NativeMemory.HasVehicleFlag(Model.Hash, SHVDN.NativeMemory.VehicleFlag2.HasLowriderHydraulics);
+            && SHVDN.NativeMemory.HasVehicleFlag(Model.Hash, SHVDN.VehicleFlag2.HasLowriderHydraulics);
 
         /// <summary>
         /// Gets a value indicating whether this <see cref="Vehicle"/> has Donk Hydraulics.
@@ -95,7 +95,7 @@ namespace GTA
         /// </remarks>
         public bool HasDonkHydraulics
             => Game.FileVersion >= ExeVersionConsts.v1_0_505_2
-            && SHVDN.NativeMemory.HasVehicleFlag(Model.Hash, SHVDN.NativeMemory.VehicleFlag2.HasLowriderDonkHydraulics);
+            && SHVDN.NativeMemory.HasVehicleFlag(Model.Hash, SHVDN.VehicleFlag2.HasLowriderDonkHydraulics);
 
         /// <summary>
         /// Gets a value indicating whether this <see cref="Vehicle"/> has a Parachute.
@@ -560,7 +560,7 @@ namespace GTA
         /// </value>
         public bool AllowRappel => Game.FileVersion >= ExeVersionConsts.v1_0_757_2
             ? Function.Call<bool>(Hash.DOES_VEHICLE_ALLOW_RAPPEL, Handle)
-            : SHVDN.NativeMemory.HasVehicleFlag(Model.Hash, SHVDN.NativeMemory.VehicleFlag1.AllowsRappel);
+            : SHVDN.NativeMemory.HasVehicleFlag(Model.Hash, SHVDN.VehicleFlag1.AllowsRappel);
 
         /// <summary>
         /// Gets a value indicating whether <see cref="Ped"/>s can stand on this <see cref="Vehicle"/> regardless of <see cref="Vehicle"/>s speed.
@@ -568,7 +568,7 @@ namespace GTA
         /// <value>
         /// <see langword="true" /> if <see cref="Ped"/>s can stand on this <see cref="Vehicle"/> regardless of <see cref="Vehicle"/>s speed; otherwise, <see langword="false" />.
         /// </value>
-        public bool CanStandOnTop => SHVDN.NativeMemory.HasVehicleFlag(Model.Hash, SHVDN.NativeMemory.VehicleFlag1.CanStandOnTop);
+        public bool CanStandOnTop => SHVDN.NativeMemory.HasVehicleFlag(Model.Hash, SHVDN.VehicleFlag1.CanStandOnTop);
 
         /// <summary>
         /// Gets a value indicating whether this <see cref="Vehicle"/> has jumping functionality.

--- a/source/scripting_v3/GTA/Weapons/WeaponCollection.cs
+++ b/source/scripting_v3/GTA/Weapons/WeaponCollection.cs
@@ -70,7 +70,7 @@ namespace GTA
 
                 unsafe
                 {
-                    return ((SHVDN.NativeMemory.RageAtArrayPtr*)(pedInventoryAddr + 0x18))->size;
+                    return ((SHVDN.RageAtArrayPtr*)(pedInventoryAddr + 0x18))->size;
                 }
             }
         }
@@ -453,14 +453,14 @@ namespace GTA
                         return null;
                     }
 
-                    var weaponInventoryArray = (SHVDN.NativeMemory.RageAtArrayPtr*)(pedInventoryAddr + 0x18);
+                    var weaponInventoryArray = (SHVDN.RageAtArrayPtr*)(pedInventoryAddr + 0x18);
                     if (index >= weaponInventoryArray->size)
                     {
                         return null;
                     }
 
                     ulong itemAddress = weaponInventoryArray->GetElementAddress(index);
-                    SHVDN.NativeMemory.ItemInfo* weaponInfo = *(SHVDN.NativeMemory.ItemInfo**)(itemAddress + 0x8);
+                    SHVDN.ItemInfo* weaponInfo = *(SHVDN.ItemInfo**)(itemAddress + 0x8);
                     if (weaponInfo == null)
                     {
                         return null;


### PR DESCRIPTION
This PR basically seperated all `struct`s and `enum`s from `NativeMemory` into their own organized files.

The visibility of members did not change, but the visibility of the structs and enums were changed according to these rules:

`private` -> `internal`
`internal` -> `internal`
`public` -> `public`

These reduces the lines of `NativeMemory` from 7036 to 5925.
**Note:**
If these changes are accepted, I will start refactoring these to follow csharp conventions and some other improvements. 
