### PR TITLE
refactor(core): remove manual `OutOfMemoryException` raise

### DIFF
--- a/source/core/StringMarshal.cs
+++ b/source/core/StringMarshal.cs
@@ -80,10 +80,6 @@ namespace SHVDN
 
                 Encoding.UTF8.GetBytes(s, 0, s.Length, s_strBufferForStringToCoTaskMemUtf8, 0);
                 IntPtr dest = Marshal.AllocCoTaskMem(byteCountUtf8 + 1);
-                if (dest == IntPtr.Zero)
-                {
-                    throw new OutOfMemoryException();
-                }
 
                 Marshal.Copy(s_strBufferForStringToCoTaskMemUtf8, 0, dest, byteCountUtf8);
 


### PR DESCRIPTION
This exception does not have to be thrown manually as `Marshal.AllocCoTaskMem` does this by itself.
https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.marshal.alloccotaskmem?view=netframework-4.8