### PR TITLE
feat(core): allow disabled props without collisions to be spawned

### DIFF
--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -728,6 +728,22 @@ namespace SHVDN
                 s_radarZoomValueAddress = (int*)(*(int*)(address + 5) + address + 9);
             }
 
+            // Nopping this enables to spawn some drawable objects without a dedicated collision (e.g. prop_fan_palm_01a)
+            address = MemScanner.FindPatternBmh("\x74\x00\x00\x00\x00\x74\x00\xe8\x00\x00\x00\x00\x48\x85\xc0\x75\x00\x38\x00\x00\x0f\x84\x00\x00\x00\x00\x48\x8d\x4d\x00\xe8\x00\x00\x00\x00\x66\x89\x45\x00\x8b\x45\x00\x8b\xc8\x33\x4d", "x????x?x????xxxx?x??xx????xxx?x????xxx?xx?xxxx");
+            if (address != null)
+            {
+                address = MemScanner.FindPatternNaive("\x25\xff\xff\xff\x3f", "xxxxx", new IntPtr(address + 0x2E), 0x7c);
+
+                if (address != null)
+                {
+                    address += 0x10;
+
+                    const int BytesToWriteInstructions = 0x18;
+                    byte[] nopBytes = Enumerable.Repeat((byte)0x90, BytesToWriteInstructions).ToArray();
+                    Marshal.Copy(nopBytes, 0, new IntPtr(address), BytesToWriteInstructions);
+                }
+            }
+
             // Generate vehicle model list
             var vehicleHashesGroupedByClass = new List<int>[0x20];
             for (int i = 0; i < 0x20; i++)


### PR DESCRIPTION
This PR adds a patch to allow disabled props without collisions to be spawned, as disguessed in #1652.

You can see some details about the patch in my comment:
https://github.com/scripthookvdotnet/scripthookvdotnet/issues/1652#issuecomment-4297397902

The patch was confirmed to be working in **b2545, b2628, b3570 and b3788** by @nomakewan.

But the signature is also valid in **b427** and should therefore also work in prior versions, though this was not fully tested.

This should close #1652.

Thanks to @nomakewan again for helping me test this.