### PR TITLE
feat(api-v3)!: use get-only properties in `WeaponHudStats`

### DIFF
--- a/source/scripting_v3/GTA/Weapons/WeaponHudStats.cs
+++ b/source/scripting_v3/GTA/Weapons/WeaponHudStats.cs
@@ -13,27 +13,27 @@ namespace GTA
         /// <summary>
         /// Weapon damage as displayed in the HUD.
         /// </summary>
-        public int Damage;
+        public int Damage { get; }
 
         /// <summary>
         /// Weapon firing speed as displayed in the HUD.
         /// </summary>
-        public int Speed;
+        public int Speed { get; }
 
         /// <summary>
         /// Weapon clip/magazine capacity as displayed in the HUD.
         /// </summary>
-        public int Capacity;
+        public int Capacity { get; }
 
         /// <summary>
         /// Weapon accuracy as displayed in the HUD.
         /// </summary>
-        public int Accuracy;
+        public int Accuracy { get; }
 
         /// <summary>
         /// Effective range of the weapon as displayed in the HUD.
         /// </summary>
-        public int Range;
+        public int Range { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WeaponHudStats"/> struct.


### PR DESCRIPTION
The values in an `WeaponHudStats` instance generally retrieved by `GET_WEAPON_HUD_STATS` should be readonly as we can't override the actual values on the hud.

This struct was added by me in https://github.com/Tivertoni/ScripthookV.NET/commit/0c69ac7f5997f520bbd847d2e9b509f74531e73c during nightly so this does not break binary compatiblity with stable versions.