### PR TITLE
fix(api-v2, api-v3): `Quaternion.FromToRotation` returning random value

### DIFF
--- a/source/scripting_v2/GTA.Math/Quaternion.cs
+++ b/source/scripting_v2/GTA.Math/Quaternion.cs
@@ -431,7 +431,11 @@ namespace GTA.Math
 
             if (w >= 1e-6f * NormAB)
             {
-                result = new Quaternion(Vector3.Cross(fromDirection, toDirection), w);
+                // The axis is equal to `Cross(fromDirection, toDirection)`
+			    result.X = fromDirection.Y * toDirection.Z - fromDirection.Z * toDirection.Y;
+			    result.Y = fromDirection.Z * toDirection.X - fromDirection.X * toDirection.Z;
+			    result.Z = fromDirection.X * toDirection.Y - fromDirection.Y * toDirection.X;
+			    result.W = w;
             }
             else
             {

--- a/source/scripting_v3/GTA.Math/Quaternion.cs
+++ b/source/scripting_v3/GTA.Math/Quaternion.cs
@@ -459,7 +459,11 @@ namespace GTA.Math
 
             if (w >= 1e-6f * NormAB)
             {
-                Result = new Quaternion(Vector3.Cross(fromDirection, toDirection), w);
+                // The axis is equal to `Cross(fromDirection, toDirection)`
+			    Result.X = fromDirection.Y * toDirection.Z - fromDirection.Z * toDirection.Y;
+			    Result.Y = fromDirection.Z * toDirection.X - fromDirection.X * toDirection.Z;
+			    Result.Z = fromDirection.X * toDirection.Y - fromDirection.Y * toDirection.X;
+			    Result.W = w;
             }
             else
             {


### PR DESCRIPTION
Fixing a `Quaternion` method that didn't work as expected for most pairs of direction vector inputs...

## Details
Fix `Quaternion.FromToRotation` returning what the ctor with a axis `Vector3` and an angle `float` returns but the axis argument is the from direction cross the to direction vector and the angle value is the product of the magnitudes of direction vectors plus the dot product of them. The only exceptional case is when the passed direction `Vector`s point in approximately opposite directions.

Can be tested with these pairs of direction `Vector3`s:
* { `Vector3(1f, 0f, 0f)`, `Vector3(1f / 1.414213f, 1f / 1.414213f, 0f)` }
* { `Vector3(0f, 1f, 0f)`, `Vector3(0f, 0f, 1f)` }
* { `Vector3(0f, 0f, 1f)`, `Vector3(1f / 1.414213f, 0f, -1f / 1.414213f)` }

Fix #1734.