### PR TITLE
refactor(api-v3): split obsolete members into seperate partial class

### DIFF
--- a/source/scripting_v3/GTA.UI/Notification.Obsolete.cs
+++ b/source/scripting_v3/GTA.UI/Notification.Obsolete.cs
@@ -1,0 +1,48 @@
+using System;
+using System.ComponentModel;
+using GTA.Native;
+
+namespace GTA.UI
+{
+    public static partial class Notification
+    {
+        /// <summary>
+        /// Creates a <see cref="Notification"/> above the minimap with the given message.
+        /// </summary>
+        /// <param name="message">The message in the notification.</param>
+        /// <param name="blinking">if set to <see langword="true" /> the notification will blink.</param>
+        /// <returns>The handle of the <see cref="Notification"/> which can be used to hide it using <see cref="Notification.Hide(int)"/>.</returns>
+        [Obsolete("Use Notification.PostTicker instead.")]
+        public static int Show(string message, bool blinking = false)
+        {
+            BeginTextCommandForFeedPostAndPushLongString(message);
+            return Function.Call<int>(Hash.END_TEXT_COMMAND_THEFEED_POST_TICKER, blinking, true);
+        }
+
+        /// <summary>
+        /// Creates a more advanced (SMS-alike) <see cref="Notification"/> above the minimap showing a sender icon, subject and the message.
+        /// </summary>
+        /// <param name="icon">
+        /// The notification icon.
+        /// Although you can use any pair of a texture dictionary (txd) and a texture as long as the txd is loaded
+        /// and the txd contains the texture in <c>END_TEXT_COMMAND_THEFEED_POST_MESSAGETEXT</c>, you can only specify
+        /// the textures chosen for <see cref="NotificationIcon"/> in this overload.
+        /// </param>
+        /// <param name="sender">The sender name.</param>
+        /// <param name="subject">The subject line.</param>
+        /// <param name="message">The message itself.</param>
+        /// <param name="fadeIn">If <see langword="true" /> the message will fade in.</param>
+        /// <param name="blinking">if set to <see langword="true" /> the notification will blink.</param>
+        /// <returns>The handle of the <see cref="Notification"/> which can be used to hide it using <see cref="Notification.Hide(int)"/>.</returns>
+        [Obsolete("Notification.Show is obsolete since it may fail to draw a texture icon for a text message." +
+            "Use Notification.PostMessageText instead."), EditorBrowsable(EditorBrowsableState.Never)]
+        public static int Show(NotificationIcon icon, string sender, string subject, string message, bool fadeIn = false, bool blinking = false)
+        {
+            string iconName = s_iconNames[(int)icon];
+
+            BeginTextCommandForFeedPostAndPushLongString(message);
+            return Function.Call<int>(Hash.END_TEXT_COMMAND_THEFEED_POST_MESSAGETEXT, iconName, iconName, fadeIn, 1, sender, subject);
+        }
+
+    }
+}

--- a/source/scripting_v3/GTA.UI/Notification.cs
+++ b/source/scripting_v3/GTA.UI/Notification.cs
@@ -13,7 +13,7 @@ namespace GTA.UI
     /// <summary>
     /// Methods to manage the display of notifications.
     /// </summary>
-    public static class Notification
+    public static partial class Notification
     {
         #region Fields
         static readonly string[] s_iconNames = new string[] {
@@ -258,44 +258,6 @@ namespace GTA.UI
         {
             Function.Call(Hash.BEGIN_TEXT_COMMAND_THEFEED_POST, SHVDN.NativeMemory.CellEmailBcon);
             SHVDN.NativeFunc.PushLongString(message);
-        }
-
-        /// <summary>
-        /// Creates a <see cref="Notification"/> above the minimap with the given message.
-        /// </summary>
-        /// <param name="message">The message in the notification.</param>
-        /// <param name="blinking">if set to <see langword="true" /> the notification will blink.</param>
-        /// <returns>The handle of the <see cref="Notification"/> which can be used to hide it using <see cref="Notification.Hide(int)"/>.</returns>
-        [Obsolete("Use Notification.PostTicker instead.")]
-        public static int Show(string message, bool blinking = false)
-        {
-            BeginTextCommandForFeedPostAndPushLongString(message);
-            return Function.Call<int>(Hash.END_TEXT_COMMAND_THEFEED_POST_TICKER, blinking, true);
-        }
-
-        /// <summary>
-        /// Creates a more advanced (SMS-alike) <see cref="Notification"/> above the minimap showing a sender icon, subject and the message.
-        /// </summary>
-        /// <param name="icon">
-        /// The notification icon.
-        /// Although you can use any pair of a texture dictionary (txd) and a texture as long as the txd is loaded
-        /// and the txd contains the texture in <c>END_TEXT_COMMAND_THEFEED_POST_MESSAGETEXT</c>, you can only specify
-        /// the textures chosen for <see cref="NotificationIcon"/> in this overload.
-        /// </param>
-        /// <param name="sender">The sender name.</param>
-        /// <param name="subject">The subject line.</param>
-        /// <param name="message">The message itself.</param>
-        /// <param name="fadeIn">If <see langword="true" /> the message will fade in.</param>
-        /// <param name="blinking">if set to <see langword="true" /> the notification will blink.</param>
-        /// <returns>The handle of the <see cref="Notification"/> which can be used to hide it using <see cref="Notification.Hide(int)"/>.</returns>
-        [Obsolete("Notification.Show is obsolete since it may fail to draw a texture icon for a text message." +
-            "Use Notification.PostMessageText instead."), EditorBrowsable(EditorBrowsableState.Never)]
-        public static int Show(NotificationIcon icon, string sender, string subject, string message, bool fadeIn = false, bool blinking = false)
-        {
-            string iconName = s_iconNames[(int)icon];
-
-            BeginTextCommandForFeedPostAndPushLongString(message);
-            return Function.Call<int>(Hash.END_TEXT_COMMAND_THEFEED_POST_MESSAGETEXT, iconName, iconName, fadeIn, 1, sender, subject);
         }
 
         /// <summary>

--- a/source/scripting_v3/GTA.UI/TextElement.Obsolete.cs
+++ b/source/scripting_v3/GTA.UI/TextElement.Obsolete.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GTA.UI
+{
+    public partial class TextElement : IWorldDrawableElement
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether the alignment of this <see cref="TextElement" /> is centered.
+        /// See <see cref="Alignment"/>
+        /// </summary>
+        /// <value>
+        ///   <see langword="true" /> if centered; otherwise, <see langword="false" />.
+        /// </value>
+        [Obsolete("`TextElement.Centered` is obsolete because it is redundant and setting the property to false is " +
+            "confusing. Use `TextElement.Alignment` instead."), EditorBrowsable(EditorBrowsableState.Never)]
+        public bool Centered
+        {
+            get => Alignment == Alignment.Center;
+            set => Alignment = value ? Alignment.Center : Alignment.Left;
+        }
+    }
+}

--- a/source/scripting_v3/GTA.UI/TextElement.cs
+++ b/source/scripting_v3/GTA.UI/TextElement.cs
@@ -14,7 +14,7 @@ using GTA.Native;
 
 namespace GTA.UI
 {
-    public class TextElement : IWorldDrawableElement
+    public partial class TextElement : IWorldDrawableElement
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TextElement"/> class used for drawing text on the screen.
@@ -236,20 +236,6 @@ namespace GTA.UI
         public float WrapWidth
         {
             get; set;
-        }
-        /// <summary>
-        /// Gets or sets a value indicating whether the alignment of this <see cref="TextElement" /> is centered.
-        /// See <see cref="Alignment"/>
-        /// </summary>
-        /// <value>
-        ///   <see langword="true" /> if centered; otherwise, <see langword="false" />.
-        /// </value>
-        [Obsolete("`TextElement.Centered` is obsolete because it is redundant and setting the property to false is " +
-            "confusing. Use `TextElement.Alignment` instead."), EditorBrowsable(EditorBrowsableState.Never)]
-        public bool Centered
-        {
-            get => Alignment == Alignment.Center;
-            set => Alignment = value ? Alignment.Center : Alignment.Left;
         }
 
         /// <summary>

--- a/source/scripting_v3/GTA/Audio.Obsolete.cs
+++ b/source/scripting_v3/GTA/Audio.Obsolete.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GTA.Math;
+using GTA.Native;
+
+namespace GTA
+{
+    public static partial class Audio
+    {
+        /// <summary>
+        /// Plays a sound from the game's sound files at the specified <paramref name="entity"/>.
+        /// </summary>
+        /// <param name="entity">The entity to play the sound at.</param>
+        /// <param name="soundFile">The sound file to play.</param>
+        /// <returns>The identifier of the active sound effect instance.</returns>
+        [Obsolete("Audio.PlaySoundAt is obsolete, use ScriptSoundId.PlaySoundFromEntity or Audio.PlaySoundFromEntityAndForget.")]
+        public static int PlaySoundAt(Entity entity, string soundFile)
+        {
+            int id = Function.Call<int>(Hash.GET_SOUND_ID);
+            Function.Call(Hash.PLAY_SOUND_FROM_ENTITY, id, soundFile, entity.Handle, 0, 0, 0);
+            return id;
+        }
+
+        /// <summary>
+        /// Plays a sound from the game's sound files at the specified <paramref name="entity"/>.
+        /// </summary>
+        /// <param name="entity">The entity to play the sound at.</param>
+        /// <param name="soundFile">The sound file to play.</param>
+        /// <param name="soundSet">The name of the sound inside the file.</param>
+        /// <returns>The identifier of the active sound effect instance.</returns>
+        [Obsolete("Use ScriptSoundId.PlaySoundFromEntity or Audio.PlaySoundFromEntityAndForget instead."),
+        EditorBrowsable(EditorBrowsableState.Never)]
+        public static int PlaySoundAt(Entity entity, string soundFile, string soundSet)
+        {
+            int id = Function.Call<int>(Hash.GET_SOUND_ID);
+            Function.Call(Hash.PLAY_SOUND_FROM_ENTITY, id, soundFile, entity.Handle, soundSet, 0, 0);
+            return id;
+        }
+
+        /// <summary>
+        /// Plays a sound from the game's sound files at the specified <paramref name="position"/>.
+        /// </summary>
+        /// <param name="position">The world coordinates to play the sound at.</param>
+        /// <param name="soundFile">The sound file to play.</param>
+        /// <returns>The identifier of the active sound effect instance.</returns>
+        [Obsolete("Use ScriptSoundId.PlaySoundFromPosition or Audio.PlaySoundFromPositionAndForget instead."),
+        EditorBrowsable(EditorBrowsableState.Never)]
+        public static int PlaySoundAt(Vector3 position, string soundFile)
+        {
+            int id = Function.Call<int>(Hash.GET_SOUND_ID);
+            Function.Call(Hash.PLAY_SOUND_FROM_COORD, id, soundFile, position.X, position.Y, position.Z, 0, 0, 0, 0);
+            return id;
+        }
+
+        /// <summary>
+        /// Plays a sound from the game's sound files at the specified <paramref name="position"/>.
+        /// </summary>
+        /// <param name="position">The world coordinates to play the sound at.</param>
+        /// <param name="soundFile">The sound file to play.</param>
+        /// <param name="soundSet">The name of the sound inside the file.</param>
+        /// <returns>The identifier of the active sound effect instance.</returns>
+        [Obsolete("Use ScriptSoundId.PlaySoundFromPosition or Audio.PlaySoundFromPositionAndForget instead."),
+        EditorBrowsable(EditorBrowsableState.Never)]
+        public static int PlaySoundAt(Vector3 position, string soundFile, string soundSet)
+        {
+            int id = Function.Call<int>(Hash.GET_SOUND_ID);
+            Function.Call(Hash.PLAY_SOUND_FROM_COORD, id, soundFile, position.X, position.Y, position.Z, soundSet, 0, 0, 0);
+            return id;
+        }
+
+        /// <summary>
+        /// Plays a sound from the game's sound files without transformation.
+        /// </summary>
+        /// <param name="soundFile">The sound file to play.</param>
+        /// <returns>The identifier of the active sound effect instance.</returns>
+        [Obsolete("Use ScriptSoundId.PlaySoundFrontend or Audio.PlaySoundFrontendAndForget instead."),
+        EditorBrowsable(EditorBrowsableState.Never)]
+        public static int PlaySoundFrontend(string soundFile)
+        {
+            int id = Function.Call<int>(Hash.GET_SOUND_ID);
+            Function.Call(Hash.PLAY_SOUND_FRONTEND, id, soundFile, 0, 0);
+            return id;
+        }
+
+        /// <summary>
+        /// Plays a sound from the game's sound files without transformation.
+        /// </summary>
+        /// <param name="soundFile">The sound file to play.</param>
+        /// <param name="soundSet">The name of the sound inside the file.</param>
+        /// <returns>The identifier of the active sound effect instance.</returns>
+        [Obsolete("Use ScriptSoundId.PlaySoundFrontend or Audio.PlaySoundFrontendAndForget instead."),
+        EditorBrowsable(EditorBrowsableState.Never)]
+        public static int PlaySoundFrontend(string soundFile, string soundSet)
+        {
+            int id = Function.Call<int>(Hash.GET_SOUND_ID);
+            Function.Call(Hash.PLAY_SOUND_FRONTEND, id, soundFile, soundSet, 0);
+            return id;
+        }
+
+        /// <summary>
+        /// Cancels playing the specified sound instance.
+        /// </summary>
+        /// <param name="id">The identifier of the active sound effect instance.</param>
+        [Obsolete("Use ScriptSoundId.Stop instead."), EditorBrowsable(EditorBrowsableState.Never)]
+        public static void StopSound(int id)
+        {
+            Function.Call(Hash.STOP_SOUND, id);
+        }
+
+        /// <summary>
+        /// Releases the specified sound instance. Call this for every sound effect started.
+        /// </summary>
+        /// <param name="id">The identifier of the active sound effect instance.</param>
+        [Obsolete("Use ScriptSoundId.Release instead."), EditorBrowsable(EditorBrowsableState.Never)]
+        public static void ReleaseSound(int id)
+        {
+            Function.Call(Hash.RELEASE_SOUND_ID, id);
+        }
+
+        /// <summary>
+        /// Gets a boolean indicating whether the specified sound instance has completed playing.
+        /// </summary>
+        /// <param name="id">The identifier of the active sound effect instance.</param>
+        [Obsolete("Use ScriptSoundId.HasFinished instead."), EditorBrowsable(EditorBrowsableState.Never)]
+        public static bool HasSoundFinished(int id)
+        {
+            return Function.Call<bool>(Hash.HAS_SOUND_FINISHED, id);
+        }
+    }
+}

--- a/source/scripting_v3/GTA/Audio.cs
+++ b/source/scripting_v3/GTA/Audio.cs
@@ -13,7 +13,7 @@ namespace GTA
     /// <summary>
     /// Methods to manipulate audio.
     /// </summary>
-    public static class Audio
+    public static partial class Audio
     {
         #region Music
 
@@ -118,120 +118,6 @@ namespace GTA
         /// </param>
         public static void PlaySoundFromPositionAndForget(Vector3 position, string soundName, string setName = null, bool isExteriorLoc = false)
             => Function.Call(Hash.PLAY_SOUND_FROM_COORD, -1, soundName, position.X, position.Y, position.Z, setName, false, 0, isExteriorLoc);
-
-        /// <summary>
-        /// Plays a sound from the game's sound files at the specified <paramref name="entity"/>.
-        /// </summary>
-        /// <param name="entity">The entity to play the sound at.</param>
-        /// <param name="soundFile">The sound file to play.</param>
-        /// <returns>The identifier of the active sound effect instance.</returns>
-        [Obsolete("Audio.PlaySoundAt is obsolete, use ScriptSoundId.PlaySoundFromEntity or Audio.PlaySoundFromEntityAndForget.")]
-        public static int PlaySoundAt(Entity entity, string soundFile)
-        {
-            int id = Function.Call<int>(Hash.GET_SOUND_ID);
-            Function.Call(Hash.PLAY_SOUND_FROM_ENTITY, id, soundFile, entity.Handle, 0, 0, 0);
-            return id;
-        }
-        /// <summary>
-        /// Plays a sound from the game's sound files at the specified <paramref name="entity"/>.
-        /// </summary>
-        /// <param name="entity">The entity to play the sound at.</param>
-        /// <param name="soundFile">The sound file to play.</param>
-        /// <param name="soundSet">The name of the sound inside the file.</param>
-        /// <returns>The identifier of the active sound effect instance.</returns>
-        [Obsolete("Use ScriptSoundId.PlaySoundFromEntity or Audio.PlaySoundFromEntityAndForget instead."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public static int PlaySoundAt(Entity entity, string soundFile, string soundSet)
-        {
-            int id = Function.Call<int>(Hash.GET_SOUND_ID);
-            Function.Call(Hash.PLAY_SOUND_FROM_ENTITY, id, soundFile, entity.Handle, soundSet, 0, 0);
-            return id;
-        }
-        /// <summary>
-        /// Plays a sound from the game's sound files at the specified <paramref name="position"/>.
-        /// </summary>
-        /// <param name="position">The world coordinates to play the sound at.</param>
-        /// <param name="soundFile">The sound file to play.</param>
-        /// <returns>The identifier of the active sound effect instance.</returns>
-        [Obsolete("Use ScriptSoundId.PlaySoundFromPosition or Audio.PlaySoundFromPositionAndForget instead."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public static int PlaySoundAt(Vector3 position, string soundFile)
-        {
-            int id = Function.Call<int>(Hash.GET_SOUND_ID);
-            Function.Call(Hash.PLAY_SOUND_FROM_COORD, id, soundFile, position.X, position.Y, position.Z, 0, 0, 0, 0);
-            return id;
-        }
-        /// <summary>
-        /// Plays a sound from the game's sound files at the specified <paramref name="position"/>.
-        /// </summary>
-        /// <param name="position">The world coordinates to play the sound at.</param>
-        /// <param name="soundFile">The sound file to play.</param>
-        /// <param name="soundSet">The name of the sound inside the file.</param>
-        /// <returns>The identifier of the active sound effect instance.</returns>
-        [Obsolete("Use ScriptSoundId.PlaySoundFromPosition or Audio.PlaySoundFromPositionAndForget instead."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public static int PlaySoundAt(Vector3 position, string soundFile, string soundSet)
-        {
-            int id = Function.Call<int>(Hash.GET_SOUND_ID);
-            Function.Call(Hash.PLAY_SOUND_FROM_COORD, id, soundFile, position.X, position.Y, position.Z, soundSet, 0, 0, 0);
-            return id;
-        }
-        /// <summary>
-        /// Plays a sound from the game's sound files without transformation.
-        /// </summary>
-        /// <param name="soundFile">The sound file to play.</param>
-        /// <returns>The identifier of the active sound effect instance.</returns>
-        [Obsolete("Use ScriptSoundId.PlaySoundFrontend or Audio.PlaySoundFrontendAndForget instead."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public static int PlaySoundFrontend(string soundFile)
-        {
-            int id = Function.Call<int>(Hash.GET_SOUND_ID);
-            Function.Call(Hash.PLAY_SOUND_FRONTEND, id, soundFile, 0, 0);
-            return id;
-        }
-        /// <summary>
-        /// Plays a sound from the game's sound files without transformation.
-        /// </summary>
-        /// <param name="soundFile">The sound file to play.</param>
-        /// <param name="soundSet">The name of the sound inside the file.</param>
-        /// <returns>The identifier of the active sound effect instance.</returns>
-        [Obsolete("Use ScriptSoundId.PlaySoundFrontend or Audio.PlaySoundFrontendAndForget instead."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public static int PlaySoundFrontend(string soundFile, string soundSet)
-        {
-            int id = Function.Call<int>(Hash.GET_SOUND_ID);
-            Function.Call(Hash.PLAY_SOUND_FRONTEND, id, soundFile, soundSet, 0);
-            return id;
-        }
-
-        /// <summary>
-        /// Cancels playing the specified sound instance.
-        /// </summary>
-        /// <param name="id">The identifier of the active sound effect instance.</param>
-        [Obsolete("Use ScriptSoundId.Stop instead."), EditorBrowsable(EditorBrowsableState.Never)]
-        public static void StopSound(int id)
-        {
-            Function.Call(Hash.STOP_SOUND, id);
-        }
-        /// <summary>
-        /// Releases the specified sound instance. Call this for every sound effect started.
-        /// </summary>
-        /// <param name="id">The identifier of the active sound effect instance.</param>
-        [Obsolete("Use ScriptSoundId.Release instead."), EditorBrowsable(EditorBrowsableState.Never)]
-        public static void ReleaseSound(int id)
-        {
-            Function.Call(Hash.RELEASE_SOUND_ID, id);
-        }
-
-        /// <summary>
-        /// Gets a boolean indicating whether the specified sound instance has completed playing.
-        /// </summary>
-        /// <param name="id">The identifier of the active sound effect instance.</param>
-        [Obsolete("Use ScriptSoundId.HasFinished instead."), EditorBrowsable(EditorBrowsableState.Never)]
-        public static bool HasSoundFinished(int id)
-        {
-            return Function.Call<bool>(Hash.HAS_SOUND_FINISHED, id);
-        }
 
         /// <summary>
         /// Sets an audio flag to modify subsequent sounds.

--- a/source/scripting_v3/GTA/Blip/Blip.Obsolete.cs
+++ b/source/scripting_v3/GTA/Blip/Blip.Obsolete.cs
@@ -1,0 +1,27 @@
+using System;
+using System.ComponentModel;
+using GTA.Native;
+
+namespace GTA
+{
+    public sealed partial class Blip
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="Blip"/> shows the dollar sign at the top left corner of the <see cref="Blip"/>.
+        /// </summary>
+        /// <value>
+        ///   <see langword="true" /> to show the dollar sign; otherwise, <see langword="false" />.
+        /// </value>
+        [Obsolete(
+            "`Blip.ShowsDollarSign` is obsolete because the setter changes whether to show the tick, and also " +
+            "because `SHOW_FOR_SALE_ICON_ON_BLIP` was added in b2802, which reveals `ShowsDollarSign` is too " +
+            "different from internal flags for the blip \"for sale\" icon. For what the setter does, use " +
+            "`Blip.ShowsTick` instead."),
+            EditorBrowsable(EditorBrowsableState.Never)]
+        public bool ShowsDollarSign
+        {
+            get => SHVDN.NativeMemory.GetBlipPropertyFlag(MemoryAddress, SHVDN.BlipPropertyFlags.ShowForSale);
+            set => Function.Call(Hash.SHOW_TICK_ON_BLIP, Handle, value);
+        }
+    }
+}

--- a/source/scripting_v3/GTA/Blip/Blip.cs
+++ b/source/scripting_v3/GTA/Blip/Blip.cs
@@ -12,7 +12,7 @@ using GTA.UI;
 
 namespace GTA
 {
-    public sealed class Blip : PoolObject
+    public sealed partial class Blip : PoolObject
     {
         public Blip(int handle) : base(handle)
         {
@@ -455,24 +455,6 @@ namespace GTA
         public bool ShowsTick
         {
             get => SHVDN.NativeMemory.GetBlipPropertyFlag(MemoryAddress, SHVDN.BlipPropertyFlags.ShowTick);
-            set => Function.Call(Hash.SHOW_TICK_ON_BLIP, Handle, value);
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether this <see cref="Blip"/> shows the dollar sign at the top left corner of the <see cref="Blip"/>.
-        /// </summary>
-        /// <value>
-        ///   <see langword="true" /> to show the dollar sign; otherwise, <see langword="false" />.
-        /// </value>
-        [Obsolete(
-            "`Blip.ShowsDollarSign` is obsolete because the setter changes whether to show the tick, and also " +
-            "because `SHOW_FOR_SALE_ICON_ON_BLIP` was added in b2802, which reveals `ShowsDollarSign` is too " +
-            "different from internal flags for the blip \"for sale\" icon. For what the setter does, use " +
-            "`Blip.ShowsTick` instead."),
-            EditorBrowsable(EditorBrowsableState.Never)]
-        public bool ShowsDollarSign
-        {
-            get => SHVDN.NativeMemory.GetBlipPropertyFlag(MemoryAddress, SHVDN.BlipPropertyFlags.ShowForSale);
             set => Function.Call(Hash.SHOW_TICK_ON_BLIP, Handle, value);
         }
 

--- a/source/scripting_v3/GTA/Camera/Camera.Obsolete.cs
+++ b/source/scripting_v3/GTA/Camera/Camera.Obsolete.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GTA.Native;
+
+namespace GTA
+{
+    public sealed partial class Camera : PoolObject, ISpatial
+    {
+        /// <summary>
+        /// Sets a cam active which will be interpolated too from this <see cref="Camera"/>.
+        /// </summary>
+        [Obsolete("Use Camera.InterpTo(Camera, int, CamFrameInterpolatorCurveType, CamFrameInterpolatorCurveType) instead."),
+        EditorBrowsable(EditorBrowsableState.Never)]
+        public void InterpTo(Camera to, int duration, int easePosition, int easeRotation)
+        {
+            Function.Call(Hash.SET_CAM_ACTIVE_WITH_INTERP, to.Handle, Handle, duration, easePosition, easeRotation);
+        }
+    }
+}

--- a/source/scripting_v3/GTA/Camera/Camera.cs
+++ b/source/scripting_v3/GTA/Camera/Camera.cs
@@ -13,7 +13,7 @@ namespace GTA
     /// <summary>
     /// Represents a scripted camera.
     /// </summary>
-    public sealed class Camera : PoolObject, ISpatial
+    public sealed partial class Camera : PoolObject, ISpatial
     {
         public Camera(int handle) : base(handle)
         {
@@ -474,15 +474,6 @@ namespace GTA
         {
             Function.Call(Hash.SET_CAM_ACTIVE_WITH_INTERP, destinationCam.Handle, Handle, duration, (int)graphTypePos,
                 (int)graphTypeRot);
-        }
-        /// <summary>
-        /// Sets a cam active which will be interpolated too from this <see cref="Camera"/>.
-        /// </summary>
-        [Obsolete("Use Camera.InterpTo(Camera, int, CamFrameInterpolatorCurveType, CamFrameInterpolatorCurveType) instead."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public void InterpTo(Camera to, int duration, int easePosition, int easeRotation)
-        {
-            Function.Call(Hash.SET_CAM_ACTIVE_WITH_INTERP, to.Handle, Handle, duration, easePosition, easeRotation);
         }
 
         /// <summary>

--- a/source/scripting_v3/GTA/Camera/GameplayCamera.Obsolete.cs
+++ b/source/scripting_v3/GTA/Camera/GameplayCamera.Obsolete.cs
@@ -1,0 +1,17 @@
+using System;
+using System.ComponentModel;
+
+namespace GTA
+{
+    public static partial class GameplayCamera
+    {
+        /// <summary>
+        /// Gets the first-person ped aim zoom factor associated with equipped sniper scoped weapon,
+        /// or the mobile phone camera, if active.
+        /// </summary>
+        [Obsolete("GameplayCamera.Zoom is obsolete since it does not suggest the value is relevant only when a first" +
+            "person aim camera is used. Use GameplayCamera.FirstPersonAimCamZoomFactor instead."),
+            EditorBrowsable(EditorBrowsableState.Never)]
+        public static float Zoom => FirstPersonAimCamZoomFactor;
+    }
+}

--- a/source/scripting_v3/GTA/Camera/GameplayCamera.cs
+++ b/source/scripting_v3/GTA/Camera/GameplayCamera.cs
@@ -14,7 +14,7 @@ namespace GTA
     /// Represents the gameplay camera director.
     /// The gameplay director is responsible for the follow and aim cameras.
     /// </summary>
-    public static class GameplayCamera
+    public static partial class GameplayCamera
     {
         /// <summary>
         /// Gets the memory address of the gameplay camera director.
@@ -397,15 +397,6 @@ namespace GTA
             get => Function.Call<float>(Hash.GET_FIRST_PERSON_AIM_CAM_ZOOM_FACTOR);
             set => Function.Call(Hash.SET_FIRST_PERSON_AIM_CAM_ZOOM_FACTOR, value);
         }
-
-        /// <summary>
-        /// Gets the first-person ped aim zoom factor associated with equipped sniper scoped weapon,
-        /// or the mobile phone camera, if active.
-        /// </summary>
-        [Obsolete("GameplayCamera.Zoom is obsolete since it does not suggest the value is relevant only when a first" +
-            "person aim camera is used. Use GameplayCamera.FirstPersonAimCamZoomFactor instead."),
-            EditorBrowsable(EditorBrowsableState.Never)]
-        public static float Zoom => FirstPersonAimCamZoomFactor;
 
         /// <summary>
         /// Gets the field of view of the <see cref="GameplayCamera"/>.

--- a/source/scripting_v3/GTA/Entities/Entity.Obsolete.cs
+++ b/source/scripting_v3/GTA/Entities/Entity.Obsolete.cs
@@ -1,0 +1,55 @@
+using System;
+using System.ComponentModel;
+using GTA.Math;
+using GTA.Native;
+
+namespace GTA
+{
+    public abstract partial class Entity : PoolObject, ISpatial
+    {
+        /// <summary>
+        /// Gets or sets the rotation velocity of this <see cref="Entity"/> in local space.
+        /// </summary>
+        [Obsolete("Entity.RotationVelocity is obsolete because GET_ENTITY_ROTATION_VELOCITY returns the world angular velocity with local to world conversion applied. Use Entity.LocalRotationVelocity instead.")]
+        public Vector3 RotationVelocity
+        {
+            get => Function.Call<Vector3>(Hash.GET_ENTITY_ROTATION_VELOCITY, Handle);
+            set
+            {
+                if (!TryGetMemoryAddress(out IntPtr address))
+                    return;
+
+                Vector3 angularVelocityInLocalAxes = Quaternion * value;
+                SHVDN.NativeMemory.SetEntityAngularVelocity(address, angularVelocityInLocalAxes.X, angularVelocityInLocalAxes.Y, angularVelocityInLocalAxes.Z);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="Entity"/> is water cannon proof.
+        /// <see cref="Ped"/>s does not get ragdolled by the water jet from fire hydrants when this property is set to <see langword="true" />.
+        /// </summary>
+        /// <value>
+        /// <see langword="true" /> if this <see cref="Entity"/> is water cannon proof; otherwise, <see langword="false" />.
+        /// </value>
+        [Obsolete("Entity.IsWaterCannonProof is obsolete because CPhysical has no flags that makes it " +
+            "water cannon proof.", true)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool IsWaterCannonProof
+        {
+            get
+            {
+                if (!TryGetMemoryAddress(out IntPtr address))
+                    return false;
+
+                return SHVDN.MemDataMarshal.IsBitSet(address + 392, 12);
+            }
+            set
+            {
+                if (!TryGetMemoryAddress(out IntPtr address))
+                    return;
+
+                SHVDN.MemDataMarshal.SetBit(address + 392, 12, value);
+            }
+        }
+    }
+}

--- a/source/scripting_v3/GTA/Entities/Entity.cs
+++ b/source/scripting_v3/GTA/Entities/Entity.cs
@@ -21,7 +21,7 @@ namespace GTA
     /// that can work only with physical entities (`<c>CPhysical</c>`s) but not with non-physical entities such as
     /// buildings (`<c>CBuilding</c>`s).
     /// </remarks>
-    public abstract class Entity : PoolObject, ISpatial
+    public abstract partial class Entity : PoolObject, ISpatial
     {
         #region Fields
         EntityBoneCollection _bones;
@@ -805,23 +805,6 @@ namespace GTA
         }
 
         /// <summary>
-        /// Gets or sets the rotation velocity of this <see cref="Entity"/> in local space.
-        /// </summary>
-        [Obsolete("Entity.RotationVelocity is obsolete because GET_ENTITY_ROTATION_VELOCITY returns the world angular velocity with local to world conversion applied. Use Entity.LocalRotationVelocity instead.")]
-        public Vector3 RotationVelocity
-        {
-            get => Function.Call<Vector3>(Hash.GET_ENTITY_ROTATION_VELOCITY, Handle);
-            set
-            {
-                if (!TryGetMemoryAddress(out IntPtr address))
-                    return;
-
-                Vector3 angularVelocityInLocalAxes = Quaternion * value;
-                SHVDN.NativeMemory.SetEntityAngularVelocity(address, angularVelocityInLocalAxes.X, angularVelocityInLocalAxes.Y, angularVelocityInLocalAxes.Z);
-            }
-        }
-
-        /// <summary>
         /// Gets or sets the rotation velocity of this <see cref="Entity"/> in world space.
         /// </summary>
         public Vector3 WorldRotationVelocity
@@ -1345,35 +1328,6 @@ namespace GTA
                     return;
 
                 SHVDN.MemDataMarshal.SetBit(address + 392, 6, value);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether this <see cref="Entity"/> is water cannon proof.
-        /// <see cref="Ped"/>s does not get ragdolled by the water jet from fire hydrants when this property is set to <see langword="true" />.
-        /// </summary>
-        /// <value>
-        /// <see langword="true" /> if this <see cref="Entity"/> is water cannon proof; otherwise, <see langword="false" />.
-        /// </value>
-        [Obsolete("Entity.IsWaterCannonProof is obsolete because CPhysical has no flags that makes it " +
-            "water cannon proof.", true)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool IsWaterCannonProof
-        {
-            // The 13th bit of [CPhysical + 0x188] actually points to `bOnlyDamagedByRelGroup`, which is incorrect!
-            get
-            {
-                if (!TryGetMemoryAddress(out IntPtr address))
-                    return false;
-
-                return SHVDN.MemDataMarshal.IsBitSet(address + 392, 12);
-            }
-            set
-            {
-                if (!TryGetMemoryAddress(out IntPtr address))
-                    return;
-
-                SHVDN.MemDataMarshal.SetBit(address + 392, 12, value);
             }
         }
 

--- a/source/scripting_v3/GTA/Entities/Peds/Ped.Obsolete.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Ped.Obsolete.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using GTA.Native;
+
+namespace GTA
+{
+    public sealed partial class Ped : Entity
+    {
+        /// <summary>
+        /// Spawn an identical clone of this <see cref="Ped"/>.
+        /// </summary>
+        /// <param name="heading">
+        /// This was meant to be the direction the clone should be facing, but has no effect.
+        /// </param>
+        [Obsolete("`Ped.Clone(float)` is obsolete because the float parameter does not make any sense. " +
+                  "Use `Ped.Clone(bool)` instead.", true)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Ped Clone(float heading = 0.0f)
+        {
+            const bool RegisterAsNetworkObject = true;
+            const bool ScriptHostObject = true;
+
+            // Do not return null even if the native function returns 0, this overload always returns a new `Ped`
+            // instance in v3.6.0 and earlier.
+            return new Ped(Function.Call<int>(Hash.CLONE_PED, Handle, RegisterAsNetworkObject, ScriptHostObject,
+                false));
+        }
+
+        [Obsolete("Use Ped.GiveHelmet(bool, HelmetPropFlags, int) instead."),
+        EditorBrowsable(EditorBrowsableState.Never)]
+        public void GiveHelmet(bool canBeRemovedByPed, Helmet helmetType, int textureIndex)
+        {
+            Function.Call(Hash.GIVE_PED_HELMET, Handle, !canBeRemovedByPed, (int)helmetType, textureIndex);
+        }
+
+        /// <summary>
+        /// Sets how high up on this <see cref="Ped"/>s body water should be visible.
+        /// </summary>
+        /// <value>
+        /// The height offset ranges from -2f to 1.99f inclusive, -2f being no water visible, 1.99f being fully covered in water.
+        /// </value>
+        /// <remarks>
+        /// Although zero sets the height offset of the water line to zero in meters on water height members of <c>CPed</c>,
+        /// This property will clear the wet/soaked effect if the value is set to the zero for the compatibility of scripts built against v3.6.0.
+        /// </remarks>
+        [Obsolete("Ped.WetnessHeight is obsolete because it does not indicate that it clears the wetness effect from the ped if the value is exactly zero," +
+            "while the value can take any values in the range of -2f to 1.99f inclusive. Please use Ped.Wet or Ped.ClearWetnessEffect instead."),
+        EditorBrowsable(EditorBrowsableState.Never)]
+        public float WetnessHeight
+        {
+            set
+            {
+                if (value == 0.0f)
+                {
+                    Function.Call(Hash.CLEAR_PED_WETNESS, Handle);
+                }
+                else
+                {
+                    Function.Call(Hash.SET_PED_WETNESS_HEIGHT, Handle, value);
+                }
+            }
+        }
+
+        /// <inheritdoc cref="GetConfigFlag(PedConfigFlagToggles)"/>
+        [Obsolete("Use GetConfigFlag(PedConfigFlagToggles) instead."), EditorBrowsable(EditorBrowsableState.Never)]
+        public bool GetConfigFlag(int flagID) => GetConfigFlag((PedConfigFlagToggles)flagID);
+        /// <inheritdoc cref="GetConfigFlag(PedConfigFlagToggles)"/>
+        [Obsolete("Use SetConfigFlag(PedConfigFlagToggles, bool) instead."), EditorBrowsable(EditorBrowsableState.Never)]
+        public void SetConfigFlag(int flagID, bool value) => SetConfigFlag((PedConfigFlagToggles)flagID, value);
+
+        /// <summary>
+        /// Do not use this method and use <see cref="Ped.SetResetFlag(PedResetFlagToggles, bool)"/> or <see cref="Ped.GetResetFlag(PedResetFlagToggles)"/> instead,
+        /// because <c>SET_PED_RESET_FLAG</c> uses different flag IDs from the IDs <see cref="GetConfigFlag(int)"/> and <see cref="SetConfigFlag(int, bool)"/> use.
+        /// </summary>
+        [Obsolete("Ped.ResetConfigFlag is obsolete since SET_PED_RESET_FLAG uses different flag IDs from the IDs GET_PED_CONFIG_FLAG and SET_PED_CONFIG_FLAG use " +
+            "and the said overload always set the flag (2nd argument of SET_PED_RESET_FLAG) to true. Use Ped.SetResetFlag or Ped.GetResetFlag instead", true)]
+        public void ResetConfigFlag(int flagID)
+        {
+            Function.Call(Hash.SET_PED_RESET_FLAG, Handle, flagID, true);
+        }
+
+        /// <summary>
+        /// Sets whether this <see cref="Ped"/> keeps their tasks when they are marked as no longer needed by <see cref="Entity.MarkAsNoLongerNeeded"/>.
+        /// Despite the property name, this property does not determine whether permanent events can interrupt the <see cref="Ped"/>'s tasks (e.g. seeing hated peds or getting shot at).
+        /// </summary>
+        /// <inheritdoc cref="KeepTaskWhenMarkedAsNoLongerNeeded"/>
+        [Obsolete("Ped.AlwaysKeepTask is obsolete because it does not indicate that it only affects when the ped is marked as no longer needed. " +
+                  "Use Ped.KeepTaskWhenMarkedAsNoLongerNeeded instead."), EditorBrowsable(EditorBrowsableState.Never)]
+        public bool AlwaysKeepTask
+        {
+            set => KeepTaskWhenMarkedAsNoLongerNeeded = value;
+        }
+
+        [Obsolete("Use IsEnteringVehicle instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool IsGettingIntoVehicle => IsEnteringVehicle;
+
+        /// <summary>
+        /// Sets the value that indicates whether this <see cref="Ped"/> can be knocked off a <see cref="Vehicle"/> (not limited to a bike despite the property name).
+        /// </summary>
+        [Obsolete("Use Ped.KnockOffVehicleType instead."),
+        EditorBrowsable(EditorBrowsableState.Never)]
+        public bool CanBeKnockedOffBike
+        {
+            set => Function.Call(Hash.SET_PED_CAN_BE_KNOCKED_OFF_VEHICLE, Handle, !value);
+        }
+
+        /// <summary>
+        /// <para>
+        /// Sets the drive tasks driving style.
+        /// </para>
+        /// <para>
+        /// This <see cref="Ped"/> must be on a <see cref="Vehicle"/> as a driver and the drive task running on this <see cref="Ped"/> must be active before setting the value can actually affect.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// Despite the interface, this actually changes the driving flags field on <c>CTaskVehicleMissionBase</c>, which is not for <see cref="Ped"/> but for <see cref="Vehicle"/>.
+        /// </remarks>
+        [Obsolete("Use Ped.VehicleDrivingFlags instead."), EditorBrowsable(EditorBrowsableState.Never)]
+        public DrivingStyle DrivingStyle
+        {
+            set => Function.Call(Hash.SET_DRIVE_TASK_DRIVING_STYLE, Handle, (int)value);
+        }
+
+        /// <summary>
+        /// Sets the movement clip/animation set this <see cref="Ped"/> should use or <see langword="null"/>
+        /// to reset to the default value defined in <c>peds.meta</c> under <c>&lt;MovementClipSet&gt;</c>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// When the value is set to <see langword="null"/>, <see cref="TaskInvoker.ClearAll"/> will be called
+        /// right after resetting the movement clipset.
+        /// </para>
+        /// <para>
+        /// Despite what the doc for this property said in between v3.0.0 in v3.6.0, the loading state of some animation
+        /// dictionaries has nothing to do with this property. Specifying a string only registered as a clip/animation
+        /// dictionary will result in the setter failure.
+        /// </para>
+        /// </remarks>
+        [Obsolete("Use Ped.SetMovementClipSet or Ped.ResetMovementClipSet instead."),
+        EditorBrowsable(EditorBrowsableState.Never)]
+        public string MovementAnimationSet
+        {
+            set
+            {
+                if (value == null)
+                {
+                    Function.Call(Hash.RESET_PED_MOVEMENT_CLIPSET, Handle, 0.25f);
+                    Task.ClearAll();
+                }
+                else
+                {
+                    Function.Call(Hash.REQUEST_CLIP_SET, value);
+                    int startTime = Environment.TickCount;
+
+                    while (!Function.Call<bool>(Hash.HAS_CLIP_SET_LOADED, value))
+                    {
+                        Script.Yield();
+
+                        if (Environment.TickCount - startTime >= 1000)
+                        {
+                            return;
+                        }
+                    }
+
+                    Function.Call(Hash.SET_PED_MOVEMENT_CLIPSET, Handle, value, 0.25f);
+                }
+            }
+        }
+    }
+}

--- a/source/scripting_v3/GTA/Entities/Peds/Ped.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Ped.cs
@@ -12,7 +12,7 @@ using System.Linq;
 
 namespace GTA
 {
-    public sealed class Ped : Entity
+    public sealed partial class Ped : Entity
     {
         #region Fields
         TaskInvoker _tasks;
@@ -89,26 +89,6 @@ namespace GTA
                 linkBlends);
 
             return MakePedInstIfHandleIsNotZero(handle);
-        }
-
-        /// <summary>
-        /// Spawn an identical clone of this <see cref="Ped"/>.
-        /// </summary>
-        /// <param name="heading">
-        /// This was meant to be the direction the clone should be facing, but has no effect.
-        /// </param>
-        [Obsolete("`Ped.Clone(float)` is obsolete because the float parameter does not make any sense. " +
-                  "Use `Ped.Clone(bool)` instead.", true)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public Ped Clone(float heading = 0.0f)
-        {
-            const bool RegisterAsNetworkObject = true;
-            const bool ScriptHostObject = true;
-
-            // Do not return null even if the native function returns 0, this overload always returns a new `Ped`
-            // instance in v3.6.0 and earlier.
-            return new Ped(Function.Call<int>(Hash.CLONE_PED, Handle, RegisterAsNetworkObject, ScriptHostObject,
-                false));
         }
 
         /// <summary>
@@ -321,13 +301,6 @@ namespace GTA
             Function.Call(Hash.RESET_PED_VISIBLE_DAMAGE, Handle);
         }
 
-        [Obsolete("Use Ped.GiveHelmet(bool, HelmetPropFlags, int) instead."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public void GiveHelmet(bool canBeRemovedByPed, Helmet helmetType, int textureIndex)
-        {
-            Function.Call(Hash.GIVE_PED_HELMET, Handle, !canBeRemovedByPed, (int)helmetType, textureIndex);
-        }
-
         /// <summary>
         /// Gives this <see cref="Ped"/> a helmet.
         /// </summary>
@@ -400,34 +373,6 @@ namespace GTA
                 }
 
                 Function.Call(Hash.SET_PED_SWEAT, Handle, value);
-            }
-        }
-
-        /// <summary>
-        /// Sets how high up on this <see cref="Ped"/>s body water should be visible.
-        /// </summary>
-        /// <value>
-        /// The height offset ranges from -2f to 1.99f inclusive, -2f being no water visible, 1.99f being fully covered in water.
-        /// </value>
-        /// <remarks>
-        /// Although zero sets the height offset of the water line to zero in meters on water height members of <c>CPed</c>,
-        /// This property will clear the wet/soaked effect if the value is set to the zero for the compatibility of scripts built against v3.6.0.
-        /// </remarks>
-        [Obsolete("Ped.WetnessHeight is obsolete because it does not indicate that it clears the wetness effect from the ped if the value is exactly zero," +
-            "while the value can take any values in the range of -2f to 1.99f inclusive. Please use Ped.Wet or Ped.ClearWetnessEffect instead."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public float WetnessHeight
-        {
-            set
-            {
-                if (value == 0.0f)
-                {
-                    Function.Call(Hash.CLEAR_PED_WETNESS, Handle);
-                }
-                else
-                {
-                    Function.Call(Hash.SET_PED_WETNESS_HEIGHT, Handle, value);
-                }
             }
         }
 
@@ -751,24 +696,6 @@ namespace GTA
             Function.Call(Hash.SET_PED_RESET_FLAG, Handle, (int)configFlag, value);
         }
 
-        /// <inheritdoc cref="GetConfigFlag(PedConfigFlagToggles)"/>
-        [Obsolete("Use GetConfigFlag(PedConfigFlagToggles) instead."), EditorBrowsable(EditorBrowsableState.Never)]
-        public bool GetConfigFlag(int flagID) => GetConfigFlag((PedConfigFlagToggles)flagID);
-        /// <inheritdoc cref="GetConfigFlag(PedConfigFlagToggles)"/>
-        [Obsolete("Use SetConfigFlag(PedConfigFlagToggles, bool) instead."), EditorBrowsable(EditorBrowsableState.Never)]
-        public void SetConfigFlag(int flagID, bool value) => SetConfigFlag((PedConfigFlagToggles)flagID, value);
-
-        /// <summary>
-        /// Do not use this method and use <see cref="Ped.SetResetFlag(PedResetFlagToggles, bool)"/> or <see cref="Ped.GetResetFlag(PedResetFlagToggles)"/> instead,
-        /// because <c>SET_PED_RESET_FLAG</c> uses different flag IDs from the IDs <see cref="GetConfigFlag(int)"/> and <see cref="SetConfigFlag(int, bool)"/> use.
-        /// </summary>
-        [Obsolete("Ped.ResetConfigFlag is obsolete since SET_PED_RESET_FLAG uses different flag IDs from the IDs GET_PED_CONFIG_FLAG and SET_PED_CONFIG_FLAG use " +
-            "and the said overload always set the flag (2nd argument of SET_PED_RESET_FLAG) to true. Use Ped.SetResetFlag or Ped.GetResetFlag instead", true)]
-        public void ResetConfigFlag(int flagID)
-        {
-            Function.Call(Hash.SET_PED_RESET_FLAG, Handle, flagID, true);
-        }
-
         /// <summary>
         /// Sets a value indicating whether this <see cref="Entity"/> is persistent.
         /// Unlike <see cref="Entity.IsPersistent"/>, calling this method does not affect assigned tasks.
@@ -904,18 +831,6 @@ namespace GTA
         public bool KeepTaskWhenMarkedAsNoLongerNeeded
         {
             set => Function.Call(Hash.SET_PED_KEEP_TASK, Handle, value);
-        }
-
-        /// <summary>
-        /// Sets whether this <see cref="Ped"/> keeps their tasks when they are marked as no longer needed by <see cref="Entity.MarkAsNoLongerNeeded"/>.
-        /// Despite the property name, this property does not determine whether permanent events can interrupt the <see cref="Ped"/>'s tasks (e.g. seeing hated peds or getting shot at).
-        /// </summary>
-        /// <inheritdoc cref="KeepTaskWhenMarkedAsNoLongerNeeded"/>
-        [Obsolete("Ped.AlwaysKeepTask is obsolete because it does not indicate that it only affects when the ped is marked as no longer needed. " +
-                  "Use Ped.KeepTaskWhenMarkedAsNoLongerNeeded instead."), EditorBrowsable(EditorBrowsableState.Never)]
-        public bool AlwaysKeepTask
-        {
-            set => KeepTaskWhenMarkedAsNoLongerNeeded = value;
         }
 
         /// <summary>
@@ -1606,10 +1521,6 @@ namespace GTA
 
         public bool IsInPoliceVehicle => Function.Call<bool>(Hash.IS_PED_IN_ANY_POLICE_VEHICLE, Handle);
 
-        [Obsolete("Use IsEnteringVehicle instead.")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public bool IsGettingIntoVehicle => IsEnteringVehicle;
-
         /// <summary>
         /// Indicates whether is currently entering a <see cref="Vehicle"/> but not sitting in a <see cref="Vehicle"/>.
         /// </summary>
@@ -1667,16 +1578,6 @@ namespace GTA
         public bool CanBeKnockedOffVehicle
         {
             get => Function.Call<bool>(Hash.CAN_KNOCK_PED_OFF_VEHICLE, Handle);
-        }
-
-        /// <summary>
-        /// Sets the value that indicates whether this <see cref="Ped"/> can be knocked off a <see cref="Vehicle"/> (not limited to a bike despite the property name).
-        /// </summary>
-        [Obsolete("Use Ped.KnockOffVehicleType instead."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public bool CanBeKnockedOffBike
-        {
-            set => Function.Call(Hash.SET_PED_CAN_BE_KNOCKED_OFF_VEHICLE, Handle, !value);
         }
 
         /// <summary>
@@ -1861,23 +1762,6 @@ namespace GTA
         public float MaxDrivingSpeed
         {
             set => Function.Call(Hash.SET_DRIVE_TASK_MAX_CRUISE_SPEED, Handle, value);
-        }
-
-        /// <summary>
-        /// <para>
-        /// Sets the drive tasks driving style.
-        /// </para>
-        /// <para>
-        /// This <see cref="Ped"/> must be on a <see cref="Vehicle"/> as a driver and the drive task running on this <see cref="Ped"/> must be active before setting the value can actually affect.
-        /// </para>
-        /// </summary>
-        /// <remarks>
-        /// Despite the interface, this actually changes the driving flags field on <c>CTaskVehicleMissionBase</c>, which is not for <see cref="Ped"/> but for <see cref="Vehicle"/>.
-        /// </remarks>
-        [Obsolete("Use Ped.VehicleDrivingFlags instead."), EditorBrowsable(EditorBrowsableState.Never)]
-        public DrivingStyle DrivingStyle
-        {
-            set => Function.Call(Hash.SET_DRIVE_TASK_DRIVING_STYLE, Handle, (int)value);
         }
 
         /// <summary>
@@ -2762,52 +2646,6 @@ namespace GTA
         {
             get => GetResetFlag(PedResetFlagToggles.GestureAnimsAllowed);
             set => Function.Call(Hash.SET_PED_CAN_PLAY_GESTURE_ANIMS, Handle, value);
-        }
-
-        /// <summary>
-        /// Sets the movement clip/animation set this <see cref="Ped"/> should use or <see langword="null"/>
-        /// to reset to the default value defined in <c>peds.meta</c> under <c>&lt;MovementClipSet&gt;</c>.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// When the value is set to <see langword="null"/>, <see cref="TaskInvoker.ClearAll"/> will be called
-        /// right after resetting the movement clipset.
-        /// </para>
-        /// <para>
-        /// Despite what the doc for this property said in between v3.0.0 in v3.6.0, the loading state of some animation
-        /// dictionaries has nothing to do with this property. Specifying a string only registered as a clip/animation
-        /// dictionary will result in the setter failure.
-        /// </para>
-        /// </remarks>
-        [Obsolete("Use Ped.SetMovementClipSet or Ped.ResetMovementClipSet instead."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public string MovementAnimationSet
-        {
-            set
-            {
-                if (value == null)
-                {
-                    Function.Call(Hash.RESET_PED_MOVEMENT_CLIPSET, Handle, 0.25f);
-                    Task.ClearAll();
-                }
-                else
-                {
-                    Function.Call(Hash.REQUEST_CLIP_SET, value);
-                    int startTime = Environment.TickCount;
-
-                    while (!Function.Call<bool>(Hash.HAS_CLIP_SET_LOADED, value))
-                    {
-                        Script.Yield();
-
-                        if (Environment.TickCount - startTime >= 1000)
-                        {
-                            return;
-                        }
-                    }
-
-                    Function.Call(Hash.SET_PED_MOVEMENT_CLIPSET, Handle, value, 0.25f);
-                }
-            }
         }
 
         /// <summary>

--- a/source/scripting_v3/GTA/Entities/Peds/PedComponent.Obsolete.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/PedComponent.Obsolete.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GTA
+{
+    public sealed partial class PedComponent : IPedVariation
+    {
+        /// <summary>
+        /// Returns <see langword="true"/> if there are textures for current drawable id (<see cref="Index"/>).
+        /// </summary>
+        [Obsolete("PedComponent.HasTextureVariations is obsolete because it does not make sense " +
+                  "as texture count cannot be determined without specifying both component id and drawable id."),
+        EditorBrowsable(EditorBrowsableState.Never)]
+        public bool HasTextureVariations => Count > 0 && TextureCount > 1;
+
+        [Obsolete("PedComponent.HasAnyVariation is obsolete because it does not make sense " +
+                  "as texture count cannot be determined without specifying both component id and drawable id."),
+        EditorBrowsable(EditorBrowsableState.Never)]
+        public bool HasAnyVariations => HasVariations || HasTextureVariations;
+    }
+}

--- a/source/scripting_v3/GTA/Entities/Peds/PedComponent.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/PedComponent.cs
@@ -9,7 +9,7 @@ using GTA.Native;
 
 namespace GTA
 {
-    public sealed class PedComponent : IPedVariation
+    public sealed partial class PedComponent : IPedVariation
     {
         #region Fields
         readonly Ped _ped;
@@ -95,19 +95,6 @@ namespace GTA
         }
 
         public bool HasVariations => Count > 1;
-
-        /// <summary>
-        /// Returns <see langword="true"/> if there are textures for current drawable id (<see cref="Index"/>).
-        /// </summary>
-        [Obsolete("PedComponent.HasTextureVariations is obsolete because it does not make sense " +
-                  "as texture count cannot be determined without specifying both component id and drawable id."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public bool HasTextureVariations => Count > 0 && TextureCount > 1;
-
-        [Obsolete("PedComponent.HasAnyVariation is obsolete because it does not make sense " +
-                  "as texture count cannot be determined without specifying both component id and drawable id."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public bool HasAnyVariations => HasVariations || HasTextureVariations;
 
         public override string ToString()
         {

--- a/source/scripting_v3/GTA/Entities/Peds/PedProp.Obsolete.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/PedProp.Obsolete.cs
@@ -1,0 +1,22 @@
+using System;
+using System.ComponentModel;
+
+namespace GTA
+{
+    public sealed partial class PedProp : IPedVariation
+    {
+        [Obsolete("PedProp.Type is obsolete, use PedProp.AnchorPoint instead."),
+         EditorBrowsable(EditorBrowsableState.Never)]
+        public PedPropType Type => (PedPropType)AnchorPoint;
+
+        [Obsolete("PedProp.HasTextureVariations is obsolete because it does not make sense " +
+          "as texture count cannot be determined without specifying both prop position id and drawable id."),
+         EditorBrowsable(EditorBrowsableState.Never)]
+        public bool HasTextureVariations => Count > 1 && TextureCount > 1;
+
+        [Obsolete("PedProp.HasAnyVariations is obsolete because it does not make sense " +
+          "as texture count cannot be determined without specifying both prop position id and drawable id."),
+         EditorBrowsable(EditorBrowsableState.Never)]
+        public bool HasAnyVariations => HasVariations;
+    }
+}

--- a/source/scripting_v3/GTA/Entities/Peds/PedProp.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/PedProp.cs
@@ -9,7 +9,7 @@ using System.ComponentModel;
 
 namespace GTA
 {
-    public sealed class PedProp : IPedVariation
+    public sealed partial class PedProp : IPedVariation
     {
         #region Fields
         readonly Ped _ped;
@@ -28,10 +28,6 @@ namespace GTA
         }
 
         public string Name => AnchorPoint.ToString();
-
-        [Obsolete("PedProp.Type is obsolete, use PedProp.AnchorPoint instead."),
-         EditorBrowsable(EditorBrowsableState.Never)]
-        public PedPropType Type => (PedPropType)AnchorPoint;
 
         public PedPropAnchorPoint AnchorPoint
         {
@@ -121,16 +117,6 @@ namespace GTA
                     (int)anchorPoint, drawableIndex)));
 
         public bool HasVariations => Count > 1;
-
-        [Obsolete("PedProp.HasTextureVariations is obsolete because it does not make sense " +
-                  "as texture count cannot be determined without specifying both prop position id and drawable id."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public bool HasTextureVariations => Count > 1 && TextureCount > 1;
-
-        [Obsolete("PedProp.HasAnyVariations is obsolete because it does not make sense " +
-          "as texture count cannot be determined without specifying both prop position id and drawable id."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public bool HasAnyVariations => HasVariations;
 
         public override string ToString()
         {

--- a/source/scripting_v3/GTA/Entities/Peds/Style.Obsolete.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Style.Obsolete.cs
@@ -1,0 +1,12 @@
+using System;
+using System.ComponentModel;
+
+namespace GTA
+{
+    public sealed partial class Style
+    {
+        [Obsolete("Use the indexer overload with the type PedPropAnchorPoint instead."),
+         EditorBrowsable(EditorBrowsableState.Never)]
+        public PedProp this[PedPropType propId] => this[(PedPropAnchorPoint)propId];
+    }
+}

--- a/source/scripting_v3/GTA/Entities/Peds/Style.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Style.cs
@@ -10,7 +10,7 @@ using System.ComponentModel;
 
 namespace GTA
 {
-    public sealed class Style
+    public sealed partial class Style
     {
         #region Fields
 
@@ -65,10 +65,6 @@ namespace GTA
                 return variation;
             }
         }
-
-        [Obsolete("Use the indexer overload with the type PedPropAnchorPoint instead."),
-         EditorBrowsable(EditorBrowsableState.Never)]
-        public PedProp this[PedPropType propId] => this[(PedPropAnchorPoint)propId];
 
         public PedProp[] GetAllProps()
         {

--- a/source/scripting_v3/GTA/Entities/Peds/Task/TaskInvoker.Obsolete.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Task/TaskInvoker.Obsolete.cs
@@ -1,0 +1,86 @@
+
+using System;
+using System.ComponentModel;
+using GTA.Math;
+using GTA.Native;
+
+namespace GTA
+{
+    public sealed partial class TaskInvoker
+    {
+        [Obsolete("Use TaskInvoker.AimGunAtEntity for entity targets instead.")]
+        public void AimAt(Entity target, int duration)
+        {
+            Function.Call(Hash.TASK_AIM_GUN_AT_ENTITY, _ped.Handle, target.Handle, duration, 0);
+        }
+
+        [Obsolete("Use TaskInvoker.AimGunAtPosition for coordinate targets instead.")]
+        public void AimAt(Vector3 target, int duration)
+        {
+            Function.Call(Hash.TASK_AIM_GUN_AT_COORD, _ped.Handle, target.X, target.Y, target.Z, duration, 0, 0);
+        }
+
+        [Obsolete("Use TaskInvoker.CruiseWithVehicle(Vehicle, float, VehicleDrivingFlags) instead."),
+         EditorBrowsable(EditorBrowsableState.Never)]
+        public void CruiseWithVehicle(Vehicle vehicle, float speed, DrivingStyle style = DrivingStyle.Normal)
+        {
+            Function.Call(Hash.TASK_VEHICLE_DRIVE_WANDER, _ped.Handle, vehicle.Handle, speed, (int)style);
+        }
+
+        [Obsolete("Use DriveTo(Vehicle, Vector3, float, VehicleDrivingFlags, float) instead."),
+         EditorBrowsable(EditorBrowsableState.Never)]
+        public void DriveTo(Vehicle vehicle, Vector3 target, float radius, float speed, DrivingStyle style = DrivingStyle.Normal)
+        {
+            Function.Call(Hash.TASK_VEHICLE_DRIVE_TO_COORD_LONGRANGE, _ped.Handle, vehicle.Handle, target.X, target.Y, target.Z, speed, (int)style, radius);
+        }
+
+        [Obsolete("Use TaskInvoker.Combat instead.")]
+        public void FightAgainst(Ped target)
+        {
+            Function.Call(Hash.TASK_COMBAT_PED, _ped.Handle, target.Handle, 0, 16);
+        }
+
+        [Obsolete("Use TaskInvoker.CombatTimed instead.")]
+        public void FightAgainst(Ped target, int duration)
+        {
+            Function.Call(Hash.TASK_COMBAT_PED_TIMED, _ped.Handle, target.Handle, duration, 0);
+        }
+
+        [Obsolete("Use TaskInvoker.CombatHatedTargetsAroundPed instead.")]
+        public void FightAgainstHatedTargets(float radius)
+        {
+            Function.Call(Hash.TASK_COMBAT_HATED_TARGETS_AROUND_PED, _ped.Handle, radius, 0);
+        }
+
+        [Obsolete("Use TaskInvoker.CombatHatedTargetsAroundPedTimed instead.")]
+        public void FightAgainstHatedTargets(float radius, int duration)
+        {
+            Function.Call(Hash.TASK_COMBAT_HATED_TARGETS_AROUND_PED_TIMED, _ped.Handle, radius, duration, 0);
+        }
+
+        [Obsolete("TaskInvoker.GoTo with the position parameter may not obvious enough to suggest it uses navigation mesh. Use TaskInvoker.FollowNavMeshTo instead."),
+        EditorBrowsable(EditorBrowsableState.Never)]
+        public void GoTo(Vector3 position, int timeout = -1)
+        {
+            Function.Call(Hash.TASK_FOLLOW_NAV_MESH_TO_COORD, _ped.Handle, position.X, position.Y, position.Z, 1f, timeout, 0f, 0, 0f);
+        }
+
+        [Obsolete("TaskInvoker.StartScenario is obsolete, use TaskInvoker.StartScenarioInPlace instead.")]
+        public void StartScenario(string name, float heading) => StartScenarioInPlace(name);
+
+        [Obsolete("TaskInvoker.StartScenario is obsolete, use TaskInvoker.StartScenarioAtPosition instead.")]
+        public void StartScenario(string name, Vector3 position, float heading) => StartScenarioAtPosition(name, position, heading, playIntroClip: false);
+
+        [Obsolete("TaskInvoke.Wait is obsolete, use TaskInvoker.Pause instead.")]
+        public void Wait(int duration) => Pause(duration);
+
+        [Obsolete("the overload of TaskInvoker.WanderAround with no parameters is obsolete, use TaskInvoker.Wander instead.")]
+        public void WanderAround() => Wander(0, false);
+
+        [Obsolete("Use StopScriptedAnimationTask instead.")]
+        public void ClearAnimation(string animSet, string animName)
+        {
+            Function.Call(Hash.STOP_ANIM_TASK, _ped.Handle, animSet, animName, -4f);
+        }
+    }
+}

--- a/source/scripting_v3/GTA/Entities/Peds/Task/TaskInvoker.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Task/TaskInvoker.cs
@@ -10,7 +10,7 @@ using System.ComponentModel;
 
 namespace GTA
 {
-    public sealed class TaskInvoker
+    public sealed partial class TaskInvoker
     {
         #region Fields
         readonly Ped _ped;
@@ -27,17 +27,6 @@ namespace GTA
         public void AchieveHeading(float heading, int timeout = 0)
         {
             Function.Call(Hash.TASK_ACHIEVE_HEADING, _ped.Handle, heading, timeout);
-        }
-
-        [Obsolete("Use TaskInvoker.AimGunAtEntity for entity targets instead.")]
-        public void AimAt(Entity target, int duration)
-        {
-            Function.Call(Hash.TASK_AIM_GUN_AT_ENTITY, _ped.Handle, target.Handle, duration, 0);
-        }
-        [Obsolete("Use TaskInvoker.AimGunAtPosition for coordinate targets instead.")]
-        public void AimAt(Vector3 target, int duration)
-        {
-            Function.Call(Hash.TASK_AIM_GUN_AT_COORD, _ped.Handle, target.X, target.Y, target.Z, duration, 0, 0);
         }
 
         /// <summary>
@@ -151,22 +140,10 @@ namespace GTA
         {
             Function.Call(Hash.TASK_VEHICLE_DRIVE_WANDER, _ped.Handle, vehicle.Handle, speed, (int)drivingFlags);
         }
-        [Obsolete("Use TaskInvoker.CruiseWithVehicle(Vehicle, float, VehicleDrivingFlags) instead."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public void CruiseWithVehicle(Vehicle vehicle, float speed, DrivingStyle style = DrivingStyle.Normal)
-        {
-            Function.Call(Hash.TASK_VEHICLE_DRIVE_WANDER, _ped.Handle, vehicle.Handle, speed, (int)style);
-        }
 
         public void DriveTo(Vehicle vehicle, Vector3 target, float speed, VehicleDrivingFlags drivingFlags, float radius)
         {
             Function.Call(Hash.TASK_VEHICLE_DRIVE_TO_COORD_LONGRANGE, _ped.Handle, vehicle.Handle, target.X, target.Y, target.Z, speed, (int)drivingFlags, radius);
-        }
-        [Obsolete("Use DriveTo(Vehicle, Vector3, float, VehicleDrivingFlags, float) instead."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public void DriveTo(Vehicle vehicle, Vector3 target, float radius, float speed, DrivingStyle style = DrivingStyle.Normal)
-        {
-            Function.Call(Hash.TASK_VEHICLE_DRIVE_TO_COORD_LONGRANGE, _ped.Handle, vehicle.Handle, target.X, target.Y, target.Z, speed, (int)style, radius);
         }
 
         public void EnterAnyVehicle(VehicleSeat seat = VehicleSeat.Any, int timeout = -1, float speed = 1f, EnterVehicleFlags flag = EnterVehicleFlags.None)
@@ -342,27 +319,6 @@ namespace GTA
             => Function.Call(Hash.TASK_PUT_PED_DIRECTLY_INTO_MELEE, _ped.Handle, target, blendIn, -1f,
                 strafePhaseSync, (uint)aiCombatFlags);
 
-        [Obsolete("Use TaskInvoker.Combat instead.")]
-        public void FightAgainst(Ped target)
-        {
-            Function.Call(Hash.TASK_COMBAT_PED, _ped.Handle, target.Handle, 0, 16);
-        }
-        [Obsolete("Use TaskInvoker.CombatTimed instead.")]
-        public void FightAgainst(Ped target, int duration)
-        {
-            Function.Call(Hash.TASK_COMBAT_PED_TIMED, _ped.Handle, target.Handle, duration, 0);
-        }
-        [Obsolete("Use TaskInvoker.CombatHatedTargetsAroundPed instead.")]
-        public void FightAgainstHatedTargets(float radius)
-        {
-            Function.Call(Hash.TASK_COMBAT_HATED_TARGETS_AROUND_PED, _ped.Handle, radius, 0);
-        }
-        [Obsolete("Use TaskInvoker.CombatHatedTargetsAroundPedTimed instead.")]
-        public void FightAgainstHatedTargets(float radius, int duration)
-        {
-            Function.Call(Hash.TASK_COMBAT_HATED_TARGETS_AROUND_PED_TIMED, _ped.Handle, radius, duration, 0);
-        }
-
         public void FleeFrom(Ped ped, int duration = -1) => FleeFrom(ped, 100f, duration);
         public void FleeFrom(Ped otherPed, float safeDistance, int duration)
         {
@@ -453,13 +409,6 @@ namespace GTA
         public void GoTo(Entity target, Vector3 offset = default(Vector3), int timeout = -1)
         {
             Function.Call(Hash.TASK_GOTO_ENTITY_OFFSET_XY, _ped.Handle, target.Handle, timeout, offset.X, offset.Y, offset.Z, 1f, true);
-        }
-
-        [Obsolete("TaskInvoker.GoTo with the position parameter may not obvious enough to suggest it uses navigation mesh. Use TaskInvoker.FollowNavMeshTo instead."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public void GoTo(Vector3 position, int timeout = -1)
-        {
-            Function.Call(Hash.TASK_FOLLOW_NAV_MESH_TO_COORD, _ped.Handle, position.X, position.Y, position.Z, 1f, timeout, 0f, 0, 0f);
         }
 
         public void GoStraightTo(Vector3 position, int timeout = -1, float targetHeading = 0f, float distanceToSlide = 0f)
@@ -1130,12 +1079,6 @@ namespace GTA
         {
             Function.Call(Hash.TASK_STAND_STILL, _ped.Handle, duration);
         }
-
-        [Obsolete("TaskInvoker.StartScenario is obsolete, use TaskInvoker.StartScenarioInPlace instead.")]
-        public void StartScenario(string name, float heading) => StartScenarioInPlace(name);
-
-        [Obsolete("TaskInvoker.StartScenario is obsolete, use TaskInvoker.StartScenarioAtPosition instead.")]
-        public void StartScenario(string name, Vector3 position, float heading) => StartScenarioAtPosition(name, position, heading, playIntroClip: false);
 
         /// <summary>
         /// Puts this <see cref="Ped"/> into the given scenario immediately in place.
@@ -2036,9 +1979,6 @@ namespace GTA
             Function.Call(Hash.TASK_VEHICLE_SHOOT_AT_PED, _ped.Handle, target.Handle, 20f);
         }
 
-        [Obsolete("TaskInvoke.Wait is obsolete, use TaskInvoker.Pause instead.")]
-        public void Wait(int duration) => Pause(duration);
-
         /// <summary>
         /// Tells the <see cref="Ped"/> to wander.
         /// </summary>
@@ -2047,8 +1987,6 @@ namespace GTA
             // the 3rd argument is actually a flag value, but only the 1st bit is used as of b2845
             Function.Call(Hash.TASK_WANDER_STANDARD, _ped.Handle, heading, keepMovingWhilstWaitingForFirstPath ? 1 : 0);
         }
-        [Obsolete("the overload of TaskInvoker.WanderAround with no parameters is obsolete, use TaskInvoker.Wander instead.")]
-        public void WanderAround() => Wander(0, false);
 
         /// <inheritdoc cref="WanderAround(Vector3, float, float, float)"/>
         public void WanderAround(Vector3 position, float radius) => WanderAround(position, radius, 0, 0);
@@ -2134,12 +2072,6 @@ namespace GTA
                 : (AnimationBlendDelta.NormalBlendOut.Value);
 
             Function.Call(Hash.STOP_ANIM_TASK, _ped.Handle, clipDict, clipName, deltaArg);
-        }
-
-        [Obsolete("Use StopScriptedAnimationTask instead.")]
-        public void ClearAnimation(string animSet, string animName)
-        {
-            Function.Call(Hash.STOP_ANIM_TASK, _ped.Handle, animSet, animName, -4f);
         }
     }
 }

--- a/source/scripting_v3/GTA/Entities/Projectile.Obsolete.cs
+++ b/source/scripting_v3/GTA/Entities/Projectile.Obsolete.cs
@@ -1,0 +1,23 @@
+using System;
+using System.ComponentModel;
+
+namespace GTA
+{
+    public partial class Projectile : Prop
+    {
+        /// <summary>
+        /// Gets the <see cref="Ped"/> this <see cref="Projectile"/> belongs to.
+        /// Can be <see langword="null" /> or a <see cref="Ped"/> instance whose handle is for <see cref="Vehicle"/>, which is not valid as a <see cref="Ped"/> instance.
+        /// </summary>
+        [Obsolete("The Projectile.Owner is obsolete in the v3 API because the actual owner can be a Vehicle, use Projectile.OwnerEntity instead."),
+        EditorBrowsable(EditorBrowsableState.Never)]
+        public Ped Owner
+        {
+            get
+            {
+                int ownerHandle = GetOwnerEntityInternal();
+                return ownerHandle != 0 ? new Ped(ownerHandle) : null;
+            }
+        }
+    }
+}

--- a/source/scripting_v3/GTA/Entities/Projectile.cs
+++ b/source/scripting_v3/GTA/Entities/Projectile.cs
@@ -11,25 +11,10 @@ namespace GTA
     /// <summary>
     /// Represents a projectile, which is for `<c>CProjectile</c>`.
     /// </summary>
-    public class Projectile : Prop
+    public partial class Projectile : Prop
     {
         internal Projectile(int handle) : base(handle)
         {
-        }
-
-        /// <summary>
-        /// Gets the <see cref="Ped"/> this <see cref="Projectile"/> belongs to.
-        /// Can be <see langword="null" /> or a <see cref="Ped"/> instance whose handle is for <see cref="Vehicle"/>, which is not valid as a <see cref="Ped"/> instance.
-        /// </summary>
-        [Obsolete("The Projectile.Owner is obsolete in the v3 API because the actual owner can be a Vehicle, use Projectile.OwnerEntity instead."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public Ped Owner
-        {
-            get
-            {
-                int ownerHandle = GetOwnerEntityInternal();
-                return ownerHandle != 0 ? new Ped(ownerHandle) : null;
-            }
         }
 
         /// <summary>

--- a/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.Obsolete.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.Obsolete.cs
@@ -1,0 +1,75 @@
+using System;
+using System.ComponentModel;
+using GTA.Math;
+using GTA.Native;
+
+namespace GTA
+{
+    public sealed partial class Vehicle : Entity
+    {
+        /// <summary>
+        /// Determines whether the specified <c>extra</c> is currently enabled on this <see cref="Vehicle"/>.
+        /// </summary>
+        /// <param name="extra">The extra to check.</param>
+        /// <returns>
+        /// <see langword="true"/> if the extra is enabled; otherwise, <see langword="false"/>.
+        /// </returns>
+        [Obsolete("Use Vehicle.Extras[VehicleExtraIndex].Enabled instead!")]
+        public bool IsExtraOn(int extra)
+        {
+            return Function.Call<bool>(Hash.IS_VEHICLE_EXTRA_TURNED_ON, Handle, extra);
+        }
+
+        /// <summary>
+        /// Determines whether the specified <c>extra</c> exists on this <see cref="Vehicle"/>.
+        /// </summary>
+        /// <param name="extra">The extra to check.</param>
+        /// <returns>
+        /// <see langword="true"/> if the extra exists; otherwise, <see langword="false"/>.
+        /// </returns>
+        [Obsolete("Use Vehicle.Extras[VehicleExtraIndex].Exists() instead!")]
+        public bool ExtraExists(int extra)
+        {
+            return Function.Call<bool>(Hash.DOES_EXTRA_EXIST, Handle, extra);
+        }
+
+        /// <summary>
+        /// Enables or disables the specified <c>extra</c> on this <see cref="Vehicle"/>.
+        /// </summary>
+        /// <param name="extra">The extra to enable or disable.</param>
+        /// <param name="toggle"><see langword="true"/> to enable the extra; <see langword="false"/> to disable it.</param>
+        [Obsolete("Use Vehicle.Extras[VehicleExtraIndex].Enabled instead!")]
+        public void ToggleExtra(int extra, bool toggle)
+        {
+            Function.Call(Hash.SET_VEHICLE_EXTRA, Handle, extra, !toggle);
+        }
+
+        /// <summary>
+        /// Gets or sets the gears value of this <see cref="Vehicle"/>.
+        /// </summary>
+        [Obsolete("Use Vehicle.HighGear for the high gear value and Vehicle.CurrentGear for the current gear value instead."),
+        EditorBrowsable(EditorBrowsableState.Never)]
+        public int Gears
+        {
+            get => HighGear;
+            set => HighGear = value;
+        }
+
+        /// <inheritdoc cref="Vehicle.HasDamageDecals"/>
+        [Obsolete("Use Vehicle.HasDamageDecals instead."), EditorBrowsable(EditorBrowsableState.Never)]
+        public bool IsDamaged => Function.Call<bool>(Hash.GET_DOES_VEHICLE_HAVE_DAMAGE_DECALS, Handle);
+
+        [Obsolete("Use ApplyDamageDeformation instead."), EditorBrowsable(EditorBrowsableState.Never)]
+        public void ApplyDamage(Vector3 position, float damageAmount, float radius)
+        {
+            Function.Call(Hash.SET_VEHICLE_DAMAGE, Handle, position.X, position.Y, position.Z, damageAmount, radius);
+        }
+
+        [Obsolete("Vehicle.TowVehicle(Vehicle, bool) is obsolete because the bone index parameter is incorrectly used " +
+    "as a bool parameter. Use one of the other overload instead."), EditorBrowsable(EditorBrowsableState.Never)]
+        public void TowVehicle(Vehicle vehicle, bool rear)
+        {
+            Function.Call(Hash.ATTACH_VEHICLE_TO_TOW_TRUCK, Handle, vehicle.Handle, rear, 0f, 0f, 0f);
+        }
+    }
+}

--- a/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs
@@ -12,7 +12,7 @@ using System.Linq;
 
 namespace GTA
 {
-    public sealed class Vehicle : Entity
+    public sealed partial class Vehicle : Entity
     {
         #region Fields
         VehicleDoorCollection _doors;
@@ -242,46 +242,6 @@ namespace GTA
         /// </para>
         /// </param>
         public void ForceUseAudioGameObject(string gameObjectName) => Function.Call(Hash.FORCE_USE_AUDIO_GAME_OBJECT, Handle, gameObjectName);
-
-        #endregion
-
-        #region Extras
-        /// <summary>
-        /// Determines whether the specified <c>extra</c> is currently enabled on this <see cref="Vehicle"/>.
-        /// </summary>
-        /// <param name="extra">The extra to check.</param>
-        /// <returns>
-        /// <see langword="true"/> if the extra is enabled; otherwise, <see langword="false"/>.
-        /// </returns>
-        [Obsolete("Use Vehicle.Extras[VehicleExtraIndex].Enabled instead!")]
-        public bool IsExtraOn(int extra)
-        {
-            return Function.Call<bool>(Hash.IS_VEHICLE_EXTRA_TURNED_ON, Handle, extra);
-        }
-
-        /// <summary>
-        /// Determines whether the specified <c>extra</c> exists on this <see cref="Vehicle"/>.
-        /// </summary>
-        /// <param name="extra">The extra to check.</param>
-        /// <returns>
-        /// <see langword="true"/> if the extra exists; otherwise, <see langword="false"/>.
-        /// </returns>
-        [Obsolete("Use Vehicle.Extras[VehicleExtraIndex].Exists() instead!")]
-        public bool ExtraExists(int extra)
-        {
-            return Function.Call<bool>(Hash.DOES_EXTRA_EXIST, Handle, extra);
-        }
-
-        /// <summary>
-        /// Enables or disables the specified <c>extra</c> on this <see cref="Vehicle"/>.
-        /// </summary>
-        /// <param name="extra">The extra to enable or disable.</param>
-        /// <param name="toggle"><see langword="true"/> to enable the extra; <see langword="false"/> to disable it.</param>
-        [Obsolete("Use Vehicle.Extras[VehicleExtraIndex].Enabled instead!")]
-        public void ToggleExtra(int extra, bool toggle)
-        {
-            Function.Call(Hash.SET_VEHICLE_EXTRA, Handle, extra, !toggle);
-        }
 
         #endregion
 
@@ -965,17 +925,6 @@ namespace GTA
         #endregion
 
         #region Performance & Driving
-
-        /// <summary>
-        /// Gets or sets the gears value of this <see cref="Vehicle"/>.
-        /// </summary>
-        [Obsolete("Use Vehicle.HighGear for the high gear value and Vehicle.CurrentGear for the current gear value instead."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public int Gears
-        {
-            get => HighGear;
-            set => HighGear = value;
-        }
 
         /// <summary>
         /// Gets or sets the high gear value of this <see cref="Vehicle"/>.
@@ -1705,11 +1654,6 @@ namespace GTA
         /// </summary>
         public bool HasDamageDecals => Function.Call<bool>(Hash.GET_DOES_VEHICLE_HAVE_DAMAGE_DECALS, Handle);
 
-
-        /// <inheritdoc cref="Vehicle.HasDamageDecals"/>
-        [Obsolete("Use Vehicle.HasDamageDecals instead."), EditorBrowsable(EditorBrowsableState.Never)]
-        public bool IsDamaged => Function.Call<bool>(Hash.GET_DOES_VEHICLE_HAVE_DAMAGE_DECALS, Handle);
-
         /// <summary>
         /// Gets the value that indicates whether this <see cref="Vehicle"/> is driveable.
         /// For the setter, it behaves in the same way as <see cref="IsUndriveable"/> except that this setter negates the value.
@@ -1864,11 +1808,6 @@ namespace GTA
         public void ApplyDamageDeformation(Vector3 position, float damage, float deformation, bool localDamage)
         {
             Function.Call(Hash.SET_VEHICLE_DAMAGE, Handle, position.X, position.Y, position.Z, damage, deformation, localDamage);
-        }
-        [Obsolete("Use ApplyDamageDeformation instead."), EditorBrowsable(EditorBrowsableState.Never)]
-        public void ApplyDamage(Vector3 position, float damageAmount, float radius)
-        {
-            Function.Call(Hash.SET_VEHICLE_DAMAGE, Handle, position.X, position.Y, position.Z, damageAmount, radius);
         }
 
         /// <summary>
@@ -2560,12 +2499,6 @@ namespace GTA
         {
             Function.Call(Hash.ATTACH_VEHICLE_TO_TOW_TRUCK, Handle, vehicleBone.Owner, vehicleBone.Index,
                 attachPointOffset.X, attachPointOffset.Y, attachPointOffset.Z);
-        }
-        [Obsolete("Vehicle.TowVehicle(Vehicle, bool) is obsolete because the bone index parameter is incorrectly used " +
-            "as a bool parameter. Use one of the other overload instead."), EditorBrowsable(EditorBrowsableState.Never)]
-        public void TowVehicle(Vehicle vehicle, bool rear)
-        {
-            Function.Call(Hash.ATTACH_VEHICLE_TO_TOW_TRUCK, Handle, vehicle.Handle, rear, 0f, 0f, 0f);
         }
 
         /// <summary>

--- a/source/scripting_v3/GTA/Entities/Vehicles/VehicleWheel.Obsolete.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/VehicleWheel.Obsolete.cs
@@ -1,0 +1,15 @@
+using System;
+using System.ComponentModel;
+
+namespace GTA
+{
+    public sealed partial class VehicleWheel
+    {
+        /// <summary>
+        /// Gets the script wheel index for native functions.
+        /// </summary>
+        [Obsolete("Use VehicleWheel.BoneId or VehicleWheel.ScriptIndex instead."),
+        EditorBrowsable(EditorBrowsableState.Never)]
+        public int Index => (int)ScriptIndex;
+    }
+}

--- a/source/scripting_v3/GTA/Entities/Vehicles/VehicleWheel.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/VehicleWheel.cs
@@ -14,7 +14,7 @@ namespace GTA
     /// <summary>
     /// Represents a vehicle wheel for a vehicle (internally for a <c>CWheel</c> struct).
     /// </summary>
-    public sealed class VehicleWheel
+    public sealed partial class VehicleWheel
     {
         #region Fields
         IntPtr _cachedAddress;
@@ -105,13 +105,6 @@ namespace GTA
         {
             get;
         }
-
-        /// <summary>
-        /// Gets the script wheel index for native functions.
-        /// </summary>
-        [Obsolete("Use VehicleWheel.BoneId or VehicleWheel.ScriptIndex instead."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public int Index => (int)ScriptIndex;
 
         /// <summary>
         /// Gets the script wheel index for native functions.

--- a/source/scripting_v3/GTA/Game.Obsolete.cs
+++ b/source/scripting_v3/GTA/Game.Obsolete.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using GTA.Native;
+
+namespace GTA
+{
+    public static partial class Game
+    {
+        /// <summary>
+        /// Gets the version of the game.
+        /// </summary>
+        [Obsolete("`Game.Version` is deprecated because Script Hook V is deprecating `getGameVersion`, which " +
+            "the property is based on. Use `Game.FileVersion` instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static GameVersion Version => (GameVersion)SHVDN.NativeMemory.GetGameVersion();
+
+        /// <summary>
+        /// Gets a value indicating whether there is a loading screen being displayed if Script Hook V v1.0.3337.0 or
+        /// older is installed to the game.
+        /// </summary>
+        /// <remarks>
+        /// This property always return <see langword="false"/> since Script Hook V v1.0.3351.0+ This is because
+        /// SHV changed the way SHV scripts start in v1.0.3351.0 (SHV version and not game version) and they will never be
+        /// able to start before the game finished showing the loading screen since SHV v1.0.3351.0+. See
+        /// <see href="https://github.com/scripthookvdotnet/scripthookvdotnet/issues/1549">#1549 on the main GitHub
+        /// repository</see> for details.
+        /// </remarks>
+        [Obsolete("`Game.IsLoading` is obsolete because Script Hook V changed the way SHV scripts start in" +
+            "v1.0.3351.0 (SHV version and not game version) and they never be able to start before the game " +
+            "finished showing the loading screen since SHV v1.0.3351.0+. It is advised not to use `Game.IsLoading`" +
+            "at all.")]
+        public static bool IsLoading => Function.Call<bool>(Hash.GET_IS_LOADING_SCREEN_ACTIVE);
+
+        /// <summary>
+        /// Calculates a Jenkins One At A Time hash from the given <see cref="string"/> which can then be used by any native function that takes a hash.
+        /// Can be called in any thread.
+        /// </summary>
+        /// <param name="input">The input <see cref="string"/> to hash.</param>
+        /// <returns>The Jenkins hash of the input <see cref="string"/>.</returns>
+        /// <remarks>
+        /// Converts ASCII uppercase characters to lowercase ones and backslash characters to slash ones before
+        /// converting into a hash. Computes the hash from the substring between two double quotes if the first
+        /// character is a double quote character.
+        /// </remarks>
+        [Obsolete("Use StringHash.AtStringHash(string, uint), StringHash.AtStringHashUtf8(string, uint), " +
+            "AtHashValue.FromString(string, uint), or StringHash.AtStringHashUtf8(string, uint) instead.")]
+        // Use AtStringHashUtf8 for compatibility reasons
+        public static int GenerateHash(string input) => (int)StringHash.AtStringHashUtf8(input);
+    }
+}

--- a/source/scripting_v3/GTA/Game.cs
+++ b/source/scripting_v3/GTA/Game.cs
@@ -13,7 +13,7 @@ using System.Windows.Forms;
 
 namespace GTA
 {
-    public static class Game
+    public static partial class Game
     {
         #region Fields
         static Player s_cachedPlayer = null;
@@ -131,14 +131,6 @@ namespace GTA
         /// <c>getGameVersionInfo</c> retrieves, as a <see cref="System.Version"/> instance.
         /// </summary>
         public static Version FileVersion => SHVDN.NativeMemory.GameFileVersion;
-
-        /// <summary>
-        /// Gets the version of the game.
-        /// </summary>
-        [Obsolete("`Game.Version` is deprecated because Script Hook V is deprecating `getGameVersion`, which " +
-            "the property is based on. Use `Game.FileVersion` instead.")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static GameVersion Version => (GameVersion)SHVDN.NativeMemory.GetGameVersion();
 
         /// <summary>
         /// Gets the measurement system the game uses to display.
@@ -347,23 +339,6 @@ namespace GTA
         {
             Function.Call(Hash.SET_GAME_PAUSED, value);
         }
-
-        /// <summary>
-        /// Gets a value indicating whether there is a loading screen being displayed if Script Hook V v1.0.3337.0 or
-        /// older is installed to the game.
-        /// </summary>
-        /// <remarks>
-        /// This property always return <see langword="false"/> since Script Hook V v1.0.3351.0+ This is because
-        /// SHV changed the way SHV scripts start in v1.0.3351.0 (SHV version and not game version) and they will never be
-        /// able to start before the game finished showing the loading screen since SHV v1.0.3351.0+. See
-        /// <see href="https://github.com/scripthookvdotnet/scripthookvdotnet/issues/1549">#1549 on the main GitHub
-        /// repository</see> for details.
-        /// </remarks>
-        [Obsolete("`Game.IsLoading` is obsolete because Script Hook V changed the way SHV scripts start in" +
-            "v1.0.3351.0 (SHV version and not game version) and they never be able to start before the game " +
-            "finished showing the loading screen since SHV v1.0.3351.0+. It is advised not to use `Game.IsLoading`" +
-            "at all.")]
-        public static bool IsLoading => Function.Call<bool>(Hash.GET_IS_LOADING_SCREEN_ACTIVE);
 
         /// <summary>
         /// Creates an input box for the user to input text using the keyboard.
@@ -699,22 +674,6 @@ namespace GTA
         {
             Function.Call(Hash.DISABLE_ALL_CONTROL_ACTIONS, 0);
         }
-
-        /// <summary>
-        /// Calculates a Jenkins One At A Time hash from the given <see cref="string"/> which can then be used by any native function that takes a hash.
-        /// Can be called in any thread.
-        /// </summary>
-        /// <param name="input">The input <see cref="string"/> to hash.</param>
-        /// <returns>The Jenkins hash of the input <see cref="string"/>.</returns>
-        /// <remarks>
-        /// Converts ASCII uppercase characters to lowercase ones and backslash characters to slash ones before
-        /// converting into a hash. Computes the hash from the substring between two double quotes if the first
-        /// character is a double quote character.
-        /// </remarks>
-        [Obsolete("Use StringHash.AtStringHash(string, uint), StringHash.AtStringHashUtf8(string, uint), " +
-            "AtHashValue.FromString(string, uint), or StringHash.AtStringHashUtf8(string, uint) instead.")]
-        // Use AtStringHashUtf8 for compatibility reasons
-        public static int GenerateHash(string input) => (int)StringHash.AtStringHashUtf8(input);
 
         /// <summary>
         /// Returns a localized <see cref="string"/> from the games language files with a specified GXT key.

--- a/source/scripting_v3/GTA/GameVersionNotSupportedException.Obsolete.cs
+++ b/source/scripting_v3/GTA/GameVersionNotSupportedException.Obsolete.cs
@@ -1,0 +1,14 @@
+using System;
+using System.ComponentModel;
+
+namespace GTA
+{
+    public sealed partial class GameVersionNotSupportedException : Exception
+    {
+        [Obsolete("`GameVersionNotSupportedException.MinimumSupportedGameVersion` is deprecated " +
+    "because Script Hook V is deprecating `getGameVersion`, which the property is based on. " +
+    "Use `GameVersionNotSupportedException.MinimumSupportedGameFileVersion` instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public GameVersion MinimumSupportedGameVersion { get; }
+    }
+}

--- a/source/scripting_v3/GTA/GameVersionNotSupportedException.cs
+++ b/source/scripting_v3/GTA/GameVersionNotSupportedException.cs
@@ -39,13 +39,8 @@ namespace GTA
     /// </list>
     /// </remarks>
     [Serializable]
-    public sealed class GameVersionNotSupportedException : Exception
+    public sealed partial class GameVersionNotSupportedException : Exception
     {
-        [Obsolete("`GameVersionNotSupportedException.MinimumSupportedGameVersion` is deprecated " +
-            "because Script Hook V is deprecating `getGameVersion`, which the property is based on. " +
-            "Use `GameVersionNotSupportedException.MinimumSupportedGameFileVersion` instead.")]
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public GameVersion MinimumSupportedGameVersion { get; }
         public Version MinimumSupportedGameFileVersion { get; }
 
         private Dictionary<Version, GameVersion> _supportedGameVersionEnumMaps

--- a/source/scripting_v3/GTA/Player.Obsolete.cs
+++ b/source/scripting_v3/GTA/Player.Obsolete.cs
@@ -1,0 +1,133 @@
+using System;
+using GTA.Math;
+using GTA.Native;
+
+namespace GTA
+{
+    public sealed partial class Player : INativeValue
+    {
+        /// <summary>
+        /// Gets or sets the wanted level for this <see cref="Player"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Will refocus the search area if you set a value less than the current value and is not zero.
+        /// </para>
+        /// <para>
+        /// Hardcoded to clamp to at most 5 since <c>SET_PLAYER_WANTED_LEVEL</c> just sets the pending crime value to zero
+        /// when passed wanted level is a value other than from 1 to 5 (inclusive).
+        /// Also, the game does not read <c>WantedLevel6</c> items from <c>dispatch.meta</c>.
+        /// </para>
+        /// </remarks>
+        public int WantedLevel
+        {
+            [Obsolete("Use `GTA.Wanted.WantedLevel` instead via the property `GTA.Player.Wanted`.")]
+            get => Function.Call<int>(Hash.GET_PLAYER_WANTED_LEVEL, Handle);
+            [Obsolete("Use the combination of `SetWantedLevel` and `ApplyWantedLevelChangeNow` of `GTA.Wanted` " +
+                      "instead via the property `GTA.Player.Wanted`.")]
+            set
+            {
+                Function.Call(Hash.SET_PLAYER_WANTED_LEVEL, Handle, value, false);
+                Function.Call(Hash.SET_PLAYER_WANTED_LEVEL_NOW, Handle, false);
+            }
+        }
+
+
+        /// <summary>
+        /// Gets or sets the wanted center position for this <see cref="Player"/>.
+        /// </summary>
+        /// <value>
+        /// The place in world coordinates where the police think this <see cref="Player"/> is.
+        /// </value>
+        public Vector3 WantedCenterPosition
+        {
+            [Obsolete("Use `GTA.Wanted.LastPositionSpottedByPolice` instead via the property `GTA.Player.Wanted`.")]
+            get => Function.Call<Vector3>(Hash.GET_PLAYER_WANTED_CENTRE_POSITION, Handle);
+            [Obsolete("Use `GTA.Wanted.SetRadiusCenter` instead via the property `GTA.Player.Wanted`.")]
+            set => Function.Call(Hash.SET_PLAYER_WANTED_CENTRE_POSITION, Handle, value.X, value.Y, value.Z);
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="Player"/> is ignored by the police.
+        /// </summary>
+        /// <value>
+        /// <see langword="true" /> if this <see cref="Player"/> is ignored by the police; otherwise, <see langword="false" />.
+        /// </value>
+        public bool IgnoredByPolice
+        {
+            [Obsolete("Use `GTA.Wanted.PoliceBackOff` instead via the property `GTA.Player.Wanted`.")]
+            get
+            {
+                if (SHVDN.NativeMemory.CWantedIgnorePlayerFlagOffset == 0)
+                {
+                    return false;
+                }
+
+                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(Handle);
+                if (cWantedAddress == IntPtr.Zero)
+                {
+                    return false;
+                }
+
+                return SHVDN.MemDataMarshal.IsBitSet(cWantedAddress + SHVDN.NativeMemory.CWantedIgnorePlayerFlagOffset, 16);
+            }
+            [Obsolete("Use `GTA.Wanted.SetPoliceIgnorePlayer` instead via the property `GTA.Player.Wanted`.")]
+            set => Function.Call(Hash.SET_POLICE_IGNORE_PLAYER, Handle, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="Player"/> is ignored by everyone.
+        /// </summary>
+        /// <value>
+        /// <see langword="true" /> if this <see cref="Player"/> is ignored by everyone; otherwise, <see langword="false" />.
+        /// </value>
+        public bool IgnoredByEveryone
+        {
+            [Obsolete("Use `GTA.Wanted.EveryoneBackOff` instead via the property `GTA.Player.Wanted`.")]
+            get
+            {
+                if (SHVDN.NativeMemory.CWantedIgnorePlayerFlagOffset == 0)
+                {
+                    return false;
+                }
+
+                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(Handle);
+                if (cWantedAddress == IntPtr.Zero)
+                {
+                    return false;
+                }
+
+                return SHVDN.MemDataMarshal.IsBitSet(cWantedAddress + SHVDN.NativeMemory.CWantedIgnorePlayerFlagOffset, 18);
+            }
+            [Obsolete("Use `GTA.Wanted.SetEveryoneIgnorePlayer` instead via the property `GTA.Player.Wanted`.")]
+            set => Function.Call(Hash.SET_EVERYONE_IGNORE_PLAYER, Handle, value);
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether cops will be dispatched for this <see cref="Player"/>.
+        /// </summary>
+        /// <value>
+        /// <see langword="true" /> if cops will be dispatched; otherwise, <see langword="false" />.
+        /// </value>
+        [Obsolete("Use `GTA.Wanted.DispatchesCopsForPlayer` instead via the property `GTA.Player.Wanted`.")]
+        public bool DispatchsCops
+        {
+            get
+            {
+                if (SHVDN.NativeMemory.CWantedIgnorePlayerFlagOffset == 0)
+                {
+                    return false;
+                }
+
+                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(Handle);
+                if (cWantedAddress == IntPtr.Zero)
+                {
+                    return false;
+                }
+
+                return !SHVDN.MemDataMarshal.IsBitSet(cWantedAddress + SHVDN.NativeMemory.CWantedIgnorePlayerFlagOffset, 23);
+            }
+            set => Function.Call(Hash.SET_DISPATCH_COPS_FOR_PLAYER, Handle, value);
+        }
+    }
+}

--- a/source/scripting_v3/GTA/Player.cs
+++ b/source/scripting_v3/GTA/Player.cs
@@ -11,7 +11,7 @@ using System.Drawing;
 
 namespace GTA
 {
-    public sealed class Player : INativeValue
+    public sealed partial class Player : INativeValue
     {
         #region Fields
         private Ped _ped;
@@ -260,133 +260,6 @@ namespace GTA
 
                 return new Vector3(SHVDN.MemDataMarshal.ReadVector3(cPlayerPedTargetingAddr + 0x40));
             }
-        }
-
-        #endregion
-
-        #region Wanted Info (CWanted)
-
-        /// <summary>
-        /// Gets or sets the wanted level for this <see cref="Player"/>.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// Will refocus the search area if you set a value less than the current value and is not zero.
-        /// </para>
-        /// <para>
-        /// Hardcoded to clamp to at most 5 since <c>SET_PLAYER_WANTED_LEVEL</c> just sets the pending crime value to zero
-        /// when passed wanted level is a value other than from 1 to 5 (inclusive).
-        /// Also, the game does not read <c>WantedLevel6</c> items from <c>dispatch.meta</c>.
-        /// </para>
-        /// </remarks>
-        public int WantedLevel
-        {
-            [Obsolete("Use `GTA.Wanted.WantedLevel` instead via the property `GTA.Player.Wanted`.")]
-            get => Function.Call<int>(Hash.GET_PLAYER_WANTED_LEVEL, Handle);
-            [Obsolete("Use the combination of `SetWantedLevel` and `ApplyWantedLevelChangeNow` of `GTA.Wanted` " +
-                      "instead via the property `GTA.Player.Wanted`.")]
-            set
-            {
-                Function.Call(Hash.SET_PLAYER_WANTED_LEVEL, Handle, value, false);
-                Function.Call(Hash.SET_PLAYER_WANTED_LEVEL_NOW, Handle, false);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the wanted center position for this <see cref="Player"/>.
-        /// </summary>
-        /// <value>
-        /// The place in world coordinates where the police think this <see cref="Player"/> is.
-        /// </value>
-        public Vector3 WantedCenterPosition
-        {
-            [Obsolete("Use `GTA.Wanted.LastPositionSpottedByPolice` instead via the property `GTA.Player.Wanted`.")]
-            get => Function.Call<Vector3>(Hash.GET_PLAYER_WANTED_CENTRE_POSITION, Handle);
-            [Obsolete("Use `GTA.Wanted.SetRadiusCenter` instead via the property `GTA.Player.Wanted`.")]
-            set => Function.Call(Hash.SET_PLAYER_WANTED_CENTRE_POSITION, Handle, value.X, value.Y, value.Z);
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether this <see cref="Player"/> is ignored by the police.
-        /// </summary>
-        /// <value>
-        /// <see langword="true" /> if this <see cref="Player"/> is ignored by the police; otherwise, <see langword="false" />.
-        /// </value>
-        public bool IgnoredByPolice
-        {
-            [Obsolete("Use `GTA.Wanted.PoliceBackOff` instead via the property `GTA.Player.Wanted`.")]
-            get
-            {
-                if (SHVDN.NativeMemory.CWantedIgnorePlayerFlagOffset == 0)
-                {
-                    return false;
-                }
-
-                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(Handle);
-                if (cWantedAddress == IntPtr.Zero)
-                {
-                    return false;
-                }
-
-                return SHVDN.MemDataMarshal.IsBitSet(cWantedAddress + SHVDN.NativeMemory.CWantedIgnorePlayerFlagOffset, 16);
-            }
-            [Obsolete("Use `GTA.Wanted.SetPoliceIgnorePlayer` instead via the property `GTA.Player.Wanted`.")]
-            set => Function.Call(Hash.SET_POLICE_IGNORE_PLAYER, Handle, value);
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether this <see cref="Player"/> is ignored by everyone.
-        /// </summary>
-        /// <value>
-        /// <see langword="true" /> if this <see cref="Player"/> is ignored by everyone; otherwise, <see langword="false" />.
-        /// </value>
-        public bool IgnoredByEveryone
-        {
-            [Obsolete("Use `GTA.Wanted.EveryoneBackOff` instead via the property `GTA.Player.Wanted`.")]
-            get
-            {
-                if (SHVDN.NativeMemory.CWantedIgnorePlayerFlagOffset == 0)
-                {
-                    return false;
-                }
-
-                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(Handle);
-                if (cWantedAddress == IntPtr.Zero)
-                {
-                    return false;
-                }
-
-                return SHVDN.MemDataMarshal.IsBitSet(cWantedAddress + SHVDN.NativeMemory.CWantedIgnorePlayerFlagOffset, 18);
-            }
-            [Obsolete("Use `GTA.Wanted.SetEveryoneIgnorePlayer` instead via the property `GTA.Player.Wanted`.")]
-            set => Function.Call(Hash.SET_EVERYONE_IGNORE_PLAYER, Handle, value);
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether cops will be dispatched for this <see cref="Player"/>.
-        /// </summary>
-        /// <value>
-        /// <see langword="true" /> if cops will be dispatched; otherwise, <see langword="false" />.
-        /// </value>
-        [Obsolete("Use `GTA.Wanted.DispatchesCopsForPlayer` instead via the property `GTA.Player.Wanted`.")]
-        public bool DispatchsCops
-        {
-            get
-            {
-                if (SHVDN.NativeMemory.CWantedIgnorePlayerFlagOffset == 0)
-                {
-                    return false;
-                }
-
-                IntPtr cWantedAddress = SHVDN.NativeMemory.GetCWantedAddress(Handle);
-                if (cWantedAddress == IntPtr.Zero)
-                {
-                    return false;
-                }
-
-                return !SHVDN.MemDataMarshal.IsBitSet(cWantedAddress + SHVDN.NativeMemory.CWantedIgnorePlayerFlagOffset, 23);
-            }
-            set => Function.Call(Hash.SET_DISPATCH_COPS_FOR_PLAYER, Handle, value);
         }
 
         #endregion

--- a/source/scripting_v3/GTA/Scaleform.Obsolete.cs
+++ b/source/scripting_v3/GTA/Scaleform.Obsolete.cs
@@ -1,0 +1,14 @@
+using System;
+using GTA.Native;
+
+namespace GTA
+{
+    public sealed partial class Scaleform : IDisposable, INativeValue
+    {
+        [Obsolete("The Scaleform constructor with a string parameter is obsolete. Use Scaleform.RequestMovie instead.")]
+        public Scaleform(string scaleformID)
+        {
+            Handle = Function.Call<int>(Hash.REQUEST_SCALEFORM_MOVIE, scaleformID);
+        }
+    }
+}

--- a/source/scripting_v3/GTA/Scaleform.cs
+++ b/source/scripting_v3/GTA/Scaleform.cs
@@ -13,16 +13,11 @@ namespace GTA
     /// <summary>
     /// A class which handles rendering of Scaleform elements.
     /// </summary>
-    public sealed class Scaleform : IDisposable, INativeValue
+    public sealed partial class Scaleform : IDisposable, INativeValue
     {
         internal Scaleform(int handle)
         {
             Handle = handle;
-        }
-        [Obsolete("The Scaleform constructor with a string parameter is obsolete. Use Scaleform.RequestMovie instead.")]
-        public Scaleform(string scaleformID)
-        {
-            Handle = Function.Call<int>(Hash.REQUEST_SCALEFORM_MOVIE, scaleformID);
         }
 
         /// <summary>

--- a/source/scripting_v3/GTA/Weapons/WeaponComponentCollection.Obsolete.cs
+++ b/source/scripting_v3/GTA/Weapons/WeaponComponentCollection.Obsolete.cs
@@ -1,0 +1,31 @@
+using System;
+using System.ComponentModel;
+
+namespace GTA
+{
+    public sealed partial class WeaponComponentCollection
+    {
+        /// <summary>
+        /// Gets the first component of all the components for <see cref="WeaponAttachmentPoint.GunRoot"/>.
+        /// Despite the method name, return value is not guaranteed to a <see cref="WeaponComponent"/> instance that represents the luxury finish component.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="WeaponComponent"/> instance if the first component of all the components for <see cref="WeaponAttachmentPoint.GunRoot"/> is found;
+        /// otherwise, the <see cref="WeaponComponent"/> instance representing the invalid component.
+        /// </returns>
+        [Obsolete("WeaponComponentCollection.GetLuxuryFinishComponent is wrongly named and cannot necessarily get all of the components for gun_root (e.g. camo components)," +
+                  "use WeaponComponentCollection.GetGunRootComponent instead."),
+        EditorBrowsable(EditorBrowsableState.Never)]
+        public WeaponComponent GetLuxuryFinishComponent()
+        {
+            foreach (WeaponComponent component in this)
+            {
+                if (component.AttachmentPoint == WeaponAttachmentPoint.GunRoot)
+                {
+                    return component;
+                }
+            }
+            return _invalidComponent;
+        }
+    }
+}

--- a/source/scripting_v3/GTA/Weapons/WeaponComponentCollection.cs
+++ b/source/scripting_v3/GTA/Weapons/WeaponComponentCollection.cs
@@ -10,7 +10,7 @@ using System.Linq;
 
 namespace GTA
 {
-    public sealed class WeaponComponentCollection
+    public sealed partial class WeaponComponentCollection
     {
         #region Fields
         readonly Ped _owner;
@@ -344,29 +344,6 @@ namespace GTA
                 }
 
                 if (component.AttachmentPoint is WeaponAttachmentPoint.FlashLaser or WeaponAttachmentPoint.FlashLaser2)
-                {
-                    return component;
-                }
-            }
-            return _invalidComponent;
-        }
-
-        /// <summary>
-        /// Gets the first component of all the components for <see cref="WeaponAttachmentPoint.GunRoot"/>.
-        /// Despite the method name, return value is not guaranteed to a <see cref="WeaponComponent"/> instance that represents the luxury finish component.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="WeaponComponent"/> instance if the first component of all the components for <see cref="WeaponAttachmentPoint.GunRoot"/> is found;
-        /// otherwise, the <see cref="WeaponComponent"/> instance representing the invalid component.
-        /// </returns>
-        [Obsolete("WeaponComponentCollection.GetLuxuryFinishComponent is wrongly named and cannot necessarily get all of the components for gun_root (e.g. camo components)," +
-                  "use WeaponComponentCollection.GetGunRootComponent instead."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public WeaponComponent GetLuxuryFinishComponent()
-        {
-            foreach (WeaponComponent component in this)
-            {
-                if (component.AttachmentPoint == WeaponAttachmentPoint.GunRoot)
                 {
                     return component;
                 }

--- a/source/scripting_v3/GTA/World.Obsolete.cs
+++ b/source/scripting_v3/GTA/World.Obsolete.cs
@@ -1,0 +1,305 @@
+using System;
+using System.ComponentModel;
+using GTA.Math;
+using GTA.Native;
+
+namespace GTA
+{
+    public static partial class World
+    {
+        /// <inheritdoc cref="GTA.Chrono.GameClock.IsPaused"/>
+        [Obsolete("World.IsClockPaused is obsolete, use GTA.Chrono.IsPaused instead.")]
+        public static bool IsClockPaused
+        {
+            get => SHVDN.NativeMemory.IsClockPaused;
+            set => Function.Call(Hash.PAUSE_CLOCK, value);
+        }
+
+        /// <summary>
+        /// Pauses or resumes the in-game clock.
+        /// </summary>
+        /// <param name="value">Pauses the game clock if set to <see langword="true" />; otherwise, resumes the game clock.</param>
+        [Obsolete("The World.PauseClock is obsolete, use GTA.Chrono.IsPaused instead.")]
+        public static void PauseClock(bool value)
+        {
+            IsClockPaused = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the current date and time in the GTA world.
+        /// </summary>
+        /// <value>
+        /// The current date and time.
+        /// </value>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// The internal date is not valid for the Gregorian calendar or the internal time of day is not normalized.
+        /// </exception>
+        [Obsolete("World.CurrentDate is obsolete because DateTime can represent the years only in the range of 1 to 9999, while the game supports wider range of years." +
+            "Use properties or methods of GTA.Chrono.GameClock instead."), EditorBrowsable(EditorBrowsableState.Never)]
+        public static DateTime CurrentDate
+        {
+            get
+            {
+                int year = Function.Call<int>(Hash.GET_CLOCK_YEAR);
+                int month = Function.Call<int>(Hash.GET_CLOCK_MONTH) + 1;
+                int day = System.Math.Min(Function.Call<int>(Hash.GET_CLOCK_DAY_OF_MONTH), s_calendar.GetDaysInMonth(year, month));
+                int hour = Function.Call<int>(Hash.GET_CLOCK_HOURS);
+                int minute = Function.Call<int>(Hash.GET_CLOCK_MINUTES);
+                int second = Function.Call<int>(Hash.GET_CLOCK_SECONDS);
+
+                return new DateTime(year, month, day, hour, minute, second);
+            }
+            set
+            {
+                Function.Call(Hash.SET_CLOCK_DATE, value.Day, value.Month - 1, value.Year);
+                Function.Call(Hash.SET_CLOCK_TIME, value.Hour, value.Minute, value.Second);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the current time of day in the GTA world.
+        /// </summary>
+        /// <value>
+        /// The current time of day.
+        /// </value>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// One of the values minutes or seconds are smaller than <c>0</c> or larger than <c>59</c>, or the hour value
+        /// is smaller than <c>0</c> or larger than <c>23</c>.
+        /// </exception>
+        /// <remarks>
+        /// The resolution of the value is 1 second.
+        /// </remarks>
+        [Obsolete("World.CurrentTimeOfDay is obsolete, use GTA.Chrono.GameClock.Today instead.")]
+        public static TimeSpan CurrentTimeOfDay
+        {
+            get
+            {
+                int hours = Function.Call<int>(Hash.GET_CLOCK_HOURS);
+                int minutes = Function.Call<int>(Hash.GET_CLOCK_MINUTES);
+                int seconds = Function.Call<int>(Hash.GET_CLOCK_SECONDS);
+
+                return new TimeSpan(hours, minutes, seconds);
+            }
+            set => Function.Call(Hash.SET_CLOCK_TIME, value.Hours, value.Minutes, value.Seconds);
+        }
+
+        /// <inheritdoc cref="GTA.Chrono.GameClock.MillisecondsPerGameMinute"/>
+        [Obsolete("World.MillisecondsPerGameMinute is obsolete, use GTA.Chrono.GameClock.MillisecondsPerGameMinute instead.")]
+        public static int MillisecondsPerGameMinute
+        {
+            get => Function.Call<int>(Hash.GET_MILLISECONDS_PER_GAME_MINUTE);
+            set => SHVDN.NativeMemory.MillisecondsPerGameMinute = value;
+        }
+
+        /// <summary>
+        /// Creates a pickup <see cref="Prop"/> similar to those dropped by dead <see cref="Ped"/>s.
+        /// These types of pickups are part of the ambient population and will get removed if the player moves too far away from them.
+        /// </summary>
+        [Obsolete("The World.CreateAmbientPickup overload with non-optional custom model and amount (named \"value\") parameters are obsolete since they can lead to confusion in custom model parameter (which is actually not mandatory)." +
+            "Use World.CreateAmbientPickup(PickupType, Vector3, PickupPlacementFlags, int, Model, bool) instead.")]
+        public static Prop CreateAmbientPickup(PickupType type, Vector3 position, Model model, int value)
+            => CreateAmbientPickup(type, position, PickupPlacementFlags.None, value, model, false);
+
+        /// <summary>
+        /// Spawns a <see cref="Pickup"/> at the specified position.
+        /// </summary>
+        [Obsolete("The World.CreatePickup overloads with non-optional custom model and amount (named \"value\") parameters are obsolete since they can lead to confusion in custom model parameter (which is actually not mandatory)." +
+            "Use a World.CreatePickup overload with optional placement flags and amount parameters instead."),
+        EditorBrowsable(EditorBrowsableState.Never)]
+        public static Pickup CreatePickup(PickupType type, Vector3 position, Model model, int value)
+            => CreatePickup(type, position, PickupPlacementFlags.None, value, model);
+        /// <summary>
+        /// Spawns a <see cref="Pickup"/> at the specified position.
+        /// </summary>
+        [Obsolete("The World.CreatePickup overloads with non-optional custom model and amount (named \"value\") parameters are obsolete since they can lead to confusion in custom model parameter (which is actually not mandatory)." +
+            "Use a World.CreatePickup overload with optional placement flags and amount parameters instead."),
+        EditorBrowsable(EditorBrowsableState.Never)]
+        public static Pickup CreatePickup(PickupType type, Vector3 position, Vector3 rotation, Model model, int value)
+            => CreatePickup(type, position, rotation, PickupPlacementFlags.None, value, EulerRotationOrder.YXZ, model);
+
+        /// <summary>
+        /// Destroys all scripted <see cref="Camera"/>s.
+        /// </summary>
+        [Obsolete("World.DestroyAllCameras is obsolete. Use Camera.DeleteAllCameras instead."),
+        EditorBrowsable(EditorBrowsableState.Never)]
+        public static void DestroyAllCameras()
+        {
+            Function.Call(Hash.DESTROY_ALL_CAMS, 0);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="Camera"/>, use <see cref="ScriptCameraDirector.StartRendering()"/> to switch to
+        /// this camera.
+        /// </summary>
+        /// <param name="position">The position of the camera.</param>
+        /// <param name="rotation">The rotation of the camera.</param>
+        /// <param name="fov">The field of view of the camera.</param>
+        /// <remarks>
+        /// This overload (<see cref="World.CreateCamera(Vector3, Vector3, float)"/>) does not return <see langword="null"/>
+        /// even if the method fails to create and <c>CREATE_CAM_WITH_PARAMS</c> returns -1 due to the camera pool being full.
+        /// This is done for compatibility for scripts built against v3.6.0 or earlier.
+        /// </remarks>
+        [Obsolete("World.CreateCamera is obsolete. Use Camera.Create instead."),
+         EditorBrowsable(EditorBrowsableState.Never)]
+        public static Camera CreateCamera(Vector3 position, Vector3 rotation, float fov)
+        {
+            return new Camera(Function.Call<int>(Hash.CREATE_CAM_WITH_PARAMS, "DEFAULT_SCRIPTED_CAMERA", position.X, position.Y, position.Z, rotation.X, rotation.Y, rotation.Z, fov, 1, 2));
+        }
+
+        /// <summary>
+        /// Gets or sets the rendering camera.
+        /// </summary>
+        /// <value>
+        /// The rendering <see cref="Camera"/>.
+        /// </value>
+        /// <remarks>
+        /// Setting to <see langword="null" /> sets the rendering <see cref="Camera"/> to <see cref="GameplayCamera"/>.
+        /// The getter will return an invalid <see cref="Camera"/> where <see cref="PoolObject.Handle"/> is -1 if the
+        /// rendering camera does not match any scripted cameras the scripted camera director is managing.
+        /// </remarks>
+        [Obsolete("World.RenderingCamera is obsolete. " +
+            "Use ScriptCameraDirector.RenderingCam to get the rendering scripted camera. " +
+            "Use ScriptCameraDirector.StartRendering or ScriptCameraDirector.StopRendering to tell the game to render " +
+            "or stop rendering a scripted camera."),
+        EditorBrowsable(EditorBrowsableState.Never)]
+        public static Camera RenderingCamera
+        {
+            get => new(Function.Call<int>(Hash.GET_RENDERING_CAM));
+            set
+            {
+                if (value == null)
+                {
+                    Function.Call(Hash.RENDER_SCRIPT_CAMS, false, 0, 3000, 1, 0);
+                }
+                else
+                {
+                    value.IsActive = true;
+                    Function.Call(Hash.RENDER_SCRIPT_CAMS, true, 0, 3000, 1, 0);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Fires a single bullet in the world.
+        /// </summary>
+        /// <param name="sourcePosition">Where the bullet is fired from.</param>
+        /// <param name="targetPosition">Where the bullet is fired to.</param>
+        /// <param name="owner">The <see cref="Ped"/> who fired the bullet, leave <see langword="null" /> for no one.</param>
+        /// <param name="weaponAsset">The weapon that the bullet is fired from.</param>
+        /// <param name="damage">The damage the bullet will cause.</param>
+        /// <param name="speed">The speed, only affects projectile weapons, leave -1 for default.</param>
+        [Obsolete("Use ShootSingleBullet instead."), EditorBrowsable(EditorBrowsableState.Never)]
+        public static void ShootBullet(Vector3 sourcePosition, Vector3 targetPosition, Ped owner, WeaponAsset weaponAsset, int damage, float speed = -1f)
+        {
+            Function.Call(Hash.SHOOT_SINGLE_BULLET_BETWEEN_COORDS, sourcePosition.X, sourcePosition.Y, sourcePosition.Z, targetPosition.X, targetPosition.Y, targetPosition.Z, damage, 1, weaponAsset.Hash, (owner == null ? 0 : owner.Handle), 1, 0, speed);
+        }
+
+        /// <summary>
+        /// Creates a 3D raycast between 2 points.
+        /// </summary>
+        /// <param name="source">The source of the raycast.</param>
+        /// <param name="target">The target of the raycast.</param>
+        /// <param name="radius">The radius of the raycast.</param>
+        /// <param name="options">What type of objects the raycast should intersect with.</param>
+        /// <param name="ignoreEntity">Specify an <see cref="Entity"/> that the raycast should ignore, leave null for no entities ignored.</param>
+        [Obsolete("World.RaycastCapsule is obsolete because the result may not be made in the same frame you call the method. " +
+                  "Use ShapeTest.StartTestCapsule instead."), EditorBrowsable(EditorBrowsableState.Never)]
+        public static RaycastResult RaycastCapsule(Vector3 source, Vector3 target, float radius, IntersectFlags options, Entity ignoreEntity = null)
+        {
+            return new RaycastResult(Function.Call<int>(Hash.START_SHAPE_TEST_CAPSULE,
+                source.X,
+                source.Y,
+                source.Z,
+                target.X,
+                target.Y,
+                target.Z,
+                radius,
+                (int)options,
+                ignoreEntity == null
+                    ? 0
+                    : ignoreEntity.Handle,
+                7));
+        }
+        /// <summary>
+        /// Creates a 3D raycast between 2 points.
+        /// </summary>
+        /// <param name="source">The source of the raycast.</param>
+        /// <param name="direction">The direction of the raycast.</param>
+        /// <param name="radius">The radius of the raycast.</param>
+        /// <param name="maxDistance">How far the raycast should go out to.</param>
+        /// <param name="options">What type of objects the raycast should intersect with.</param>
+        /// <param name="ignoreEntity">Specify an <see cref="Entity"/> that the raycast should ignore, leave null for no entities ignored.</param>
+        [Obsolete("World.RaycastCapsule is obsolete because the result may not be made in the same frame you call the method. " +
+                  "Use ShapeTest.StartTestCapsule instead."), EditorBrowsable(EditorBrowsableState.Never)]
+        public static RaycastResult RaycastCapsule(Vector3 source, Vector3 direction, float maxDistance, float radius, IntersectFlags options, Entity ignoreEntity = null)
+        {
+            Vector3 target = source + direction * maxDistance;
+
+            return new RaycastResult(Function.Call<int>(Hash.START_SHAPE_TEST_CAPSULE,
+                source.X,
+                source.Y,
+                source.Z,
+                target.X,
+                target.Y,
+                target.Z,
+                radius,
+                (int)options,
+                ignoreEntity == null
+                    ? 0
+                    : ignoreEntity.Handle,
+                7));
+        }
+
+        /// <summary>
+        /// Gets the height of the ground at a given position.
+        /// </summary>
+        /// <param name="position">The position.</param>
+        /// <returns>The height measured in meters</returns>
+        [Obsolete("Use GetGroundHeight(Vector3, out float, GetGroundHeightMode) instead."),
+        EditorBrowsable(EditorBrowsableState.Never)]
+        public static float GetGroundHeight(Vector2 position)
+        {
+            return GetGroundHeight(new Vector3(position.X, position.Y, 1000f));
+        }
+
+        /// <summary>
+        /// Gets the height of the ground at a given position.
+        /// Note : If the Vector3 is already below the ground, this will return 0.
+        /// You may want to use the other overloaded function to be safe.
+        /// </summary>
+        /// <param name="position">The position.</param>
+        /// <returns>The height measured in meters</returns>
+        [Obsolete("Use GetGroundHeight(Vector3, out float, GetGroundHeightMode) instead."),
+        EditorBrowsable(EditorBrowsableState.Never)]
+        public static float GetGroundHeight(Vector3 position)
+        {
+            float resultArg;
+            unsafe
+            {
+                Function.Call(Hash.GET_GROUND_Z_FOR_3D_COORD, position.X, position.Y, position.Z, &resultArg, false);
+            }
+            return resultArg;
+        }
+
+        /// <summary>
+        /// Gets the nearest safe coordinate to position a <see cref="Ped"/>.
+        /// </summary>
+        /// <param name="position">The position to check around.</param>
+        /// <param name="sidewalk">if set to <see langword="true" /> Only find positions on the sidewalk.</param>
+        /// <param name="flags">The flags.</param>
+        [Obsolete("World.GetSafeCoordForPed is obsolete since there is no way to check if the method is failed while GET_SAFE_COORD_FOR_PED provides one." +
+        "Use GetSafePositionForPed instead."), EditorBrowsable(EditorBrowsableState.Never)]
+        public static Vector3 GetSafeCoordForPed(Vector3 position, bool sidewalk = true, int flags = 0)
+        {
+            NativeVector3 outPos;
+            unsafe
+            {
+                if (Function.Call<bool>(Hash.GET_SAFE_COORD_FOR_PED, position.X, position.Y, position.Z, sidewalk, &outPos, flags))
+                {
+                    return outPos;
+                }
+            }
+            return Vector3.Zero;
+        }
+    }
+}

--- a/source/scripting_v3/GTA/World.cs
+++ b/source/scripting_v3/GTA/World.cs
@@ -16,7 +16,7 @@ using Random = System.Random;
 
 namespace GTA
 {
-    public static class World
+    public static partial class World
     {
         #region Fields
 
@@ -24,94 +24,6 @@ namespace GTA
 
         // removes gang and animal ped models just like CREATE_RANDOM_PED does
         static readonly Func<Model, bool> s_defaultPredicateForCreateRandomPed = (x => x.IsHumanPed && !x.IsGangPed);
-        #endregion
-
-        #region Time & Day
-
-        /// <inheritdoc cref="GTA.Chrono.GameClock.IsPaused"/>
-        [Obsolete("World.IsClockPaused is obsolete, use GTA.Chrono.IsPaused instead.")]
-        public static bool IsClockPaused
-        {
-            get => SHVDN.NativeMemory.IsClockPaused;
-            set => Function.Call(Hash.PAUSE_CLOCK, value);
-        }
-
-        /// <summary>
-        /// Pauses or resumes the in-game clock.
-        /// </summary>
-        /// <param name="value">Pauses the game clock if set to <see langword="true" />; otherwise, resumes the game clock.</param>
-        [Obsolete("The World.PauseClock is obsolete, use GTA.Chrono.IsPaused instead.")]
-        public static void PauseClock(bool value)
-        {
-            IsClockPaused = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the current date and time in the GTA world.
-        /// </summary>
-        /// <value>
-        /// The current date and time.
-        /// </value>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// The internal date is not valid for the Gregorian calendar or the internal time of day is not normalized.
-        /// </exception>
-        [Obsolete("World.CurrentDate is obsolete because DateTime can represent the years only in the range of 1 to 9999, while the game supports wider range of years." +
-            "Use properties or methods of GTA.Chrono.GameClock instead."), EditorBrowsable(EditorBrowsableState.Never)]
-        public static DateTime CurrentDate
-        {
-            get
-            {
-                int year = Function.Call<int>(Hash.GET_CLOCK_YEAR);
-                int month = Function.Call<int>(Hash.GET_CLOCK_MONTH) + 1;
-                int day = System.Math.Min(Function.Call<int>(Hash.GET_CLOCK_DAY_OF_MONTH), s_calendar.GetDaysInMonth(year, month));
-                int hour = Function.Call<int>(Hash.GET_CLOCK_HOURS);
-                int minute = Function.Call<int>(Hash.GET_CLOCK_MINUTES);
-                int second = Function.Call<int>(Hash.GET_CLOCK_SECONDS);
-
-                return new DateTime(year, month, day, hour, minute, second);
-            }
-            set
-            {
-                Function.Call(Hash.SET_CLOCK_DATE, value.Day, value.Month - 1, value.Year);
-                Function.Call(Hash.SET_CLOCK_TIME, value.Hour, value.Minute, value.Second);
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the current time of day in the GTA world.
-        /// </summary>
-        /// <value>
-        /// The current time of day.
-        /// </value>
-        /// <exception cref="ArgumentOutOfRangeException">
-        /// One of the values minutes or seconds are smaller than <c>0</c> or larger than <c>59</c>, or the hour value
-        /// is smaller than <c>0</c> or larger than <c>23</c>.
-        /// </exception>
-        /// <remarks>
-        /// The resolution of the value is 1 second.
-        /// </remarks>
-        [Obsolete("World.CurrentTimeOfDay is obsolete, use GTA.Chrono.GameClock.Today instead.")]
-        public static TimeSpan CurrentTimeOfDay
-        {
-            get
-            {
-                int hours = Function.Call<int>(Hash.GET_CLOCK_HOURS);
-                int minutes = Function.Call<int>(Hash.GET_CLOCK_MINUTES);
-                int seconds = Function.Call<int>(Hash.GET_CLOCK_SECONDS);
-
-                return new TimeSpan(hours, minutes, seconds);
-            }
-            set => Function.Call(Hash.SET_CLOCK_TIME, value.Hours, value.Minutes, value.Seconds);
-        }
-
-        /// <inheritdoc cref="GTA.Chrono.GameClock.MillisecondsPerGameMinute"/>
-        [Obsolete("World.MillisecondsPerGameMinute is obsolete, use GTA.Chrono.GameClock.MillisecondsPerGameMinute instead.")]
-        public static int MillisecondsPerGameMinute
-        {
-            get => Function.Call<int>(Hash.GET_MILLISECONDS_PER_GAME_MINUTE);
-            set => SHVDN.NativeMemory.MillisecondsPerGameMinute = value;
-        }
-
         #endregion
 
         #region Weather & Effects
@@ -1403,15 +1315,6 @@ namespace GTA
             return handle == 0 ? null : new Prop(handle);
         }
 
-        /// <summary>
-        /// Creates a pickup <see cref="Prop"/> similar to those dropped by dead <see cref="Ped"/>s.
-        /// These types of pickups are part of the ambient population and will get removed if the player moves too far away from them.
-        /// </summary>
-        [Obsolete("The World.CreateAmbientPickup overload with non-optional custom model and amount (named \"value\") parameters are obsolete since they can lead to confusion in custom model parameter (which is actually not mandatory)." +
-            "Use World.CreateAmbientPickup(PickupType, Vector3, PickupPlacementFlags, int, Model, bool) instead.")]
-        public static Prop CreateAmbientPickup(PickupType type, Vector3 position, Model model, int value)
-            => CreateAmbientPickup(type, position, PickupPlacementFlags.None, value, model, false);
-
         /// <inheritdoc cref="CreatePickup(PickupType, Vector3, Vector3, PickupPlacementFlags, int, EulerRotationOrder, Model)"/>
         public static Pickup CreatePickup(
             PickupType type,
@@ -1488,23 +1391,6 @@ namespace GTA
             return handle == 0 ? null : new Pickup(handle);
         }
 
-        /// <summary>
-        /// Spawns a <see cref="Pickup"/> at the specified position.
-        /// </summary>
-        [Obsolete("The World.CreatePickup overloads with non-optional custom model and amount (named \"value\") parameters are obsolete since they can lead to confusion in custom model parameter (which is actually not mandatory)." +
-            "Use a World.CreatePickup overload with optional placement flags and amount parameters instead."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public static Pickup CreatePickup(PickupType type, Vector3 position, Model model, int value)
-            => CreatePickup(type, position, PickupPlacementFlags.None, value, model);
-        /// <summary>
-        /// Spawns a <see cref="Pickup"/> at the specified position.
-        /// </summary>
-        [Obsolete("The World.CreatePickup overloads with non-optional custom model and amount (named \"value\") parameters are obsolete since they can lead to confusion in custom model parameter (which is actually not mandatory)." +
-            "Use a World.CreatePickup overload with optional placement flags and amount parameters instead."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public static Pickup CreatePickup(PickupType type, Vector3 position, Vector3 rotation, Model model, int value)
-            => CreatePickup(type, position, rotation, PickupPlacementFlags.None, value, EulerRotationOrder.YXZ, model);
-
         #endregion
 
         #region Checkpoints
@@ -1570,72 +1456,6 @@ namespace GTA
                 color.A,
                 icon);
             return handle != 0 ? new Checkpoint(handle) : null;
-        }
-
-        #endregion
-
-        #region Cameras
-
-        /// <summary>
-        /// Destroys all scripted <see cref="Camera"/>s.
-        /// </summary>
-        [Obsolete("World.DestroyAllCameras is obsolete. Use Camera.DeleteAllCameras instead."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public static void DestroyAllCameras()
-        {
-            Function.Call(Hash.DESTROY_ALL_CAMS, 0);
-        }
-
-        /// <summary>
-        /// Creates a <see cref="Camera"/>, use <see cref="ScriptCameraDirector.StartRendering()"/> to switch to
-        /// this camera.
-        /// </summary>
-        /// <param name="position">The position of the camera.</param>
-        /// <param name="rotation">The rotation of the camera.</param>
-        /// <param name="fov">The field of view of the camera.</param>
-        /// <remarks>
-        /// This overload (<see cref="World.CreateCamera(Vector3, Vector3, float)"/>) does not return <see langword="null"/>
-        /// even if the method fails to create and <c>CREATE_CAM_WITH_PARAMS</c> returns -1 due to the camera pool being full.
-        /// This is done for compatibility for scripts built against v3.6.0 or earlier.
-        /// </remarks>
-        [Obsolete("World.CreateCamera is obsolete. Use Camera.Create instead."),
-         EditorBrowsable(EditorBrowsableState.Never)]
-        public static Camera CreateCamera(Vector3 position, Vector3 rotation, float fov)
-        {
-            return new Camera(Function.Call<int>(Hash.CREATE_CAM_WITH_PARAMS, "DEFAULT_SCRIPTED_CAMERA", position.X, position.Y, position.Z, rotation.X, rotation.Y, rotation.Z, fov, 1, 2));
-        }
-
-        /// <summary>
-        /// Gets or sets the rendering camera.
-        /// </summary>
-        /// <value>
-        /// The rendering <see cref="Camera"/>.
-        /// </value>
-        /// <remarks>
-        /// Setting to <see langword="null" /> sets the rendering <see cref="Camera"/> to <see cref="GameplayCamera"/>.
-        /// The getter will return an invalid <see cref="Camera"/> where <see cref="PoolObject.Handle"/> is -1 if the
-        /// rendering camera does not match any scripted cameras the scripted camera director is managing.
-        /// </remarks>
-        [Obsolete("World.RenderingCamera is obsolete. " +
-            "Use ScriptCameraDirector.RenderingCam to get the rendering scripted camera. " +
-            "Use ScriptCameraDirector.StartRendering or ScriptCameraDirector.StopRendering to tell the game to render " +
-            "or stop rendering a scripted camera."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public static Camera RenderingCamera
-        {
-            get => new(Function.Call<int>(Hash.GET_RENDERING_CAM));
-            set
-            {
-                if (value == null)
-                {
-                    Function.Call(Hash.RENDER_SCRIPT_CAMS, false, 0, 3000, 1, 0);
-                }
-                else
-                {
-                    value.IsActive = true;
-                    Function.Call(Hash.RENDER_SCRIPT_CAMS, true, 0, 3000, 1, 0);
-                }
-            }
         }
 
         #endregion
@@ -1968,20 +1788,6 @@ namespace GTA
                 0));
         }
 
-        /// <summary>
-        /// Fires a single bullet in the world.
-        /// </summary>
-        /// <param name="sourcePosition">Where the bullet is fired from.</param>
-        /// <param name="targetPosition">Where the bullet is fired to.</param>
-        /// <param name="owner">The <see cref="Ped"/> who fired the bullet, leave <see langword="null" /> for no one.</param>
-        /// <param name="weaponAsset">The weapon that the bullet is fired from.</param>
-        /// <param name="damage">The damage the bullet will cause.</param>
-        /// <param name="speed">The speed, only affects projectile weapons, leave -1 for default.</param>
-        [Obsolete("Use ShootSingleBullet instead."), EditorBrowsable(EditorBrowsableState.Never)]
-        public static void ShootBullet(Vector3 sourcePosition, Vector3 targetPosition, Ped owner, WeaponAsset weaponAsset, int damage, float speed = -1f)
-        {
-            Function.Call(Hash.SHOOT_SINGLE_BULLET_BETWEEN_COORDS, sourcePosition.X, sourcePosition.Y, sourcePosition.Z, targetPosition.X, targetPosition.Y, targetPosition.Z, damage, 1, weaponAsset.Hash, (owner == null ? 0 : owner.Handle), 1, 0, speed);
-        }
         /// <summary>
         /// Fires an instant hit bullet between the two points or a projectile that goes toward
         /// <paramref name="endPosition"/>.
@@ -2485,62 +2291,6 @@ namespace GTA
         }
 
         /// <summary>
-        /// Creates a 3D raycast between 2 points.
-        /// </summary>
-        /// <param name="source">The source of the raycast.</param>
-        /// <param name="target">The target of the raycast.</param>
-        /// <param name="radius">The radius of the raycast.</param>
-        /// <param name="options">What type of objects the raycast should intersect with.</param>
-        /// <param name="ignoreEntity">Specify an <see cref="Entity"/> that the raycast should ignore, leave null for no entities ignored.</param>
-        [Obsolete("World.RaycastCapsule is obsolete because the result may not be made in the same frame you call the method. " +
-                  "Use ShapeTest.StartTestCapsule instead."), EditorBrowsable(EditorBrowsableState.Never)]
-        public static RaycastResult RaycastCapsule(Vector3 source, Vector3 target, float radius, IntersectFlags options, Entity ignoreEntity = null)
-        {
-            return new RaycastResult(Function.Call<int>(Hash.START_SHAPE_TEST_CAPSULE,
-                source.X,
-                source.Y,
-                source.Z,
-                target.X,
-                target.Y,
-                target.Z,
-                radius,
-                (int)options,
-                ignoreEntity == null
-                    ? 0
-                    : ignoreEntity.Handle,
-                7));
-        }
-        /// <summary>
-        /// Creates a 3D raycast between 2 points.
-        /// </summary>
-        /// <param name="source">The source of the raycast.</param>
-        /// <param name="direction">The direction of the raycast.</param>
-        /// <param name="radius">The radius of the raycast.</param>
-        /// <param name="maxDistance">How far the raycast should go out to.</param>
-        /// <param name="options">What type of objects the raycast should intersect with.</param>
-        /// <param name="ignoreEntity">Specify an <see cref="Entity"/> that the raycast should ignore, leave null for no entities ignored.</param>
-        [Obsolete("World.RaycastCapsule is obsolete because the result may not be made in the same frame you call the method. " +
-                  "Use ShapeTest.StartTestCapsule instead."), EditorBrowsable(EditorBrowsableState.Never)]
-        public static RaycastResult RaycastCapsule(Vector3 source, Vector3 direction, float maxDistance, float radius, IntersectFlags options, Entity ignoreEntity = null)
-        {
-            Vector3 target = source + direction * maxDistance;
-
-            return new RaycastResult(Function.Call<int>(Hash.START_SHAPE_TEST_CAPSULE,
-                source.X,
-                source.Y,
-                source.Z,
-                target.X,
-                target.Y,
-                target.Z,
-                radius,
-                (int)options,
-                ignoreEntity == null
-                    ? 0
-                    : ignoreEntity.Handle,
-                7));
-        }
-
-        /// <summary>
         /// Determines where the crosshair intersects with the world.
         /// </summary>
         /// <returns>A <see cref="RaycastResult"/> containing information about where the crosshair intersects with the world.</returns>
@@ -2722,36 +2472,6 @@ namespace GTA
         }
 
         /// <summary>
-        /// Gets the height of the ground at a given position.
-        /// </summary>
-        /// <param name="position">The position.</param>
-        /// <returns>The height measured in meters</returns>
-        [Obsolete("Use GetGroundHeight(Vector3, out float, GetGroundHeightMode) instead."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public static float GetGroundHeight(Vector2 position)
-        {
-            return GetGroundHeight(new Vector3(position.X, position.Y, 1000f));
-        }
-        /// <summary>
-        /// Gets the height of the ground at a given position.
-        /// Note : If the Vector3 is already below the ground, this will return 0.
-        /// You may want to use the other overloaded function to be safe.
-        /// </summary>
-        /// <param name="position">The position.</param>
-        /// <returns>The height measured in meters</returns>
-        [Obsolete("Use GetGroundHeight(Vector3, out float, GetGroundHeightMode) instead."),
-        EditorBrowsable(EditorBrowsableState.Never)]
-        public static float GetGroundHeight(Vector3 position)
-        {
-            float resultArg;
-            unsafe
-            {
-                Function.Call(Hash.GET_GROUND_Z_FOR_3D_COORD, position.X, position.Y, position.Z, &resultArg, false);
-            }
-            return resultArg;
-        }
-
-        /// <summary>
         /// Returns an approximate height at the 2d coordinate in meters.
         /// This is based on a coarse grid compiled from collision data.
         /// </summary>
@@ -2813,27 +2533,6 @@ namespace GTA
                 safePosition = outPos;
                 return foundSafePos;
             }
-        }
-
-        /// <summary>
-        /// Gets the nearest safe coordinate to position a <see cref="Ped"/>.
-        /// </summary>
-        /// <param name="position">The position to check around.</param>
-        /// <param name="sidewalk">if set to <see langword="true" /> Only find positions on the sidewalk.</param>
-        /// <param name="flags">The flags.</param>
-        [Obsolete("World.GetSafeCoordForPed is obsolete since there is no way to check if the method is failed while GET_SAFE_COORD_FOR_PED provides one." +
-        "Use GetSafePositionForPed instead."), EditorBrowsable(EditorBrowsableState.Never)]
-        public static Vector3 GetSafeCoordForPed(Vector3 position, bool sidewalk = true, int flags = 0)
-        {
-            NativeVector3 outPos;
-            unsafe
-            {
-                if (Function.Call<bool>(Hash.GET_SAFE_COORD_FOR_PED, position.X, position.Y, position.Z, sidewalk, &outPos, flags))
-                {
-                    return outPos;
-                }
-            }
-            return Vector3.Zero;
         }
 
         /// <summary>


### PR DESCRIPTION
This PR moves obsolete members into separate files using partial classes.
Since partial class definitions are combined at compile time, this change is non-breaking.