### PR TITLE
refactor(api-v3): remove unused using directives across codebase

### DIFF
--- a/source/scripting_v3/GTA.Chrono/FormattingHelpers.cs
+++ b/source/scripting_v3/GTA.Chrono/FormattingHelpers.cs
@@ -1,11 +1,9 @@
-﻿//
+//
 // Copyright (C) 2024 kagikn & contributors
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
-using System;
 using System.Diagnostics;
-using System.Globalization;
 using System.Runtime.CompilerServices;
 
 namespace GTA.Chrono

--- a/source/scripting_v3/GTA.Chrono/NumberFormatting.cs
+++ b/source/scripting_v3/GTA.Chrono/NumberFormatting.cs
@@ -1,12 +1,10 @@
-﻿//
+//
 // Copyright (C) 2024 kagikn & contributors
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
 using System.Diagnostics;
 using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
 
 namespace GTA.Chrono
 {

--- a/source/scripting_v3/GTA.UI/Notification.cs
+++ b/source/scripting_v3/GTA.UI/Notification.cs
@@ -3,8 +3,6 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
-using System;
-using System.ComponentModel;
 using GTA.Graphics;
 using GTA.Native;
 

--- a/source/scripting_v3/GTA.UI/TextElement.Obsolete.cs
+++ b/source/scripting_v3/GTA.UI/TextElement.Obsolete.cs
@@ -1,9 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace GTA.UI
 {

--- a/source/scripting_v3/GTA.UI/TextElement.cs
+++ b/source/scripting_v3/GTA.UI/TextElement.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Text;

--- a/source/scripting_v3/GTA/Audio.Obsolete.cs
+++ b/source/scripting_v3/GTA/Audio.Obsolete.cs
@@ -1,9 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using GTA.Math;
 using GTA.Native;
 

--- a/source/scripting_v3/GTA/Audio.cs
+++ b/source/scripting_v3/GTA/Audio.cs
@@ -3,8 +3,6 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
-using System;
-using System.ComponentModel;
 using GTA.Math;
 using GTA.Native;
 

--- a/source/scripting_v3/GTA/Blip/Blip.cs
+++ b/source/scripting_v3/GTA/Blip/Blip.cs
@@ -4,7 +4,6 @@
 //
 
 using System;
-using System.ComponentModel;
 using System.Drawing;
 using GTA.Math;
 using GTA.Native;

--- a/source/scripting_v3/GTA/Camera/CamAnimationFlags.cs
+++ b/source/scripting_v3/GTA/Camera/CamAnimationFlags.cs
@@ -4,7 +4,6 @@
 //
 
 using System;
-using System.ComponentModel;
 
 namespace GTA
 {

--- a/source/scripting_v3/GTA/Camera/CamSplineSmoothingMode.cs
+++ b/source/scripting_v3/GTA/Camera/CamSplineSmoothingMode.cs
@@ -3,8 +3,6 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
-using System;
-
 namespace GTA
 {
     /// <summary>

--- a/source/scripting_v3/GTA/Camera/Camera.Obsolete.cs
+++ b/source/scripting_v3/GTA/Camera/Camera.Obsolete.cs
@@ -1,9 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using GTA.Native;
 
 namespace GTA

--- a/source/scripting_v3/GTA/Camera/Camera.cs
+++ b/source/scripting_v3/GTA/Camera/Camera.cs
@@ -6,7 +6,6 @@
 using GTA.Math;
 using GTA.Native;
 using System;
-using System.ComponentModel;
 
 namespace GTA
 {

--- a/source/scripting_v3/GTA/Camera/GameplayCamera.cs
+++ b/source/scripting_v3/GTA/Camera/GameplayCamera.cs
@@ -6,7 +6,6 @@
 using GTA.Math;
 using GTA.Native;
 using System;
-using System.ComponentModel;
 
 namespace GTA
 {

--- a/source/scripting_v3/GTA/CheckpointCustomIcon.cs
+++ b/source/scripting_v3/GTA/CheckpointCustomIcon.cs
@@ -4,7 +4,6 @@
 //
 
 using GTA.Native;
-using System;
 
 namespace GTA
 {

--- a/source/scripting_v3/GTA/CrClipAsset.cs
+++ b/source/scripting_v3/GTA/CrClipAsset.cs
@@ -4,7 +4,6 @@
 //
 
 using System;
-using System.Xml.Linq;
 
 namespace GTA
 {

--- a/source/scripting_v3/GTA/Entities/Entity.cs
+++ b/source/scripting_v3/GTA/Entities/Entity.cs
@@ -6,7 +6,6 @@
 using GTA.Math;
 using GTA.Native;
 using System;
-using System.ComponentModel;
 using System.Linq;
 
 namespace GTA

--- a/source/scripting_v3/GTA/Entities/EntityDamageRecordCollection.cs
+++ b/source/scripting_v3/GTA/Entities/EntityDamageRecordCollection.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using SHVDN;
 
 namespace GTA
 {

--- a/source/scripting_v3/GTA/Entities/Peds/LookAtPriority.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/LookAtPriority.cs
@@ -3,8 +3,6 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
-using System;
-
 namespace GTA
 {
     /// <summary>

--- a/source/scripting_v3/GTA/Entities/Peds/Ped.Obsolete.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Ped.Obsolete.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using GTA.Native;
 

--- a/source/scripting_v3/GTA/Entities/Peds/Ped.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Ped.cs
@@ -7,7 +7,6 @@ using GTA.Math;
 using GTA.Native;
 using GTA.NaturalMotion;
 using System;
-using System.ComponentModel;
 using System.Linq;
 
 namespace GTA

--- a/source/scripting_v3/GTA/Entities/Peds/PedComponent.Obsolete.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/PedComponent.Obsolete.cs
@@ -1,9 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace GTA
 {

--- a/source/scripting_v3/GTA/Entities/Peds/PedComponent.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/PedComponent.cs
@@ -3,8 +3,6 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
-using System;
-using System.ComponentModel;
 using GTA.Native;
 
 namespace GTA

--- a/source/scripting_v3/GTA/Entities/Peds/PedProp.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/PedProp.cs
@@ -4,8 +4,6 @@
 //
 
 using GTA.Native;
-using System;
-using System.ComponentModel;
 
 namespace GTA
 {

--- a/source/scripting_v3/GTA/Entities/Peds/Style.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Style.cs
@@ -4,9 +4,7 @@
 //
 
 using GTA.Native;
-using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 
 namespace GTA
 {

--- a/source/scripting_v3/GTA/Entities/Peds/Task/TaskInvoker.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Task/TaskInvoker.cs
@@ -6,7 +6,6 @@
 using GTA.Math;
 using GTA.Native;
 using System;
-using System.ComponentModel;
 
 namespace GTA
 {

--- a/source/scripting_v3/GTA/Entities/Peds/Task/TaskMoVEScriptedInitialParameters.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Task/TaskMoVEScriptedInitialParameters.cs
@@ -3,7 +3,6 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
-using GTA.Native;
 using System;
 using System.Runtime.InteropServices;
 

--- a/source/scripting_v3/GTA/Entities/Projectile.cs
+++ b/source/scripting_v3/GTA/Entities/Projectile.cs
@@ -4,7 +4,6 @@
 //
 
 using System;
-using System.ComponentModel;
 
 namespace GTA
 {

--- a/source/scripting_v3/GTA/Entities/Vehicles/VehicleWheel.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/VehicleWheel.cs
@@ -7,7 +7,6 @@ using GTA.Math;
 using GTA.Native;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 
 namespace GTA
 {

--- a/source/scripting_v3/GTA/Game.Obsolete.cs
+++ b/source/scripting_v3/GTA/Game.Obsolete.cs
@@ -1,9 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using GTA.Native;
 
 namespace GTA

--- a/source/scripting_v3/GTA/Game.cs
+++ b/source/scripting_v3/GTA/Game.cs
@@ -5,8 +5,6 @@
 
 using GTA.Native;
 using System;
-using System.ComponentModel;
-using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using System.Windows.Forms;

--- a/source/scripting_v3/GTA/GameVersionNotSupportedException.cs
+++ b/source/scripting_v3/GTA/GameVersionNotSupportedException.cs
@@ -8,8 +8,6 @@ using System.Runtime.Serialization;
 using System.Security.Permissions;
 using System.Text;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
-using System.ComponentModel;
 
 namespace GTA
 {

--- a/source/scripting_v3/GTA/VehicleAi/Task/ParkType.cs
+++ b/source/scripting_v3/GTA/VehicleAi/Task/ParkType.cs
@@ -3,8 +3,6 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
-using System;
-
 namespace GTA
 {
     /// <summary>

--- a/source/scripting_v3/GTA/VehicleAi/Task/VehicleEscortType.cs
+++ b/source/scripting_v3/GTA/VehicleAi/Task/VehicleEscortType.cs
@@ -3,8 +3,6 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
-using System;
-
 namespace GTA
 {
     /// <summary>

--- a/source/scripting_v3/GTA/Weapons/WeaponComponentCollection.cs
+++ b/source/scripting_v3/GTA/Weapons/WeaponComponentCollection.cs
@@ -3,9 +3,7 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
-using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 
 namespace GTA

--- a/source/scripting_v3/GTA/Weapons/WeaponHudStats.cs
+++ b/source/scripting_v3/GTA/Weapons/WeaponHudStats.cs
@@ -1,4 +1,3 @@
-using GTA.Math;
 using SHVDN;
 
 namespace GTA

--- a/source/scripting_v3/GTA/World.cs
+++ b/source/scripting_v3/GTA/World.cs
@@ -8,7 +8,6 @@ using GTA.Math;
 using GTA.Native;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Drawing;
 using System.Globalization;
 using System.Linq;


### PR DESCRIPTION
**Changes:**

- Cleaned up unnecessary using statements, notably `System.ComponentModel` and other unused namespaces, from multiple files.
- This reduces code clutter and improves maintainability without impacting functionality.