### PR TITLE
feat(core): adjust arrow and escape key behavior to be context-aware of candidates

### DIFF
--- a/source/core/Console.cs
+++ b/source/core/Console.cs
@@ -106,7 +106,21 @@ namespace SHVDN
 
 
             _keyManager.Register(Keys.Enter, CompileExpression);
-            _keyManager.Register(Keys.Escape, Close);
+
+            _keyManager.Register(Keys.Escape, () =>
+            {
+                lock (_lock)
+                {
+                    if (_hideCandidates || _commandCandidates.Count == 0)
+                    {
+                        Close();
+                        return;
+                    }
+
+                    _hideCandidates = true;
+                }          
+            });
+
             _keyManager.Register(Keys.Tab, CompleteCandidate);
 
             _keyManager.Register(Keys.A | Keys.Control, MoveCursorToBegOfLine);

--- a/source/core/Console.cs
+++ b/source/core/Console.cs
@@ -32,6 +32,7 @@ namespace SHVDN
         private bool _shouldBlockControls;
         private Task<MethodInfo> _compilerTask;
         private List<string> _commandCandidates = new();
+        private bool _hideCandidates = false;
         private int _selectedCandidateIndex = -1;
 
         // We need a lock because tick calls and keyboard events are fired on different threads, even if we don't use
@@ -75,8 +76,35 @@ namespace SHVDN
             _keyManager.Register(Keys.Insert | Keys.Shift, AddClipboardContent);
             _keyManager.Register(Keys.Home, MoveCursorToBegOfLine);
             _keyManager.Register(Keys.End, MoveCursorToEndOfLine);
-            _keyManager.Register(Keys.Up, NextCandidate);
-            _keyManager.Register(Keys.Down, PreviousCandidate);
+            _keyManager.Register(Keys.Up, () =>
+            {
+                lock (_lock)
+                {
+                    if (_hideCandidates || _commandCandidates.Count == 0)
+                    {
+                        GoUpCommandList();
+                        return;
+                    }
+
+                    NextCandidate();
+                }
+            });
+
+            _keyManager.Register(Keys.Down, () =>
+            {
+                lock (_lock)
+                {
+                    if (_hideCandidates || _commandCandidates.Count == 0)
+                    {
+                        GoDownCommandList();
+                        return;
+                    }
+
+                    PreviousCandidate();
+                }
+            });
+
+
             _keyManager.Register(Keys.Enter, CompileExpression);
             _keyManager.Register(Keys.Escape, Close);
             _keyManager.Register(Keys.Tab, CompleteCandidate);
@@ -552,7 +580,7 @@ namespace SHVDN
                 }
 
                 // Draw command candidates
-                if (_commandCandidates.Count > 0)
+                if (!_hideCandidates && _commandCandidates.Count > 0)
                 {
                     for (int i = 0; i < _commandCandidates.Count && i < 5; i++)
                     {
@@ -562,6 +590,7 @@ namespace SHVDN
                 }
             }
         }
+
         /// <summary>
         /// Keyboard handling logic of the console.
         /// </summary>
@@ -588,6 +617,12 @@ namespace SHVDN
                 // Translate key event to character for text input
                 ToUnicode((uint)e.KeyCode, 0, keyboardState, buf, 256, 0);
                 AddToInput(buf.ToString());
+
+                //We only want to show candidates again if the actual input has changed.
+                lock (_lock)
+                {
+                    _hideCandidates = false;
+                }
             }
         }
 


### PR DESCRIPTION
Here are the changes mentioned in #1717; this also included the thread-safety.

This should close #1612, I think atleast.