### PR TITLE
fix(core): fix flicker when printing exception to console

### DIFF
--- a/source/core/Console.cs
+++ b/source/core/Console.cs
@@ -1174,9 +1174,9 @@ namespace SHVDN
                     return compilerResult.CompiledAssembly.GetType("ConsoleInput").GetMethod("Execute");
                 }
 
-                PrintError($"Couldn't compile input expression: {capturedInput}");
-
                 var errors = new StringBuilder();
+
+                errors.AppendLine($"Couldn't compile input expression: {capturedInput}");
 
                 for (int i = 0; i < compilerResult.Errors.Count; ++i)
                 {


### PR DESCRIPTION
This PR fixes a small flicker when printing an exception to the console.
This is caused by the error message and actual exception not being in the same outputQueue slot.

Here you can see the flicker in action:
https://github.com/user-attachments/assets/c0a16b3e-d414-4650-a174-3d2c993a6602

