### PR TITLE
feat(api-v3): add ``ScriptFire`` PoolObject and ``FireManager`` class for script fires

### DIFF
--- a/source/core/Enums/ScriptResourceType.cs
+++ b/source/core/Enums/ScriptResourceType.cs
@@ -5,5 +5,6 @@ namespace SHVDN
         Checkpoint = 6,
         RelationshipGroup = 20,
         ScaleformMovie = 21,
+        ScriptFire = 2,
     }
 }

--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -4997,6 +4997,55 @@ namespace SHVDN
 
         #endregion
 
+        #region -- Script Fire --
+
+        internal sealed class DoesCScriptResourceExistByCounterTask : IScriptTask
+        {
+            internal ScriptResourceType _resourceType;
+            internal int _targetCounter;
+            internal bool _result;
+
+            internal DoesCScriptResourceExistByCounterTask(ScriptResourceType resourceType, int counter)
+            {
+                _resourceType = resourceType;
+                _targetCounter = counter;
+            }
+
+            public void Run()
+            {
+                ulong cGameScriptHandlerAddress = s_getCGameScriptHandlerAddressFunc();
+
+                if (cGameScriptHandlerAddress == 0)
+                {
+                    return;
+                }
+
+                CGameScriptResource* firstItem = *(CGameScriptResource**)(cGameScriptHandlerAddress + 48);
+                for (CGameScriptResource* item = firstItem; item != null; item = item->Next)
+                {
+                    if (item->ResourceTypeNameIndex == _resourceType && (int)item->CounterOfPool == _targetCounter)
+                    {
+                        _result = true;
+                        return;
+                    }
+                }
+            }
+        }
+
+        public static bool IsScriptFireHandleValid(int handle)
+        {
+            if (handle == 0 || handle == -1)
+            {
+                return false;
+            }
+
+            var task = new DoesCScriptResourceExistByCounterTask(ScriptResourceType.ScriptFire, handle);
+            ScriptDomain.CurrentDomain.ExecuteTaskWithGameThreadTlsContext(task);
+            return task._result;
+        }
+
+        #endregion
+
         #region -- Waypoint Info Array --
 
         private static ulong* s_waypointInfoArrayStartAddress;

--- a/source/scripting_v3/GTA/FireManager.cs
+++ b/source/scripting_v3/GTA/FireManager.cs
@@ -1,0 +1,62 @@
+//
+// Copyright (C) 2026 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+using GTA.Math;
+using GTA.Native;
+
+namespace GTA
+{
+    /// <summary> Provides static methods for managing fires within the game world. </summary>
+    public static class FireManager
+    {
+        /// <summary>
+        /// Creates a fire at the specified location, with the specified maximum number of children fires and whether it's a gas fire.
+        /// </summary>
+        /// <param name="position">The position where the fire will be created.</param>
+        /// <param name="maxChildrenCount">The maximum number of children fires. Must be less than 25 or else the fire will not be created.</param>
+        /// <param name="isGasFire">If true, makes the fire look like it originates from a line of gasoline.</param>
+        /// <returns>The created <see cref="ScriptFire"/> instance.</returns>
+        public static ScriptFire StartScriptFire(Vector3 position, int maxChildrenCount, bool isGasFire)
+        {
+            int handle = Function.Call<int>(Hash.START_SCRIPT_FIRE, position.X, position.Y, position.Z, maxChildrenCount, isGasFire);
+            return new ScriptFire(handle);
+        }
+
+        /// <summary>
+        /// Gets the number of active fires within a specified radius of a given position.
+        /// </summary>
+        /// <param name="position">The center point, as a Vector3, from which to search for fires.</param>
+        /// <param name="radius">The radius within which to count active fires. </param>
+        /// <returns>The number of active fires found within the specified radius of the given position.</returns>
+        public static int GetNumberOfFiresInRadius(Vector3 position, float radius)
+            => Function.Call<int>(Hash.GET_NUMBER_OF_FIRES_IN_RANGE, position.X, position.Y, position.Z, radius);
+
+        /// <summary>
+        /// Stops all active fires within the specified radius of the given position.
+        /// </summary>
+        /// <param name="position">The center point around which to stop fires.</param>
+        /// <param name="radius">The radius, within which all fires will be stopped. </param>
+        public static void StopFireInRadius(Vector3 position, float radius)
+            => Function.Call(Hash.STOP_FIRE_IN_RANGE, position.X, position.Y, position.Z, radius);
+
+        /// <summary>
+        /// Attempts to find the position of the closest fire relative to the specified location.
+        /// </summary>
+        /// <param name="position">The world position from which to search for the nearest fire.</param>
+        /// <param name="firePosition">If method returns true, contains the world position of the closest fire to the specified location; otherwise, <seealso cref="Vector3.Zero"/>
+        /// This parameter is passed uninitialized.</param>
+        /// <returns>true if a fire position is found near the specified location; otherwise, false.</returns>
+        public static bool TryGetClosestFirePosition(Vector3 position, out Vector3 firePosition)
+        {
+            NativeVector3 outPos;
+            unsafe
+            {
+                bool foundFire = Function.Call<bool>(Hash.GET_CLOSEST_FIRE_POS, &outPos, position.X, position.Y, position.Z);
+                firePosition = foundFire ? outPos : Vector3.Zero;
+                return foundFire;
+            }
+        }
+    }
+}

--- a/source/scripting_v3/GTA/FireManager.cs
+++ b/source/scripting_v3/GTA/FireManager.cs
@@ -18,7 +18,7 @@ namespace GTA
         /// <param name="maxChildrenCount">The maximum number of children fires. Must be less than 25 or else the fire will not be created.</param>
         /// <param name="isGasFire">If true, makes the fire look like it originates from a line of gasoline.</param>
         /// <returns>The created <see cref="ScriptFire"/> instance.</returns>
-        public static ScriptFire StartScriptFire(Vector3 position, int maxChildrenCount, bool isGasFire)
+        public static ScriptFire StartScriptFire(Vector3 position, int maxChildrenCount, bool isGasFire = false)
         {
             int handle = Function.Call<int>(Hash.START_SCRIPT_FIRE, position.X, position.Y, position.Z, maxChildrenCount, isGasFire);
             return new ScriptFire(handle);

--- a/source/scripting_v3/GTA/ScriptFire.cs
+++ b/source/scripting_v3/GTA/ScriptFire.cs
@@ -1,0 +1,30 @@
+//
+// Copyright (C) 2026 kagikn & contributors
+// License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
+//
+
+using GTA.Native;
+
+namespace GTA
+{
+    /// <summary>Represents a fire in the game world.</summary>
+    public sealed class ScriptFire : PoolObject
+    {
+        /// <summary>Initializes a new instance of the <see cref="ScriptFire"/> class.</summary>
+        /// <param name="handle">The handle of the fire.</param>
+        internal ScriptFire(int handle) : base(handle)
+        {
+        }
+
+        /// <summary>Creates a new <see cref="ScriptFire"/> from an existing handle.</summary>
+        /// <param name="handle">The handle of the fire.</param>
+        /// <returns>A new <see cref="ScriptFire"/> instance.</returns>
+        public static ScriptFire FromHandle(int handle) => new ScriptFire(handle);
+
+        /// <summary>Removes this <see cref="ScriptFire"/> from the game world.</summary>
+        public override void Delete() => Function.Call(Hash.REMOVE_SCRIPT_FIRE, Handle);
+
+        /// <summary> Determines if this <see cref="ScriptFire"/> still exists in the game world. </summary>
+        public override bool Exists() => SHVDN.NativeMemory.IsScriptFireHandleValid(Handle);
+    }
+}


### PR DESCRIPTION
I have added a ``Fire.cs`` class representing an ingame fire.
Although there is a "START_SCRIPT_FIRE" Native, there is no "DOES_SCRIPT_FIRE_EXIST", meaning I had to extend both ``ScriptResourceType`` enum and ``NativeMemory`` to be able to implement the ``Exists()`` check coming from ``PoolObject``.

I have also added a few methods to ``World.cs``:
- ``Fire StartFire(Vector3 position, int maxChildrenCount, bool isGasFire)``: To create a fire
- ``int GetNumberOfFiresInRadius(Vector3 position, float radius)``: To get the number of fires within a radius. The Native this method calls is ``GET_NUMBER_OF_FIRES_IN_RANGE`` which has ``RANGE`` in the name but takes a ``float radius`` parameter according to nativedb so I put "Radius" in the method name accordingly
- ``void StopFireInRadius(Vector3 position, float radius)``: To stop all fires in a given radius (rule of method naming accordingly to previous method)
- ~``bool TryGetClosestFirePosition(Vector3 position, float radius, out Vector3 firePosition)``: To find the nearest fire position if there are any fires in that given radius~
- ``bool TryGetClosestFirePosition(Vector3 position, out Vector3 firePosition)``: To find the nearest fire position if there are any fires

Edit:
Now outdated