### PR TITLE
refactor(api-v3): rename parameter to match base declaration

### DIFF
--- a/source/scripting_v3/GTA.Chrono/GameClockDate.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDate.cs
@@ -966,19 +966,19 @@ namespace GTA.Chrono
         /// <see cref="GameClockDate"/> value, and returns an integer that indicates whether this instance is earlier
         /// than, the same as, or later than the specified <see cref="GameClockDate"/> value.
         /// </summary>
-        /// <param name="value">A boxed object to compare, or <see langword="null"/>.</param>
+        /// <param name="obj">A boxed object to compare, or <see langword="null"/>.</param>
         /// <returns>
         /// A signed number indicating the relative values of this instance and the value parameter. Less than zero if
         /// this instance is earlier than value. Zero if this instance is the same as value. Greater than zero if this
         /// instance is later than value.
         /// </returns>
         /// <exception cref="ArgumentException">
-        /// <paramref name="value"/> is not a <see cref="GameClockDate"/>.
+        /// <paramref name="obj"/> is not a <see cref="GameClockDate"/>.
         /// </exception>
-        public int CompareTo(object value)
+        public int CompareTo(object obj)
         {
-            if (value == null) return 1;
-            if (value is not GameClockDate otherDuration)
+            if (obj == null) return 1;
+            if (obj is not GameClockDate otherDuration)
                 throw new ArgumentException();
 
             return CompareTo(otherDuration);

--- a/source/scripting_v3/GTA.Chrono/GameClockDate.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDate.cs
@@ -903,14 +903,14 @@ namespace GTA.Chrono
         /// <summary>
         /// Returns a value indicating whether this instance is equal to a specified object.
         /// </summary>
-        /// <param name="value">An object to compare with this instance.</param>
+        /// <param name="obj">An object to compare with this instance.</param>
         /// <returns>
-        /// <see langword="true"/> if <paramref name="value"/> is a <see cref="GameClockDate"/> object that represents
+        /// <see langword="true"/> if <paramref name="obj"/> is a <see cref="GameClockDate"/> object that represents
         /// the same game clock date as the current <see cref="GameClockDate"/> structure; otherwise, false.
         /// </returns>
-        public override bool Equals(object value)
+        public override bool Equals(object obj)
         {
-            if (value is GameClockDate duration)
+            if (obj is GameClockDate duration)
             {
                 return Equals(duration);
             }

--- a/source/scripting_v3/GTA.Chrono/GameClockDateTime.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDateTime.cs
@@ -558,15 +558,15 @@ namespace GTA.Chrono
         /// <summary>
         /// Returns a value indicating whether this instance is equal to a specified object.
         /// </summary>
-        /// <param name="value">An object to compare with this instance.</param>
+        /// <param name="obj">An object to compare with this instance.</param>
         /// <returns>
-        /// <see langword="true"/> if <paramref name="value"/> is a <see cref="GameClockDateTime"/> object that
+        /// <see langword="true"/> if <paramref name="obj"/> is a <see cref="GameClockDateTime"/> object that
         /// represents the same game clock date time as the current <see cref="GameClockDateTime"/> structure;
         /// otherwise, false.
         /// </returns>
-        public override bool Equals(object value)
+        public override bool Equals(object obj)
         {
-            if (value is GameClockDateTime duration)
+            if (obj is GameClockDateTime duration)
             {
                 return Equals(duration);
             }

--- a/source/scripting_v3/GTA.Chrono/GameClockDateTime.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDateTime.cs
@@ -627,19 +627,19 @@ namespace GTA.Chrono
         /// <see cref="GameClockDateTime"/> value, and returns an integer that indicates whether this instance is
         /// earlier than, the same as, or later than the specified <see cref="GameClockDateTime"/> value.
         /// </summary>
-        /// <param name="value">A boxed object to compare, or <see langword="null"/>.</param>
+        /// <param name="obj">A boxed object to compare, or <see langword="null"/>.</param>
         /// <returns>
         /// A signed number indicating the relative values of this instance and the value parameter. Less than zero if
         /// this instance is earlier than value. Zero if this instance is the same as value. Greater than zero if this
         /// instance is later than value.
         /// </returns>
         /// <exception cref="ArgumentException">
-        /// <paramref name="value"/> is not a <see cref="GameClockDateTime"/>.
+        /// <paramref name="obj"/> is not a <see cref="GameClockDateTime"/>.
         /// </exception>
-        public int CompareTo(object value)
+        public int CompareTo(object obj)
         {
-            if (value == null) return 1;
-            if (value is not GameClockDateTime otherDateTime)
+            if (obj == null) return 1;
+            if (obj is not GameClockDateTime otherDateTime)
                 throw new ArgumentException();
 
             return CompareTo(otherDateTime);

--- a/source/scripting_v3/GTA.Chrono/GameClockDuration.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDuration.cs
@@ -596,15 +596,15 @@ namespace GTA.Chrono
         /// <summary>
         /// Returns a value indicating whether this instance is equal to a specified object.
         /// </summary>
-        /// <param name="value">An object to compare with this instance.</param>
+        /// <param name="obj">An object to compare with this instance.</param>
         /// <returns>
-        /// <see langword="true"/> if <paramref name="value"/> is a <see cref="GameClockDuration"/> object that
+        /// <see langword="true"/> if <paramref name="obj"/> is a <see cref="GameClockDuration"/> object that
         /// represents the same game clock duration as the current <see cref="GameClockDuration"/> structure;
         /// otherwise, false.
         /// </returns>
-        public override bool Equals(object value)
+        public override bool Equals(object obj)
         {
-            if (value is GameClockDuration duration)
+            if (obj is GameClockDuration duration)
             {
                 return Equals(duration);
             }

--- a/source/scripting_v3/GTA.Chrono/GameClockDuration.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDuration.cs
@@ -179,19 +179,19 @@ namespace GTA.Chrono
         /// <see cref="GameClockDuration"/> value, and returns an integer that indicates whether this instance is
         /// less than, the same as, or greater than the specified <see cref="GameClockDuration"/> value.
         /// </summary>
-        /// <param name="value">A boxed object to compare, or <see langword="null"/>.</param>
+        /// <param name="obj">A boxed object to compare, or <see langword="null"/>.</param>
         /// <returns>
         /// A signed number indicating the relative values of this instance and the value parameter. Less than zero if
         /// this instance is less than value. Zero if this instance is the same as value. Greater than zero if this
         /// instance is greater than value.
         /// </returns>
         /// <exception cref="ArgumentException">
-        /// <paramref name="value"/> is not a <see cref="GameClockDuration"/>.
+        /// <paramref name="obj"/> is not a <see cref="GameClockDuration"/>.
         /// </exception>
-        public int CompareTo(object value)
+        public int CompareTo(object obj)
         {
-            if (value == null) return 1;
-            if (!(value is GameClockDuration otherDuration))
+            if (obj == null) return 1;
+            if (!(obj is GameClockDuration otherDuration))
                 throw new ArgumentException();
 
             long t = (otherDuration)._secs;

--- a/source/scripting_v3/GTA.Chrono/GameClockTime.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockTime.cs
@@ -244,19 +244,19 @@ namespace GTA.Chrono
         /// <see cref="GameClockTime"/> value, and returns an integer that indicates whether this instance is earlier
         /// than, the same as, or later than the specified <see cref="GameClockTime"/> value.
         /// </summary>
-        /// <param name="value">A boxed object to compare, or <see langword="null"/>.</param>
+        /// <param name="obj">A boxed object to compare, or <see langword="null"/>.</param>
         /// <returns>
         /// A signed number indicating the relative values of this instance and the value parameter. Less than zero if
         /// this instance is earlier than value. Zero if this instance is the same as value. Greater than zero if this
         /// instance is later than value.
         /// </returns>
         /// <exception cref="ArgumentException">
-        /// <paramref name="value"/> is not a <see cref="GameClockTime"/>.
+        /// <paramref name="obj"/> is not a <see cref="GameClockTime"/>.
         /// </exception>
-        public int CompareTo(object value)
+        public int CompareTo(object obj)
         {
-            if (value == null) return 1;
-            if (value is not GameClockTime otherTime)
+            if (obj == null) return 1;
+            if (obj is not GameClockTime otherTime)
                 throw new ArgumentException();
 
             long t = (otherTime)._secs;

--- a/source/scripting_v3/GTA.Chrono/GameClockTime.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockTime.cs
@@ -381,14 +381,14 @@ namespace GTA.Chrono
         /// <summary>
         /// Returns a value indicating whether this instance is equal to a specified object.
         /// </summary>
-        /// <param name="value">An object to compare with this instance.</param>
+        /// <param name="obj">An object to compare with this instance.</param>
         /// <returns>
-        /// <see langword="true"/> if <paramref name="value"/> is a <see cref="GameClockTime"/> object that represents
+        /// <see langword="true"/> if <paramref name="obj"/> is a <see cref="GameClockTime"/> object that represents
         /// the same game clock time as the current <see cref="GameClockTime"/> structure; otherwise, false.
         /// </returns>
-        public override bool Equals(object value)
+        public override bool Equals(object obj)
         {
-            if (value is GameClockTime duration)
+            if (obj is GameClockTime duration)
             {
                 return Equals(duration);
             }

--- a/source/scripting_v3/GTA.Math/Matrix.cs
+++ b/source/scripting_v3/GTA.Math/Matrix.cs
@@ -1644,26 +1644,26 @@ namespace GTA.Math
         /// <param name="format">
         /// A standard or custom numeric format string that defines the format of individual elements.
         /// </param>
-        /// <param name="provider">
+        /// <param name="formatProvider">
         /// A format provider that supplies culture-specific formatting information.
         /// </param>
         /// <returns>The string representation of the value of this instance.</returns>
-        public readonly string ToString(string format, IFormatProvider provider)
+        public readonly string ToString(string format, IFormatProvider formatProvider)
         {
-            return string.Format(provider,
+            return string.Format(formatProvider,
                 "[M11:{0} M12:{1} M13:{2} M14:{3}] [M21:{4} M22:{5} M23:{6} M24:{7}]" +
                 "[M31:{8} M32:{9} M33:{10} M34:{11}] [M41:{12} M42:{13} M43:{14} M44:{15}]",
-                M11.ToString(format, provider), M12.ToString(format, provider),
-                M13.ToString(format, provider), M14.ToString(format, provider),
+                M11.ToString(format, formatProvider), M12.ToString(format, formatProvider),
+                M13.ToString(format, formatProvider), M14.ToString(format, formatProvider),
 
-                M21.ToString(format, provider), M22.ToString(format, provider),
-                M23.ToString(format, provider), M24.ToString(format, provider),
+                M21.ToString(format, formatProvider), M22.ToString(format, formatProvider),
+                M23.ToString(format, formatProvider), M24.ToString(format, formatProvider),
 
-                M31.ToString(format, provider), M32.ToString(format, provider),
-                M33.ToString(format, provider), M34.ToString(format, provider),
+                M31.ToString(format, formatProvider), M32.ToString(format, formatProvider),
+                M33.ToString(format, formatProvider), M34.ToString(format, formatProvider),
 
-                M41.ToString(format, provider), M42.ToString(format, provider),
-                M43.ToString(format, provider), M44.ToString(format, provider)
+                M41.ToString(format, formatProvider), M42.ToString(format, formatProvider),
+                M43.ToString(format, formatProvider), M44.ToString(format, formatProvider)
                 );
         }
 

--- a/source/scripting_v3/GTA.Math/Plane.cs
+++ b/source/scripting_v3/GTA.Math/Plane.cs
@@ -269,7 +269,7 @@ namespace GTA.Math
 
         public readonly bool Equals(Plane value) => Normal.Equals(value.Normal) && D.Equals(value.D);
 
-        public override readonly bool Equals(object value) => value is Plane other && Equals(other);
+        public override readonly bool Equals(object obj) => obj is Plane other && Equals(other);
 
         public override readonly int GetHashCode()
         {

--- a/source/scripting_v3/GTA.Math/Plane.cs
+++ b/source/scripting_v3/GTA.Math/Plane.cs
@@ -258,13 +258,13 @@ namespace GTA.Math
         /// <param name="format">
         /// A standard or custom numeric format string that defines the format of individual elements.
         /// </param>
-        /// <param name="provider">
+        /// <param name="formatProvider">
         /// A format provider that supplies culture-specific formatting information.
         /// </param>
         /// <returns>The string representation of the value of this instance.</returns>
-        public readonly string ToString(string format, IFormatProvider provider)
+        public readonly string ToString(string format, IFormatProvider formatProvider)
         {
-            return $"Normal:{Normal.ToString(format, provider)} D:{D.ToString(format, provider)}";
+            return $"Normal:{Normal.ToString(format, formatProvider)} D:{D.ToString(format, formatProvider)}";
         }
 
         public readonly bool Equals(Plane value) => Normal.Equals(value.Normal) && D.Equals(value.D);

--- a/source/scripting_v3/GTA.Math/Quaternion.cs
+++ b/source/scripting_v3/GTA.Math/Quaternion.cs
@@ -1287,13 +1287,13 @@ namespace GTA.Math
         /// <param name="format">
         /// A standard or custom numeric format string that defines the format of individual elements.
         /// </param>
-        /// <param name="provider">
+        /// <param name="formatProvider">
         /// A format provider that supplies culture-specific formatting information.
         /// </param>
         /// <returns>The string representation of the value of this instance.</returns>
-        public readonly string ToString(string format, IFormatProvider provider)
-            => string.Format("X:{0} Y:{1} Z:{2} W:{3}", X.ToString(format, provider), Y.ToString(format, provider),
-                Z.ToString(format, provider), W.ToString(format, provider));
+        public readonly string ToString(string format, IFormatProvider formatProvider)
+            => string.Format("X:{0} Y:{1} Z:{2} W:{3}", X.ToString(format, formatProvider), Y.ToString(format, formatProvider),
+                Z.ToString(format, formatProvider), W.ToString(format, formatProvider));
 
         /// <summary>
         /// Returns the hash code for this instance.

--- a/source/scripting_v3/GTA.Math/Vector2.cs
+++ b/source/scripting_v3/GTA.Math/Vector2.cs
@@ -507,13 +507,13 @@ namespace GTA.Math
         /// <param name="format">
         /// A standard or custom numeric format string that defines the format of individual elements.
         /// </param>
-        /// <param name="provider">
+        /// <param name="formatProvider">
         /// A format provider that supplies culture-specific formatting information.
         /// </param>
         /// <returns>The string representation of the value of this instance.</returns>
-        public readonly string ToString(string format, IFormatProvider provider)
+        public readonly string ToString(string format, IFormatProvider formatProvider)
         {
-            return $"X:{X.ToString(format, provider)} Y:{Y.ToString(format, provider)}";
+            return $"X:{X.ToString(format, formatProvider)} Y:{Y.ToString(format, formatProvider)}";
         }
 
         /// <summary>

--- a/source/scripting_v3/GTA.Math/Vector3.cs
+++ b/source/scripting_v3/GTA.Math/Vector3.cs
@@ -719,13 +719,13 @@ namespace GTA.Math
         /// <param name="format">
         /// A standard or custom numeric format string that defines the format of individual elements.
         /// </param>
-        /// <param name="provider">
+        /// <param name="formatProvider">
         /// A format provider that supplies culture-specific formatting information.
         /// </param>
         /// <returns>The string representation of the value of this instance.</returns>
-        public readonly string ToString(string format, IFormatProvider provider)
-            => string.Format("X:{0} Y:{1} Z:{2}", X.ToString(format, provider), Y.ToString(format, provider),
-                Z.ToString(format, provider));
+        public readonly string ToString(string format, IFormatProvider formatProvider)
+            => string.Format("X:{0} Y:{1} Z:{2}", X.ToString(format, formatProvider), Y.ToString(format, formatProvider),
+                Z.ToString(format, formatProvider));
 
         /// <summary>
         /// Returns the hash code for this instance.

--- a/source/scripting_v3/GTA.Math/Vector4.cs
+++ b/source/scripting_v3/GTA.Math/Vector4.cs
@@ -377,13 +377,13 @@ namespace GTA.Math
         /// <param name="format">
         /// A standard or custom numeric format string that defines the format of individual elements.
         /// </param>
-        /// <param name="provider">
+        /// <param name="formatProvider">
         /// A format provider that supplies culture-specific formatting information.
         /// </param>
         /// <returns>The string representation of the value of this instance.</returns>
-        public readonly string ToString(string format, IFormatProvider provider)
+        public readonly string ToString(string format, IFormatProvider formatProvider)
         {
-            return $"X:{X.ToString(format, provider)} Y:{Y.ToString(format, provider)} Z:{Z.ToString(format, provider)} W:{W.ToString(format, provider)}";
+            return $"X:{X.ToString(format, formatProvider)} Y:{Y.ToString(format, formatProvider)} Z:{Z.ToString(format, formatProvider)} W:{W.ToString(format, formatProvider)}";
         }
 
         public readonly bool Equals(Vector4 other) => X.Equals(other.X) && Y.Equals(other.Y) && Z.Equals(other.Z) && W.Equals(other.W);


### PR DESCRIPTION
This is based on rule [CA1725](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1725). The reason I've split this into two commits is that I wasn't sure to what extent this is breaking.

All changes in both commits keep binary compatibility, but can, in some cases, break source compatibility if a dev decides to use `[...].Equals(obj: [...])`, for example. 
While this should not be a problem for the changes in 
https://github.com/scripthookvdotnet/scripthookvdotnet/commit/29768bd4a6b8780dc7c0fc581947fc818a39283f that only affect functions added after the last stable release; https://github.com/scripthookvdotnet/scripthookvdotnet/commit/7c1ab8422cc13874bf488088260fd51eae94cde3 does the same for functions that were already added before.

I will be creating a few more PRs today as I have alot of local commits that I didn't bother pushing yet. But now because @BoBoBaSs84 seems to also be doing some refactoring, I prefer just pushing them now before I have to rebase stuff. He already beat me to the race with the changes in #1757 😁
 
