### PR TITLE
 docs(api-v3): fix typo in `Player` class

### DIFF
--- a/source/scripting_v3/GTA/Player.cs
+++ b/source/scripting_v3/GTA/Player.cs
@@ -586,7 +586,7 @@ namespace GTA
         #endregion
 
         /// <summary>
-        /// Gets or sets the maximum amount of armor this <see cref="Player"/> can have.
+        /// Gets or sets the maximum amount of health this <see cref="Player"/> can have.
         /// The value range is between 0 and 65535.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
**Changes:**

- Updated the documentation comment for a property in the `Player` class within the `GTA` namespace to correctly refer to the "maximum amount of health" instead of the "maximum amount of armor."

No functional changes.