### PR TITLE
refactor(api-v3): use explicit warning code CS1591 in `NoWarn` element

### DIFF
--- a/source/scripting_v3/ScriptHookVDotNet_APIv3.csproj
+++ b/source/scripting_v3/ScriptHookVDotNet_APIv3.csproj
@@ -11,7 +11,7 @@
     <TargetFramework>net48</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <Platforms>x64</Platforms>
-    <NoWarn>1591</NoWarn>
+    <NoWarn>CS1591</NoWarn>
     <DebugType>full</DebugType>
     <ErrorReport>prompt</ErrorReport>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
**Changes:**

- The `<NoWarn>` element in the project file was updated to use the explicit compiler warning code `CS1591` instead of the numeric value `1591`.

No functional changes.