### PR TITLE
feat(api-v3,core): add read for `RadarZoom`

### DIFF
--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -715,6 +715,12 @@ namespace SHVDN
                 InteriorInstPtrInInteriorProxyOffset = (int)*(byte*)(address + 49);
             }
 
+            address = MemScanner.FindPatternBmh("\x8D\x43\x64\x89\x05\x00\x00\x00\x00", "xxxxx????");
+            if (address != null)
+            {
+                s_radarZoomValueAddress = (int*)(*(int*)(address + 5) + address + 9);
+            }
+
             // Generate vehicle model list
             var vehicleHashesGroupedByClass = new List<int>[0x20];
             for (int i = 0; i < 0x20; i++)
@@ -4603,6 +4609,28 @@ namespace SHVDN
                 float deltaY = yCenter - nearestY;
 
                 return (deltaX * deltaX + deltaY * deltaY) <= (radius * radius);
+            }
+        }
+
+        #endregion
+
+        #region -- HUD Data --
+
+        private static int* s_radarZoomValueAddress;
+
+        // We should not add a write field for this, we can just use SET_RADAR_ZOOM,
+        // which also performs some other checks and sets more values.
+        public static int RadarZoomValue
+        {
+            get
+            {
+                if (s_radarZoomValueAddress == null)
+                {
+                    return 0;
+                }
+
+                //When SET_RADAR_ZOOM writes to this field, it is set to the desired value + 100 in both tested versions(b427 and b3586).
+                return (*s_radarZoomValueAddress) - 100;
             }
         }
 

--- a/source/scripting_v3/GTA.UI/Hud.cs
+++ b/source/scripting_v3/GTA.UI/Hud.cs
@@ -100,13 +100,14 @@ namespace GTA.UI
         public static void UnlockRadarPosition() => Function.Call(Hash.UNLOCK_MINIMAP_POSITION);
 
         /// <summary>
-        /// Sets how far the minimap should be zoomed in.
+        /// Gets or sets how far the minimap should be zoomed in.
         /// </summary>
-        /// <value>
-        /// The radar zoom; accepts values from 0 to 200.
-        /// </value>
+        /// <remarks>
+        /// If bigmap is enabled, the max value is 6000; otherwise 1500.
+        /// </remarks>
         public static int RadarZoom
         {
+            get => SHVDN.NativeMemory.RadarZoomValue;
             set => Function.Call(Hash.SET_RADAR_ZOOM, value);
         }
     }


### PR DESCRIPTION
I used pattern scanning for this one. 
The pattern points into the handler of SET_RADAR_ZOOM, it was tested in b427 and b3586.