### PR TITLE
refactor(api-v3): remove redundant manual version check before `ThrowIfNotSupported`

### DIFF
--- a/source/scripting_v3/GTA.UI/Sprite.cs
+++ b/source/scripting_v3/GTA.UI/Sprite.cs
@@ -195,11 +195,8 @@ namespace GTA.UI
             {
                 // Although you can find what DRAW_SPRITE_ARX_WITH_UV eventually calls with ["48 8B 41 10 66 39 70 58 74 06 48 8B 78 50 EB 07" - 0xA],
                 // but we have to prevent the setter from calling in the game versions prior to b1868 since we haven't found an alternative way to do what DRAW_SPRITE_ARX_WITH_UV does
-                if (Game.FileVersion < ExeVersionConsts.v1_0_1868_0)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_1868_0),
-                        nameof(Sprite), nameof(TextureCoordinates));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_1868_0,
+                    nameof(Sprite), nameof(TextureCoordinates));
 
                 _textureCoordinates = value;
             }

--- a/source/scripting_v3/GTA/Entities/Vehicles/HandlingData/CarHandlingData.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/HandlingData/CarHandlingData.cs
@@ -42,10 +42,7 @@ namespace GTA
             }
             set
             {
-                if (Game.FileVersion < ExeVersionConsts.v1_0_1365_1)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_1365_1, nameof(CarHandlingData), nameof(ToeFront));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_1365_1, nameof(CarHandlingData), nameof(ToeFront));
 
                 if (!IsValid)
                 {
@@ -75,10 +72,7 @@ namespace GTA
             }
             set
             {
-                if (Game.FileVersion < ExeVersionConsts.v1_0_1365_1)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_1365_1), nameof(CarHandlingData), nameof(ToeRear));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_1365_1, nameof(CarHandlingData), nameof(ToeRear));
 
                 if (!IsValid)
                 {
@@ -108,10 +102,7 @@ namespace GTA
             }
             set
             {
-                if (Game.FileVersion < ExeVersionConsts.v1_0_1365_1)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_1365_1), nameof(CarHandlingData), nameof(CamberFront));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_1365_1, nameof(CarHandlingData), nameof(CamberFront));
 
                 if (!IsValid)
                 {
@@ -141,10 +132,7 @@ namespace GTA
             }
             set
             {
-                if (Game.FileVersion < ExeVersionConsts.v1_0_1365_1)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_1365_1), nameof(CarHandlingData), nameof(CamberRear));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_1365_1, nameof(CarHandlingData), nameof(CamberRear));
 
                 if (!IsValid)
                 {
@@ -174,10 +162,7 @@ namespace GTA
             }
             set
             {
-                if (Game.FileVersion < ExeVersionConsts.v1_0_1365_1)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_1365_1), nameof(CarHandlingData), nameof(Castor));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_1365_1, nameof(CarHandlingData), nameof(Castor));
 
                 if (!IsValid)
                 {
@@ -207,10 +192,7 @@ namespace GTA
             }
             set
             {
-                if (Game.FileVersion < ExeVersionConsts.v1_0_1365_1)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_1365_1), nameof(CarHandlingData), nameof(EngineResistance));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_1365_1, nameof(CarHandlingData), nameof(EngineResistance));
 
                 if (!IsValid)
                 {

--- a/source/scripting_v3/GTA/Entities/Vehicles/HandlingData/FlyingHandlingData.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/HandlingData/FlyingHandlingData.cs
@@ -600,10 +600,7 @@ namespace GTA
             }
             set
             {
-                if (Game.FileVersion < ExeVersionConsts.v1_0_1180_2)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_1180_2), nameof(FlyingHandlingData), nameof(ExtraLiftWithRoll));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_1180_2, nameof(FlyingHandlingData), nameof(ExtraLiftWithRoll));
 
                 if (!IsValid)
                 {

--- a/source/scripting_v3/GTA/Entities/Vehicles/HandlingData/SpecialFlightHandlingData.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/HandlingData/SpecialFlightHandlingData.cs
@@ -64,10 +64,8 @@ namespace GTA
             }
             set
             {
-                if (Game.FileVersion < ExeVersionConsts.v1_0_1493_0)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_1493_0), nameof(SpecialFlightHandlingData), nameof(VectorAngularDampingMin));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_1493_0, nameof(SpecialFlightHandlingData), nameof(VectorAngularDampingMin));
+
                 if (!IsValid)
                 {
                     return;
@@ -125,10 +123,8 @@ namespace GTA
             }
             set
             {
-                if (Game.FileVersion < ExeVersionConsts.v1_0_1493_0)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_1493_0), nameof(SpecialFlightHandlingData), nameof(VectorLinearDampingMin));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_1493_0, nameof(SpecialFlightHandlingData), nameof(VectorLinearDampingMin));
+
                 if (!IsValid)
                 {
                     return;
@@ -306,10 +302,8 @@ namespace GTA
             }
             set
             {
-                if (Game.FileVersion < ExeVersionConsts.v1_0_1493_0)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_1493_0), nameof(SpecialFlightHandlingData), nameof(MinSpeedForThrustFalloff));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_1493_0, nameof(SpecialFlightHandlingData), nameof(MinSpeedForThrustFalloff));
+
                 if (!IsValid)
                 {
                     return;
@@ -338,10 +332,8 @@ namespace GTA
             }
             set
             {
-                if (Game.FileVersion < ExeVersionConsts.v1_0_1493_0)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_1493_0), nameof(SpecialFlightHandlingData), nameof(BrakingThrustScale));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_1493_0, nameof(SpecialFlightHandlingData), nameof(BrakingThrustScale));
+
                 if (!IsValid)
                 {
                     return;

--- a/source/scripting_v3/GTA/Entities/Vehicles/HandlingData/VehicleWeaponHandlingData.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/HandlingData/VehicleWeaponHandlingData.cs
@@ -173,10 +173,8 @@ namespace GTA
         {
             get
             {
-                if (Game.FileVersion < ExeVersionConsts.v1_0_1103_2)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_1103_2), nameof(VehicleWeaponHandlingData), nameof(WeaponVehicleModType));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_1103_2, nameof(VehicleWeaponHandlingData), nameof(WeaponVehicleModType));
+
                 if (!IsValid)
                 {
                     return Array.Empty<VehicleModType>();
@@ -200,10 +198,8 @@ namespace GTA
             }
             set
             {
-                if (Game.FileVersion < ExeVersionConsts.v1_0_1103_2)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_1103_2), nameof(VehicleWeaponHandlingData), nameof(WeaponVehicleModType));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_1103_2, nameof(VehicleWeaponHandlingData), nameof(WeaponVehicleModType));
+
                 if (value.Length > s_elemCountForWeaponPropertyArrays)
                 {
                     ThrowHelper.ThrowArgumentException($"The amount of {nameof(VehicleModType)} values values must be between 0 and {s_elemCountForWeaponPropertyArrays.ToString()}.", nameof(value));

--- a/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs
@@ -143,10 +143,7 @@ namespace GTA
                 && Function.Call<bool>(Hash.IS_ROCKET_BOOST_ACTIVE, Handle);
             set
             {
-                if (Game.FileVersion < ExeVersionConsts.v1_0_944_2)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_944_2), nameof(Vehicle), nameof(IsRocketBoostActive));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_944_2, nameof(Vehicle), nameof(IsRocketBoostActive));
 
                 Function.Call(Hash.SET_ROCKET_BOOST_ACTIVE, Handle, value);
             }
@@ -2236,10 +2233,7 @@ namespace GTA
         /// </exception>
         public int GetRestrictedAmmoCount(int vehicleWeaponIndex)
         {
-            if (Game.FileVersion < ExeVersionConsts.v1_0_1011_1)
-            {
-                GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_1011_1), nameof(Vehicle), nameof(GetRestrictedAmmoCount));
-            }
+            GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_1011_1, nameof(Vehicle), nameof(GetRestrictedAmmoCount));
 
             return Function.Call<int>(Hash.GET_VEHICLE_WEAPON_RESTRICTED_AMMO, Handle, vehicleWeaponIndex);
         }
@@ -2266,10 +2260,7 @@ namespace GTA
         /// </exception>
         public void SetRestrictedAmmoCount(int vehicleWeaponIndex, int ammoCount)
         {
-            if (Game.FileVersion < ExeVersionConsts.v1_0_944_2)
-            {
-                GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_944_2), nameof(Vehicle), nameof(SetRestrictedAmmoCount));
-            }
+            GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_944_2, nameof(Vehicle), nameof(SetRestrictedAmmoCount));
 
             Function.Call(Hash.SET_VEHICLE_WEAPON_RESTRICTED_AMMO, Handle, vehicleWeaponIndex, ammoCount);
         }
@@ -2289,19 +2280,13 @@ namespace GTA
         {
             get
             {
-                if (Game.FileVersion < ExeVersionConsts.v1_0_1180_2)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_1180_2), nameof(Vehicle), nameof(GetRestrictedAmmoCount));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_1180_2, nameof(Vehicle), nameof(GetRestrictedAmmoCount));
 
                 return Function.Call<int>(Hash.GET_VEHICLE_BOMB_AMMO, Handle);
             }
             set
             {
-                if (Game.FileVersion < ExeVersionConsts.v1_0_1180_2)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_1180_2), nameof(Vehicle), nameof(GetRestrictedAmmoCount));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_1180_2, nameof(Vehicle), nameof(GetRestrictedAmmoCount));
 
                 Function.Call(Hash.SET_VEHICLE_BOMB_AMMO, Handle, value);
             }
@@ -2322,19 +2307,13 @@ namespace GTA
         {
             get
             {
-                if (Game.FileVersion < ExeVersionConsts.v1_0_1180_2)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_1180_2), nameof(Vehicle), nameof(GetRestrictedAmmoCount));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_1180_2, nameof(Vehicle), nameof(GetRestrictedAmmoCount));
 
                 return Function.Call<int>(Hash.GET_VEHICLE_COUNTERMEASURE_AMMO, Handle);
             }
             set
             {
-                if (Game.FileVersion < ExeVersionConsts.v1_0_1180_2)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_1180_2), nameof(Vehicle), nameof(GetRestrictedAmmoCount));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_1180_2, nameof(Vehicle), nameof(GetRestrictedAmmoCount));
 
                 Function.Call(Hash.SET_VEHICLE_COUNTERMEASURE_AMMO, Handle, value);
             }
@@ -2670,10 +2649,7 @@ namespace GTA
         /// </summary>
         public void StopBringingToHalt()
         {
-            if (Game.FileVersion < ExeVersionConsts.v1_0_1103_2)
-            {
-                GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_1103_2), nameof(Vehicle), nameof(StopBringingToHalt));
-            }
+            GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_1103_2, nameof(Vehicle), nameof(StopBringingToHalt));
 
             Function.Call(Hash.STOP_BRINGING_VEHICLE_TO_HALT, Handle);
         }
@@ -2695,10 +2671,7 @@ namespace GTA
         /// <param name="allowPlayerToCancel">Whether to allow the player to cancel parachuting before the vehicle lands</param>
         public void StartParachuting(bool allowPlayerToCancel)
         {
-            if (Game.FileVersion < ExeVersionConsts.v1_0_944_2)
-            {
-                GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_944_2), nameof(Vehicle), nameof(StartParachuting));
-            }
+            GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_944_2, nameof(Vehicle), nameof(StartParachuting));
 
             if (HasParachute)
             {
@@ -2735,10 +2708,7 @@ namespace GTA
             }
             set
             {
-                if (Game.FileVersion < ExeVersionConsts.v1_0_1290_1)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_1290_1), nameof(Vehicle), nameof(SpecialFlightModeTargetRatio));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_1290_1, nameof(Vehicle), nameof(SpecialFlightModeTargetRatio));
 
                 Function.Call(Hash.SET_SPECIAL_FLIGHT_MODE_TARGET_RATIO, Handle, value);
             }
@@ -2761,10 +2731,7 @@ namespace GTA
             }
             set
             {
-                if (Game.FileVersion < ExeVersionConsts.v1_0_1290_1)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_1290_1), nameof(Vehicle), nameof(SpecialFlightModeCurrentRatio));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_1290_1, nameof(Vehicle), nameof(SpecialFlightModeCurrentRatio));
 
                 Function.Call(Hash.SET_SPECIAL_FLIGHT_MODE_RATIO, Handle, value);
             }
@@ -2787,10 +2754,7 @@ namespace GTA
             }
             set
             {
-                if (Game.FileVersion < ExeVersionConsts.v1_0_1290_1)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_1290_1), nameof(Vehicle), nameof(SpecialFlightModeWingRatio));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_1290_1, nameof(Vehicle), nameof(SpecialFlightModeWingRatio));
 
                 if (!TryGetMemoryAddress(out IntPtr address) || SHVDN.NativeMemory.Vehicle.SpecialFlightAreWingsDisabledOffset == 0)
 
@@ -2822,10 +2786,7 @@ namespace GTA
             }
             set
             {
-                if (Game.FileVersion < ExeVersionConsts.v1_0_1290_1)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_1290_1), nameof(Vehicle), nameof(AreWingsEnabledForSpecialFlightMode));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_1290_1, nameof(Vehicle), nameof(AreWingsEnabledForSpecialFlightMode));
 
                 Function.Call(Hash.SET_DISABLE_HOVER_MODE_FLIGHT, Handle, !value);
             }

--- a/source/scripting_v3/GTA/Entities/Vehicles/VehicleModCollection.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/VehicleModCollection.cs
@@ -311,10 +311,7 @@ namespace GTA
         {
             get
             {
-                if (Game.FileVersion < ExeVersionConsts.v1_0_505_2)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_505_2), nameof(VehicleModCollection), nameof(TrimColor));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_505_2, nameof(VehicleModCollection), nameof(TrimColor));
 
                 int trimColorIndex;
                 unsafe
@@ -326,10 +323,7 @@ namespace GTA
             }
             set
             {
-                if (Game.FileVersion < ExeVersionConsts.v1_0_505_2)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_505_2), nameof(VehicleModCollection), nameof(TrimColor));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_505_2, nameof(VehicleModCollection), nameof(TrimColor));
 
                 Function.Call(Hash.SET_VEHICLE_EXTRA_COLOUR_5, _owner.Handle, (int)value);
             }
@@ -338,10 +332,7 @@ namespace GTA
         {
             get
             {
-                if (Game.FileVersion < ExeVersionConsts.v1_0_505_2)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_505_2), nameof(VehicleModCollection), nameof(DashboardColor));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_505_2, nameof(VehicleModCollection), nameof(DashboardColor));
 
                 int color;
                 unsafe
@@ -353,10 +344,7 @@ namespace GTA
             }
             set
             {
-                if (Game.FileVersion < ExeVersionConsts.v1_0_505_2)
-                {
-                    GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_505_2), nameof(VehicleModCollection), nameof(DashboardColor));
-                }
+                GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_505_2, nameof(VehicleModCollection), nameof(DashboardColor));
 
                 Function.Call(Hash.SET_VEHICLE_EXTRA_COLOUR_6, _owner.Handle, (int)value);
             }

--- a/source/scripting_v3/GTA/ScriptSound.cs
+++ b/source/scripting_v3/GTA/ScriptSound.cs
@@ -112,10 +112,7 @@ namespace GTA
         /// <param name="position">The new position.</param>
         public void UpdatePosition(Vector3 position)
         {
-            if (Game.FileVersion < ExeVersionConsts.v1_0_678_1)
-            {
-                GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_678_1), nameof(ScriptSound), nameof(UpdatePosition));
-            }
+            GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_678_1, nameof(ScriptSound), nameof(UpdatePosition));
 
             Function.Call(Hash.UPDATE_SOUND_COORD, Id, position.X, position.Y, position.Z);
         }

--- a/source/scripting_v3/GTA/World.cs
+++ b/source/scripting_v3/GTA/World.cs
@@ -2435,10 +2435,7 @@ namespace GTA
         /// <exception cref="GameVersionNotSupportedException">Thrown when called in v1.0.463.1 or earlier game versions.</exception>
         public static bool GetGroundHeightExcludingProps(Vector3 position, out float height, GetGroundHeightMode mode = GetGroundHeightMode.Normal)
         {
-            if (Game.FileVersion < ExeVersionConsts.v1_0_505_2)
-            {
-                GameVersionNotSupportedException.ThrowIfNotSupported((ExeVersionConsts.v1_0_505_2), nameof(GetGroundHeightExcludingProps), nameof(GetGroundHeightExcludingProps));
-            }
+            GameVersionNotSupportedException.ThrowIfNotSupported(ExeVersionConsts.v1_0_505_2, nameof(GetGroundHeightExcludingProps), nameof(GetGroundHeightExcludingProps));
 
             bool foundCollision;
 


### PR DESCRIPTION
Even though `GameVersionNotSupportedException.ThrowIfNotSupported` already performs a version check, in some cases, a manual check was performed before calling it.