### PR TITLE
fix(api-v2, api-v3): `Quaternion.Slerp` not respecting `end` when dot product is exactly zero

### DIFF
--- a/source/scripting_v2/GTA.Math/Quaternion.cs
+++ b/source/scripting_v2/GTA.Math/Quaternion.cs
@@ -383,11 +383,14 @@ namespace GTA.Math
             float opposite;
             float inverse;
             float dot = Dot(start, end);
+            // Can't use `System.Math.Sign`, because we want to avoid `opposite` being zero when the dot product is
+            // exactly zero
+            float dotSign = dot >= 0.0f ? 1.0f : -1.0f;
 
             if (System.Math.Abs(dot) > (1.0f - kEpsilon))
             {
                 inverse = 1.0f - amount;
-                opposite = amount * System.Math.Sign(dot);
+                opposite = amount * dotSign;
             }
             else
             {
@@ -395,7 +398,7 @@ namespace GTA.Math
                 float invSin = (float)(1.0 / System.Math.Sin(aCos));
 
                 inverse = (float)(System.Math.Sin((1.0f - amount) * aCos) * invSin);
-                opposite = (float)(System.Math.Sin(amount * aCos) * invSin * System.Math.Sign(dot));
+                opposite = (float)(System.Math.Sin(amount * aCos) * invSin * dotSign);
             }
 
             result.X = (inverse * start.X) + (opposite * end.X);

--- a/source/scripting_v3/GTA.Math/Quaternion.cs
+++ b/source/scripting_v3/GTA.Math/Quaternion.cs
@@ -402,11 +402,14 @@ namespace GTA.Math
             float opposite;
             float inverse;
             float dot = Dot(start, end);
+            // Can't use `System.Math.Sign`, because we want to avoid `opposite` being zero when the dot product is
+            // exactly zero
+            float dotSign = dot >= 0.0f ? 1.0f : -1.0f;
 
             if (System.Math.Abs(dot) > (1.0f - kEpsilon))
             {
                 inverse = 1.0f - amount;
-                opposite = amount * System.Math.Sign(dot);
+                opposite = amount * dotSign;
             }
             else
             {
@@ -414,7 +417,7 @@ namespace GTA.Math
                 float invSin = (float)(1.0 / System.Math.Sin(aCos));
 
                 inverse = (float)(System.Math.Sin((1.0f - amount) * aCos) * invSin);
-                opposite = (float)(System.Math.Sin(amount * aCos) * invSin * System.Math.Sign(dot));
+                opposite = (float)(System.Math.Sin(amount * aCos) * invSin * dotSign);
             }
 
             result.X = (inverse * start.X) + (opposite * end.X);


### PR DESCRIPTION
I guess a lot of script developers use `Quaternion.Slerp`, but it had a bug where it doesn't return an interporated `Quaternion` when the dot of 2 passed `Quaternion`s is *exactly* zero. Therefore, I'll create a PR for said bug as a public reference.

## Summary
Fix `Quaternion.Slerp` returning a `Quaternion` equal to `start` but multiplied by `System.Math.Sin((1.0f - amount) * 1.57079637f)` when the dot product of the `start` and `end` `Quaternion`s is *exactly* zero, which does not respect `end` at all.

Fix #1731.

## Details
The bug can be reproduced with including but not limited to a pair of the identity `Quaternion` and one that's rotated around one of X, Y, or Z unit axis by 180 degrees, or a pair of one that's rorated around one of X, Y, or Z unit axis by 90 degrees and one that's rotated around the axis by 90 degrees in the opposite direction. The bug was caused because the implementation of `Slerp` didn't handle how `System.Math.Sign(float)` returns zero when the passed `float` is exactly zero.

The bug exists since b4217eb404467d526c3aa39b3ecf34ea986cf5aa, which `Quaternion.Slerp` is added and every stable version since v2.6 has.