### PR TITLE
feat(api-v3): `Scaleform.Render2DMasked(Scaleform)`

### DIFF
--- a/source/scripting_v3/GTA/Scaleform.cs
+++ b/source/scripting_v3/GTA/Scaleform.cs
@@ -153,6 +153,20 @@ namespace GTA
         {
             Function.Call(Hash.DRAW_SCALEFORM_MOVIE_FULLSCREEN, Handle, 255, 255, 255, 255, 0);
         }
+        /// <summary>
+        /// Renders two movies with masking between this foreground movie and the specified background movie.
+        /// </summary>
+        /// <param name="background">
+        /// The background <see cref="Scaleform"/> movie. Must be loaded before calling this method.
+        /// </param>
+        // Although `DRAW_SCALEFORM_MOVIE_FULLSCREEN_MASKED` is typically called with the 2nd argument being
+        // a handle for a scaleform with the suffix "_CELEBRATION_FG", the implementation code of
+        // `DRAW_SCALEFORM_MOVIE_FULLSCREEN_MASKED` does set the background masked movie ID of `CScriptHud` to the 2nd
+        // argument. Hence, the 2nd argument being named "background".
+        public void Render2DMasked(Scaleform background)
+        {
+            Function.Call(Hash.DRAW_SCALEFORM_MOVIE_FULLSCREEN_MASKED, Handle, background.Handle, 255, 255, 255, 255);
+        }
         public void Render2DScreenSpace(PointF position, PointF size)
         {
             float x = position.X / UI.Screen.Width;


### PR DESCRIPTION
Close #1736.

I found a case where `DRAW_SCALEFORM_MOVIE_FULLSCREEN_MASKED` shines, which is a "MP_CELEBRATION" scaleforms. I made snippets for such scaleforms based on `net_job_intro.sch` and `mp_celebration.gfx`. [LemonUI's Celebration.cs](https://github.com/LemonUIbyLemon/LemonUI/blob/a37b214eb0283a3b0d636d2f52b684600f106547/LemonUI/Scaleform/Celebration.cs)? Only a bit since `mp_celebration.gfx` tells us more when decompiling with[ JPEXS Free Flash Decompiler](https://github.com/jindrapetrik/jpexs-decompiler).

```C#
// you only call once every time you want to start a sequence of the intro screen
private void AddIntroToIntroScreen(Scaleform celebration)
{
    celebration.CallFunction("CLEANUP", "intro");

    const int alphaStatWall = 40;
    celebration.CallFunction("CREATE_STAT_WALL", "intro", "HUD_COLOUR_BLACK", alphaStatWall);

    const int pauseDurationSecs = 2;
    celebration.CallFunction("SET_PAUSE_DURATION", pauseDurationSecs);

    const string modeLabelStr = "PM_ARENA";
    // for "Here Come the Monsters" in English
    string jobStr = Game.GetLocalizedString(unchecked((int)0x96E76E19));
    const string challengeTextLabel = "CELEB_POTENTIAL_CUT";
    const string challengePartsText = " $10000";
    const string TargetTextLabel = "CELEB_TARGET_TIME";
    // in milliseconds for "CELEB_TARGET_TIME" and "MP_CELEBRATION" scaleforms have hard-coded formatting
    // for "CELEB_TARGET_TIME"
    const int targetValue = 10000;
    const int delay = 0;
    const string targetPrefix = "";
    const bool modeLabelIsStringLiteral = false;
    celebration.CallFunction("ADD_INTRO_TO_WALL", "intro", modeLabelStr, jobStr, challengeTextLabel, challengePartsText, TargetTextLabel, targetValue, delay, targetPrefix, modeLabelIsStringLiteral);

    const int bgAlpha = 75;
    const int textureId = 0;
    celebration.CallFunction("ADD_BACKGROUND_TO_WALL", "intro", bgAlpha, textureId);

    celebration.CallFunction("SHOW_STAT_WALL", "intro");
}

// you call this method every frame you want to draw the intro screen
private void DrawCelebrationScaleformsThisFrame()
{
    const int colorR = 255;
    const int colorG = 255;
    const int colorB = 255;
    const int colorA = 255;
    const int stereoFlag = 0; // no stereo

    // `_celebrationFg`, `_celebrationBg`, `_celebration` are `Scaleform`s that are created with
    // `Scaleform.RequestMovie("MP_CELEBRATION_BG")`, `Scaleform.RequestMovie("MP_CELEBRATION_FG")`, and
    // `Scaleform.RequestMovie("MP_CELEBRATION")` respectively
    GTA.Graphics.Scripted2DGfxSettings.DrawOrder = GTA.Graphics.ScriptedGfxDrawOrder.BeforeHud;
    _celebrationFg.Render2DMasked(_celebrationBg);

    GTA.Graphics.Scripted2DGfxSettings.DrawOrder = GTA.Graphics.ScriptedGfxDrawOrder.AfterFade;
    _celebration.Render2D();
    GTA.Graphics.Scripted2DGfxSettings.DrawOrder = GTA.Graphics.ScriptedGfxDrawOrder.AfterHud;
}
```

## Showcases
When specifying a foreground and a background scaleform correctly:
<img width="1280" height="720" alt="mp_celebration-correct-fg-bg" src="https://github.com/user-attachments/assets/ddac8143-05ce-4b37-bfa6-530751f1c5b7" />

When specifying a foreground and a background scaleform incorrectly:
<img width="1280" height="720" alt="mp_celebration-incorrect-fg-bg" src="https://github.com/user-attachments/assets/9a8eba8a-fa03-4770-9677-d5d35cedf88b" />