### PR TITLE
fix(api-v3): fix bugs connected to incorrect usage of natives

### DIFF
--- a/source/scripting_v3/GTA.UI/Notification.cs
+++ b/source/scripting_v3/GTA.UI/Notification.cs
@@ -183,7 +183,7 @@ namespace GTA.UI
         {
             BeginTextCommandForFeedPostAndPushLongString(message);
 
-            int handle = Function.Call<int>(Hash.END_TEXT_COMMAND_THEFEED_POST_UNLOCK, title, (int)iconType, null, isImportant,
+            int handle = Function.Call<int>(Hash.END_TEXT_COMMAND_THEFEED_POST_UNLOCK_TU_WITH_COLOR, title, (int)iconType, null, isImportant,
                 (int)titleColor, titleIsLiteral);
             return handle != -1 ? new FeedPost(handle) : null;
         }

--- a/source/scripting_v3/GTA.UI/Notification.cs
+++ b/source/scripting_v3/GTA.UI/Notification.cs
@@ -149,7 +149,7 @@ namespace GTA.UI
         {
             BeginTextCommandForFeedPostAndPushLongString(message);
 
-            int handle = Function.Call<int>(Hash.END_TEXT_COMMAND_THEFEED_POST_UNLOCK, title, (int)iconType, null, isImportant);
+            int handle = Function.Call<int>(Hash.END_TEXT_COMMAND_THEFEED_POST_UNLOCK_TU, title, (int)iconType, null, isImportant);
             return handle != -1 ? new FeedPost(handle) : null;
         }
         /// <summary>

--- a/source/scripting_v3/GTA/Audio.cs
+++ b/source/scripting_v3/GTA/Audio.cs
@@ -81,7 +81,7 @@ namespace GTA
         /// <param name="enableOnReplay"><inheritdoc cref="ScriptSound.PlaySoundFrontend(string, string, bool)" path="/param[@name='enableOnReplay']"/></param>.
         public static void PlaySoundAndForget(string soundName, string setName, bool enableOnReplay = true)
         {
-            Function.Call(Hash.PLAY_SOUND, -1, soundName, setName, enableOnReplay);
+            Function.Call(Hash.PLAY_SOUND, -1, soundName, setName, /* bOverNetwork */ false, /* NetworkRange */ 0, enableOnReplay);
         }
         /// <summary>
         /// Plays back a sound "frontend" - at full volume, panned centrally, but do not track of sounds.

--- a/source/scripting_v3/GTA/Camera/Camera.cs
+++ b/source/scripting_v3/GTA/Camera/Camera.cs
@@ -468,19 +468,17 @@ namespace GTA
         /// <param name="duration">The duration of any interpolation in milliseconds.</param>
         /// <param name="graphTypePos">The camera graph type for position transition.</param>
         /// <param name="graphTypeRot">The camera graph type for rotation transition.</param>
-        /// <param name="rotOrder">The rotation order in world space.</param>
         public void InterpTo(Camera destinationCam, int duration,
             CamFrameInterpolatorCurveType graphTypePos = CamFrameInterpolatorCurveType.SinAccelDecel,
-            CamFrameInterpolatorCurveType graphTypeRot = CamFrameInterpolatorCurveType.SinAccelDecel,
-            EulerRotationOrder rotOrder = EulerRotationOrder.YXZ)
+            CamFrameInterpolatorCurveType graphTypeRot = CamFrameInterpolatorCurveType.SinAccelDecel)
         {
             Function.Call(Hash.SET_CAM_ACTIVE_WITH_INTERP, destinationCam.Handle, Handle, duration, (int)graphTypePos,
-                (int)graphTypeRot, (int)rotOrder);
+                (int)graphTypeRot);
         }
         /// <summary>
         /// Sets a cam active which will be interpolated too from this <see cref="Camera"/>.
         /// </summary>
-        [Obsolete("Use Camera.InterpTo(Camera, int, CamFrameInterpolatorCurveType, CamFrameInterpolatorCurveType, EulerRotationOrder) instead."),
+        [Obsolete("Use Camera.InterpTo(Camera, int, CamFrameInterpolatorCurveType, CamFrameInterpolatorCurveType) instead."),
         EditorBrowsable(EditorBrowsableState.Never)]
         public void InterpTo(Camera to, int duration, int easePosition, int easeRotation)
         {

--- a/source/scripting_v3/GTA/Entities/Entity.cs
+++ b/source/scripting_v3/GTA/Entities/Entity.cs
@@ -3360,7 +3360,7 @@ namespace GTA
             unsafe
             {
                 (CrClipDictionary clipDict, string clipName) = crClipAsset;
-                bool foundEventTag = Function.Call<bool>(Hash.FIND_ANIM_EVENT_PHASE, Handle, clipDict, clipName, eventName, &startPhaseTemp, &endPhaseTemp);
+                bool foundEventTag = Function.Call<bool>(Hash.FIND_ANIM_EVENT_PHASE, clipDict, clipName, eventName, &startPhaseTemp, &endPhaseTemp);
 
                 startPhase = startPhaseTemp;
                 endPhase = endPhaseTemp;

--- a/source/scripting_v3/GTA/Entities/Peds/Task/TaskInvoker.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Task/TaskInvoker.cs
@@ -2018,19 +2018,6 @@ namespace GTA
                 targetOffset.Z);
         }
         /// <summary>
-        /// Tells the <see cref="Ped"/> in a plane to land. The <see cref="Ped"/> will try to land in between the start
-        /// and end coords.
-        /// </summary>
-        /// <remarks>
-        /// Cannot be used in a <see cref="TaskSequence"/> since <c>TASK_PLANE_CHASE</c> does not expect the zero
-        /// handle for task sequences.
-        /// </remarks>
-        public void PlaneChase(Vehicle plane, Vector3 runWayStart, Vector3 runWayEnd)
-        {
-            Function.Call(Hash.TASK_PLANE_CHASE, _ped.Handle, plane.Handle, runWayStart.X, runWayStart.Y,
-                runWayStart.Z, runWayEnd.X, runWayEnd.Y, runWayEnd.Z);
-        }
-        /// <summary>
         /// Tells the <see cref="Ped"/> in a heli to chase an <see cref="Entity"/>. The <see cref="Ped"/> must be in
         /// a heli.
         /// </summary>

--- a/source/scripting_v3/GTA/ScriptSound.cs
+++ b/source/scripting_v3/GTA/ScriptSound.cs
@@ -44,7 +44,7 @@ namespace GTA
         /// <param name="enableOnReplay"><inheritdoc cref="PlaySoundFrontend(string, string, bool)" path="/param[@name='enableOnReplay']"/></param>.
         public void PlaySound(string soundName, string setName, bool enableOnReplay = true)
         {
-            Function.Call(Hash.PLAY_SOUND, Id, soundName, setName, enableOnReplay);
+            Function.Call(Hash.PLAY_SOUND, Id, soundName, setName, /* bOverNetwork */ false, /* NetworkRange */ 0, enableOnReplay);
         }
         /// <summary>
         /// Plays back a sound "frontend" - at full volume, panned centrally.

--- a/source/scripting_v3/GTA/Wanted.cs
+++ b/source/scripting_v3/GTA/Wanted.cs
@@ -563,7 +563,7 @@ namespace GTA
 
             // This additional crime value is hardcoded in a function that is called by SET_PLAYER_WANTED_LEVEL
             const int AdditionalCrimeValue = 20;
-            int threshold = Function.Call<int>(Hash.GET_WANTED_LEVEL_THRESHOLD, _playerIndex, wantedLevelToApply);
+            int threshold = Function.Call<int>(Hash.GET_WANTED_LEVEL_THRESHOLD, wantedLevelToApply);
 
             CurrentCrimeValue = threshold + AdditionalCrimeValue;
             SHVDN.MemDataMarshal.WriteInt32(cWantedAddress + SHVDN.NativeMemory.CurrentWantedLevelOffset,


### PR DESCRIPTION
I wrote a Python script that compares the argument count of native calls in v3 to nativeDB arguments. Then I did the manual work of comparing those results to actual header definitions instead of just relying on nativedb.

https://github.com/scripthookvdotnet/scripthookvdotnet/commit/5b4a2e51ce94df5e6321e682c13a9ca1c755b781: `FIND_ANIM_EVENT_PHASE` does not take in the handle of an entity as the first argument. Because this shifted all arguments one to the right before, the function would always return unexpected results. Also, I'm not sure if `FindAnimationEventPhase` belongs in the `Entity` class, even if the native is in the `Entity` namespace.

https://github.com/scripthookvdotnet/scripthookvdotnet/pull/1747/commits/137f127fd4e6bca4af85547d4baef47b254c00b2 Because `enableOnReplay` was passed in the incorrect position, it did not have any effect in the past.

https://github.com/scripthookvdotnet/scripthookvdotnet/commit/73ad66171b8b798170e9c6102d295dc233e84e9c Because `GET_WANTED_LEVEL_THRESHOLD` was called with the player index(which in most cases is 0) as the first argument, it would always return the same result.