### PR TITLE
feat(api-v3): add `Path` and `LoadTexture(string)` to `CustomSprite`

### DIFF
--- a/source/scripting_v3/GTA.UI/CustomSprite.cs
+++ b/source/scripting_v3/GTA.UI/CustomSprite.cs
@@ -17,6 +17,44 @@ namespace GTA.UI
     public class CustomSprite : ISpriteElement, IWorldDrawableElement
     {
         /// <summary>
+        /// Gets the full path to the sprite on the disk.
+        /// </summary>
+        public string Path { get; private set; }
+
+        /// <summary>
+        /// Loads the texture from the specified path.
+        /// </summary>
+        public void LoadTexture(string path)
+        {
+            if(Path == path)
+            {
+                return;
+            }
+
+            if (!File.Exists(path))
+            {
+                throw new FileNotFoundException(path);
+            }
+
+            if (!s_textures.TryGetValue(path, out _id))
+            {
+                _id = SHVDN.NativeMemory.CreateTexture(path);
+                s_textures.Add(path, _id);
+            }
+
+            Path = path;
+
+            if (!s_indexes.ContainsKey(_id))
+            {
+                s_indexes.Add(_id, 0);
+            }
+            if (!s_lastDraw.ContainsKey(_id))
+            {
+                s_lastDraw.Add(_id, 0);
+            }
+        }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="CustomSprite"/> class used for drawing external textures on the screen.
         /// </summary>
         /// <param name="filename">Full path to location of the <see cref="CustomSprite"/> on the disc.</param>
@@ -64,29 +102,7 @@ namespace GTA.UI
         /// <exception cref="FileNotFoundException">Thrown if the specified file doesn't exist</exception>
         public CustomSprite(string filename, SizeF size, PointF position, Color color, float rotation, bool centered)
         {
-            if (!File.Exists(filename))
-            {
-                throw new FileNotFoundException(filename);
-            }
-
-            if (s_textures.TryGetValue(filename, out int texture))
-            {
-                _id = texture;
-            }
-            else
-            {
-                _id = SHVDN.NativeMemory.CreateTexture(filename);
-                s_textures.Add(filename, _id);
-            }
-
-            if (!s_indexes.ContainsKey(_id))
-            {
-                s_indexes.Add(_id, 0);
-            }
-            if (!s_lastDraw.ContainsKey(_id))
-            {
-                s_lastDraw.Add(_id, 0);
-            }
+            LoadTexture(filename);
 
             Enabled = true;
             Size = size;


### PR DESCRIPTION
Moved load texture logic from the constructor to a new exposed `LoadTexture(string)` function.
Additionally, store the path of the texture in a variable so it can be accessed later.

Mention: #1659 (this would only partially resolve that issue).

Note: I think that in the future, we should expose a function to dispose of textures, but it does not seem like SHV exposes a function for that.