### PR TITLE
fix(api-v3)!: add fixes for commits of mine

### DIFF
--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -4629,7 +4629,13 @@ namespace SHVDN
                     return 0;
                 }
 
-                //When SET_RADAR_ZOOM writes to this field, it is set to the desired value + 100 in both tested versions(b427 and b3586).
+                if (*s_radarZoomValueAddress == 0)
+                {
+                    return 0;
+                }
+
+                // SET_RADAR_ZOOM adds FORCED_MIN_ZOOM_VALUE to the value if not 0.
+                // The value has been 100 in b427 and b3586.
                 return (*s_radarZoomValueAddress) - 100;
             }
         }

--- a/source/scripting_v3/GTA/Weapons/Weapon.cs
+++ b/source/scripting_v3/GTA/Weapons/Weapon.cs
@@ -241,14 +241,6 @@ namespace GTA
 
         public bool CanUseOnParachute => Function.Call<bool>(Native.Hash.CAN_USE_WEAPON_ON_PARACHUTE, (uint)Hash);
 
-        /// <summary>
-        /// Gets whether this <see cref="Weapon"/> has a flashlight attachment and whether it is currently active.
-        /// </summary>
-        public bool IsFlashlightActive
-        {
-            get => Function.Call<bool>(Native.Hash.IS_FLASH_LIGHT_ON, _owner.Handle);
-        }
-
         public WeaponComponentCollection Components => _components ??= new WeaponComponentCollection(_owner, this);
 
         public static implicit operator WeaponHash(Weapon weapon)

--- a/source/scripting_v3/GTA/Weapons/Weapon.cs
+++ b/source/scripting_v3/GTA/Weapons/Weapon.cs
@@ -250,7 +250,7 @@ namespace GTA
 
 
         /// <summary>
-        /// Gets the the stats displayed on the HUD for this <see cref="Weapon"/>.
+        /// Gets the stats displayed on the HUD for this <see cref="Weapon"/>.
         /// </summary>
         public WeaponHudStats HudStats
         {


### PR DESCRIPTION
1. `RadarZoomValue`
- The actual code checks if the desired value is 0 before adding the minimum zoom; my code did not include that check.

2. `IsFlashlightActive` (BREAKING)
- IS_FLASH_LIGHT_ON checks if the flashlight attachment of the current weapon is enabled. While technically this will return the correct value for all weapons (non-equipped weapons cannot have an enabled flashlight), this is still not ideal to have in the Weapon class.