### PR TITLE
refactor(api-v3): remove redundant variable initializations

### DIFF
--- a/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs
@@ -1993,7 +1993,7 @@ namespace GTA
             get => Function.Call<VehicleLandingGearState>(Hash.GET_LANDING_GEAR_STATE, Handle);
             set
             {
-                int state = 0;
+                int state;
                 switch (value)
                 {
                     case VehicleLandingGearState.Deploying:

--- a/source/scripting_v3/GTA/Entities/Vehicles/VehicleMod.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/VehicleMod.cs
@@ -231,7 +231,7 @@ namespace GTA
                     Function.Call(Hash.CLEAR_ADDITIONAL_TEXT, 10, true);
                     Function.Call(Hash.REQUEST_ADDITIONAL_TEXT, "mod_mnu", 10);
                 }
-                string cur = string.Empty;
+                string cur;
                 switch (Type)
                 {
                     case VehicleModType.Armor:

--- a/source/scripting_v3/GTA/Shvdn/Script/ScriptSettings.cs
+++ b/source/scripting_v3/GTA/Shvdn/Script/ScriptSettings.cs
@@ -44,9 +44,9 @@ namespace GTA
                 return result;
             }
 
-            string line = null;
+            string line;
             string tempSectionName = string.Empty;
-            StreamReader reader = null;
+            StreamReader reader;
 
             try
             {
@@ -134,8 +134,7 @@ namespace GTA
                 }
             }
 
-            StreamWriter writer = null;
-
+            StreamWriter writer;
             try
             {
                 writer = File.CreateText(_fileName);


### PR DESCRIPTION
**Changes:**

- Eliminated unnecessary default initializations for local variables in `Vehicle`, `VehicleMod` and `ScriptSettings`.
- Variables are now declared without assignment and initialized only when needed, improving clarity and reducing redundancy.

No functional changes applied.