### PR TITLE
refactor(api-v3): make fields readonly to enforce immutability

### DIFF
--- a/source/scripting_v3/GTA.Chrono/GameClockDate.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDate.cs
@@ -55,8 +55,8 @@ namespace GTA.Chrono
             _ordFlags = ordFlags;
         }
 
-        private static OrdFlags OrdFlagsForMaxDate = new(365, YearFlags.FromYear(int.MaxValue));
-        private static OrdFlags OrdFlagsForMinDate = new(1, YearFlags.FromYear(int.MinValue));
+        private static readonly OrdFlags OrdFlagsForMaxDate = new(365, YearFlags.FromYear(int.MaxValue));
+        private static readonly OrdFlags OrdFlagsForMinDate = new(1, YearFlags.FromYear(int.MinValue));
 
         /// <summary>
         /// Represents the largest possible value of a <see cref="GameClockDate"/>.

--- a/source/scripting_v3/GTA.Math/Vector3.cs
+++ b/source/scripting_v3/GTA.Math/Vector3.cs
@@ -65,7 +65,7 @@ namespace GTA.Math
         public float Z;
 
         [FieldOffset(12)]
-        float _padding;
+        readonly float _padding;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector3"/> class.

--- a/source/scripting_v3/GTA.Native/Native.cs
+++ b/source/scripting_v3/GTA.Native/Native.cs
@@ -138,7 +138,7 @@ namespace GTA.Native
         /// <summary>
         /// This holds data that was discarded, content is unpredictable.
         /// </summary>
-        private static ulong _discardData;
+        private static readonly ulong _discardData;
 
         internal ulong _data;
 

--- a/source/scripting_v3/GTA.NaturalMotion/Message.cs
+++ b/source/scripting_v3/GTA.NaturalMotion/Message.cs
@@ -17,7 +17,7 @@ namespace GTA.NaturalMotion
     public class Message
     {
         #region Fields
-        private string _message;
+        private readonly string _message;
         private Dictionary<string, (int value, Type type)> _boolIntFloatArguments;
         private Dictionary<string, object> _stringVector3ArrayArguments;
         private static readonly Dictionary<string, (int value, Type type)> s_stopArgument = new() { { "start", (0, typeof(bool)) } };

--- a/source/scripting_v3/GTA.UI/CustomSprite.cs
+++ b/source/scripting_v3/GTA.UI/CustomSprite.cs
@@ -115,9 +115,9 @@ namespace GTA.UI
         #region Fields
         int _id;
         static int s_globalLevel, s_globalLastDrawFrame;
-        static Dictionary<string, int> s_textures = new();
-        static Dictionary<int, int> s_lastDraw = new();
-        static Dictionary<int, int> s_indexes = new();
+        static readonly Dictionary<string, int> s_textures = new();
+        static readonly Dictionary<int, int> s_lastDraw = new();
+        static readonly Dictionary<int, int> s_indexes = new();
         #endregion
 
         /// <summary>

--- a/source/scripting_v3/GTA/Entities/Peds/Style.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Style.cs
@@ -15,8 +15,8 @@ namespace GTA
         #region Fields
 
         readonly Ped _ped;
-        Dictionary<PedPropAnchorPoint, PedProp> _pedProps = new();
-        Dictionary<PedComponentType, PedComponent> _pedComponents = new();
+        readonly Dictionary<PedPropAnchorPoint, PedProp> _pedProps = new();
+        readonly Dictionary<PedComponentType, PedComponent> _pedComponents = new();
 
         #endregion
 

--- a/source/scripting_v3/GTA/Entities/Vehicles/VehicleExtraCollection.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/VehicleExtraCollection.cs
@@ -11,7 +11,7 @@ namespace GTA
         /// /// </summary>
         private const int MaxExtras = 12;
 
-        private Dictionary<VehicleExtraIndex, VehicleExtra> _vehicleExtras = new();
+        private readonly Dictionary<VehicleExtraIndex, VehicleExtra> _vehicleExtras = new();
 
         /// <summary>
         /// Gets the owner <see cref="Vehicle"/> of this <see cref="VehicleExtraCollection"/>.

--- a/source/scripting_v3/GTA/GameVersionNotSupportedException.cs
+++ b/source/scripting_v3/GTA/GameVersionNotSupportedException.cs
@@ -43,7 +43,7 @@ namespace GTA
     {
         public Version MinimumSupportedGameFileVersion { get; }
 
-        private Dictionary<Version, GameVersion> _supportedGameVersionEnumMaps
+        private readonly Dictionary<Version, GameVersion> _supportedGameVersionEnumMaps
             = new Dictionary<Version, GameVersion>
         {
             { ExeVersionConsts.v1_0_335_2, GameVersion.v1_0_335_2_Steam },

--- a/source/scripting_v3/GTA/Shvdn/Script/ScriptSettings.cs
+++ b/source/scripting_v3/GTA/Shvdn/Script/ScriptSettings.cs
@@ -20,7 +20,7 @@ namespace GTA
     {
         #region Fields
         readonly string _fileName;
-        Dictionary<string, Dictionary<string, List<string>>> _values = new(StringComparer.OrdinalIgnoreCase);
+        readonly Dictionary<string, Dictionary<string, List<string>>> _values = new(StringComparer.OrdinalIgnoreCase);
         #endregion
 
         ScriptSettings(string fileName)

--- a/source/scripting_v3/GTA/Weapons/DlcWeaponData.cs
+++ b/source/scripting_v3/GTA/Weapons/DlcWeaponData.cs
@@ -12,12 +12,12 @@ namespace GTA
     [StructLayout(LayoutKind.Explicit, Size = 0x138)]
     internal unsafe struct DlcWeaponData
     {
-        [FieldOffset(0x00)] int validCheck;
-        [FieldOffset(0x08)] int weaponHash;
-        [FieldOffset(0x18)] int weaponCost;
-        [FieldOffset(0x20)] int ammoCost;
-        [FieldOffset(0x28)] int ammoType;
-        [FieldOffset(0x30)] int defaultClipSize;
+        [FieldOffset(0x00)] readonly int validCheck;
+        [FieldOffset(0x08)] readonly int weaponHash;
+        [FieldOffset(0x18)] readonly int weaponCost;
+        [FieldOffset(0x20)] readonly int ammoCost;
+        [FieldOffset(0x28)] readonly int ammoType;
+        [FieldOffset(0x30)] readonly int defaultClipSize;
         [FieldOffset(0x38)] fixed byte name[0x40];
         [FieldOffset(0x78)] fixed byte desc[0x40];
         [FieldOffset(0xB8)] fixed byte simpleDesc[0x40]; // Usually refers to "the " + name
@@ -42,10 +42,10 @@ namespace GTA
     [StructLayout(LayoutKind.Explicit, Size = 0x110)]
     internal unsafe struct DlcWeaponComponentData
     {
-        [FieldOffset(0x00)] int attachBone; // The bone on the gun to attach the component to
-        [FieldOffset(0x08)] int bActiveByDefault;
-        [FieldOffset(0x18)] int componentHash;
-        [FieldOffset(0x28)] int componentCost;
+        [FieldOffset(0x00)] readonly int attachBone; // The bone on the gun to attach the component to
+        [FieldOffset(0x08)] readonly int bActiveByDefault;
+        [FieldOffset(0x18)] readonly int componentHash;
+        [FieldOffset(0x28)] readonly int componentCost;
         [FieldOffset(0x30)] fixed byte name[0x40];
         [FieldOffset(0x70)] fixed byte desc[0x40];
 


### PR DESCRIPTION
**Changes:**

- Refactored multiple classes and structs to mark eligible fields as `readonly`.
- This change enforces immutability, prevents reassignment after construction and improves code safety and clarity across the codebase.
