### PR TITLE
docs(api-v3): provide reasoning for obsolete `RagdollType` enum values

### DIFF
--- a/source/scripting_v3/GTA/Entities/Peds/RagdollType.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/RagdollType.cs
@@ -22,13 +22,13 @@ namespace GTA
         /// </summary>
         Balance = 2,
 
-        [Obsolete]
+        [Obsolete("Use RagdollType.Relax instead.")]
         Normal = 0,
-        [Obsolete]
+        [Obsolete("Use RagdollType.ScriptControl instead.")]
         StiffLegs,
-        [Obsolete]
+        [Obsolete("Use RagdollType.Balance instead.")]
         NarrowLegs,
-        [Obsolete]
+        [Obsolete("This value does not exist, it behaves the same like RagdollType.Balance. Use RagdollType.Balance instead.")]
         WideLegs,
     }
 }


### PR DESCRIPTION
This specifies what to replace these obsolete values with, internally `SET_PED_TO_RAGDOLL` checks the value only against 0 and 1, then just defaults to `CTaskNMBalance`. Therefore `WideLegs` has no equivliant.