### PR TITLE
fix(api-v3)!: make chrono related static instances readonly

### DIFF
--- a/source/scripting_v3/GTA.Chrono/GameClockDateTime.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDateTime.cs
@@ -60,7 +60,7 @@ namespace GTA.Chrono
         /// The largest possible value of <see cref="GameClockTime"/>, which is <c>+2147483647-12-31T23:59:59</c>
         /// (23:59:59 on December 31, 2147483647 CE).
         /// </value>
-        public static GameClockDateTime MaxValue = new(GameClockDate.MaxValue, GameClockTime.MaxValue);
+        public static readonly GameClockDateTime MaxValue = new(GameClockDate.MaxValue, GameClockTime.MaxValue);
         /// <summary>
         /// Gets the smallest possible value of <see cref="GameClockDateTime"/>.
         /// </summary>

--- a/source/scripting_v3/GTA.Chrono/GameClockDateTime.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDateTime.cs
@@ -68,7 +68,7 @@ namespace GTA.Chrono
         /// The smallest possible value of <see cref="GameClockTime"/>, which is <c>-2147483648-01-01T00:00:00</c>
         /// (00:00:00 on January 1, -2147483648 BCE).
         /// </value>
-        public static GameClockDateTime MinValue = new(GameClockDate.MinValue, GameClockTime.MinValue);
+        public static readonly GameClockDateTime MinValue = new(GameClockDate.MinValue, GameClockTime.MinValue);
 
         /// <summary>
         /// Returns the date component of this instance.

--- a/source/scripting_v3/GTA.Chrono/GameClockDuration.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDuration.cs
@@ -70,7 +70,7 @@ namespace GTA.Chrono
         /// <see cref="GameClockDateTime.MaxValue"/> to <see cref="GameClockDateTime.MinValue"/>.
         /// This field is read-only.
         /// </summary>
-        public static GameClockDuration MinValue = new(MinSecDifference);
+        public static readonly GameClockDuration MinValue = new(MinSecDifference);
 
         /// <summary>
         /// Gets the hours component of the time interval represented by the current <see cref="GameClockDuration"/>

--- a/source/scripting_v3/GTA.Chrono/GameClockDuration.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDuration.cs
@@ -63,7 +63,7 @@ namespace GTA.Chrono
         /// <see cref="GameClockDateTime.MinValue"/> to <see cref="GameClockDateTime.MaxValue"/>.
         /// This field is read-only.
         /// </summary>
-        public static GameClockDuration MaxValue = new(MaxSecDifference);
+        public static readonly GameClockDuration MaxValue = new(MaxSecDifference);
 
         /// <summary>
         /// Represents the maximum <see cref="GameClockDuration"/> value, which can represent the duration from

--- a/source/scripting_v3/GTA.Chrono/GameClockDuration.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDuration.cs
@@ -56,7 +56,7 @@ namespace GTA.Chrono
         /// <summary>
         /// Represents the zero <see cref="GameClockDuration"/> value. This field is read-only.
         /// </summary>
-        public static GameClockDuration Zero = new(0);
+        public static readonly GameClockDuration Zero = new(0);
 
         /// <summary>
         /// Represents the maximum <see cref="GameClockDuration"/> value, which can represent the duration from

--- a/source/scripting_v3/GTA.Chrono/GameClockTime.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockTime.cs
@@ -42,7 +42,7 @@ namespace GTA.Chrono
         /// <value>
         /// The smallest possible value of <see cref="GameClockTime"/>, which is 00:00:00 (midnight).
         /// </value>
-        public static GameClockTime MinValue = new(0);
+        public static readonly GameClockTime MinValue = new(0);
 
         /// <summary>
         /// Gets the hour component of the time represented by this instance.

--- a/source/scripting_v3/GTA.Chrono/GameClockTime.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockTime.cs
@@ -35,7 +35,7 @@ namespace GTA.Chrono
         /// <value>
         /// The largest possible value of <see cref="GameClockTime"/>, which is 23:59:59.
         /// </value>
-        public static GameClockTime MaxValue = new(86400 - 1);
+        public static readonly GameClockTime MaxValue = new(86400 - 1);
         /// <summary>
         /// Gets the smallest possible value of <see cref="GameClockDate"/>.
         /// </summary>


### PR DESCRIPTION
These values should never be overridden, therefore they should be marked as readonly.