### PR TITLE
refactor(api-v3): remove code redundancies

### DIFF
--- a/source/scripting_v3/GTA.Chrono/FormattingHelpers.cs
+++ b/source/scripting_v3/GTA.Chrono/FormattingHelpers.cs
@@ -52,7 +52,7 @@ namespace GTA.Chrono
             Debug.Assert(Log2ToPow10ForU64.Length == 64);
             var index = (uint)Log2ToPow10ForU64[BitOperations.Log2(value)];
 
-            Debug.Assert((index + 1) <= PowersOf10.Length);
+            Debug.Assert(index + 1 <= PowersOf10.Length);
             ulong powerOf10 = PowersOf10[BitOperations.Log2(index)];
 
             // Return the number of digits based on the power of 10, shifted by 1 if it falls below the threshold.
@@ -120,7 +120,7 @@ namespace GTA.Chrono
                 while (true)
                 {
                     uint temp = value / 10;
-                    if (value != (temp * 10))
+                    if (value != temp * 10)
                     {
                         break;
                     }

--- a/source/scripting_v3/GTA.Chrono/GameClock.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClock.cs
@@ -438,14 +438,12 @@ namespace GTA.Chrono
                 {
                     return NormalizeMinuteInternal(ref minute, ref hour);
                 }
-                else
-                {
-                    // Should not come here, because the game would crash for an invalid hour value less than -1 or
-                    // more than 25. "Invalid" minute or second values don't crash the game, but invalid hour values
-                    // do. We just don't want to throw an exception, since we could semantically normalize hour values,
-                    // which is different from invalid month values.
-                    return NormalizeHourInternal(ref hour);
-                }
+
+                // Should not come here, because the game would crash for an invalid hour value less than -1 or
+                // more than 25. "Invalid" minute or second values don't crash the game, but invalid hour values
+                // do. We just don't want to throw an exception, since we could semantically normalize hour values,
+                // which is different from invalid month values.
+                return NormalizeHourInternal(ref hour);
             }
 
             int dayDiff = 0;

--- a/source/scripting_v3/GTA.Chrono/GameClockDate.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDate.cs
@@ -511,11 +511,9 @@ namespace GTA.Chrono
                 date = nullableDate.GetValueOrDefault();
                 return true;
             }
-            else
-            {
-                date = default;
-                return false;
-            }
+
+            date = default;
+            return false;
         }
 
         private GameClockDate? DiffMonths(long months)
@@ -1010,7 +1008,8 @@ namespace GTA.Chrono
             {
                 return 1;
             }
-            else if (thisYear < otherYear)
+
+            if (thisYear < otherYear)
             {
                 return -1;
             }
@@ -1021,7 +1020,8 @@ namespace GTA.Chrono
             {
                 return 1;
             }
-            else if (thisOrdinal < otherOrdinal)
+
+            if (thisOrdinal < otherOrdinal)
             {
                 return -1;
             }

--- a/source/scripting_v3/GTA.Chrono/GameClockDate.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDate.cs
@@ -920,14 +920,11 @@ namespace GTA.Chrono
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private unsafe string ToStringInternal()
         {
-            unsafe
-            {
-                // this is the minimum number that is large enough to contain any date string and is multiple of 4
-                const int BufferLen = 20;
-                char* buffer = stackalloc char[BufferLen];
-                GameClockDateTimeFormat.TryFormatDateS(this, buffer, BufferLen, out int written);
-                return new string(buffer, 0, written);
-            }
+            // this is the minimum number that is large enough to contain any date string and is multiple of 4
+            const int BufferLen = 20;
+            char* buffer = stackalloc char[BufferLen];
+            GameClockDateTimeFormat.TryFormatDateS(this, buffer, BufferLen, out int written);
+            return new string(buffer, 0, written);
         }
 
         /// <summary>

--- a/source/scripting_v3/GTA.Chrono/GameClockDate.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDate.cs
@@ -161,8 +161,8 @@ namespace GTA.Chrono
             return null;
         }
 
-        static GameClockDate FromMdfUnchecked(int year, MonthDayFlags mdf)
-            => new GameClockDate(year, mdf.ToOrdFlags().GetValueOrDefault());
+        static GameClockDate FromMdfUnchecked(int year, MonthDayFlags mdf) =>
+            new(year, mdf.ToOrdFlags().GetValueOrDefault());
 
         /// <summary>
         /// Makes a new <see cref="GameClockDateTime"/> from the current date and given <see cref="GameClockTime"/>.

--- a/source/scripting_v3/GTA.Chrono/GameClockDate.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDate.cs
@@ -559,7 +559,7 @@ namespace GTA.Chrono
             if (day > dayMax)
             {
                 day = dayMax;
-            };
+            }
 
             return FromMdfUnchecked(year, new MonthDayFlags(month, day, flags));
         }

--- a/source/scripting_v3/GTA.Chrono/GameClockDate.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDate.cs
@@ -349,8 +349,8 @@ namespace GTA.Chrono
             YearFlags flags = YearFlags.FromYear(year);
             uint nWeeks = flags.IsoWeekCount;
 
-            if ((dayOfWeek < IsoDayOfWeek.Monday || dayOfWeek > IsoDayOfWeek.Sunday) ||
-                (week < 1 || week > nWeeks))
+            if (dayOfWeek < IsoDayOfWeek.Monday || dayOfWeek > IsoDayOfWeek.Sunday ||
+                week < 1 || week > nWeeks)
             {
                 date = default;
                 return false;
@@ -521,7 +521,7 @@ namespace GTA.Chrono
 
             // Determine new year (without taking months into account for now). Return null if the new year is not in
             // the range of int32.
-            if ((years > 0 && _year > (int.MaxValue - years)) || (years < 0 && _year < (int.MinValue - years)))
+            if ((years > 0 && _year > int.MaxValue - years) || (years < 0 && _year < int.MinValue - years))
             {
                 return null;
             }
@@ -1081,7 +1081,7 @@ namespace GTA.Chrono
         {
             return month switch
             {
-                2 => (flags.IsLeapYear ? 29 : 28),
+                2 => flags.IsLeapYear ? 29 : 28,
                 4 or 6 or 9 or 11 => 30,
                 _ => 31,
             };

--- a/source/scripting_v3/GTA.Chrono/GameClockDate.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDate.cs
@@ -429,9 +429,7 @@ namespace GTA.Chrono
         /// </returns>
         public bool TryAdd(GameClockDuration duration, out GameClockDate date)
         {
-            // dividing int64 secs by a float64 value may result in unintended rounding errors when converting secs
-            // into float64.
-            long wholeDays = (long)duration.WholeDays;
+            long wholeDays = duration.WholeDays;
             long newOrdinal = DayOfYear + wholeDays;
 
             if (newOrdinal is > 0 and <= 365)
@@ -843,8 +841,8 @@ namespace GTA.Chrono
             DivModFloor(year1, 400, out int year1Div400, out int year1Mod400);
             DivModFloor(year2, 400, out int year2Div400, out int year2Mod400);
 
-            long cycle1 = (long)Internals.YearOrdinalToDayCycle(year1Mod400, (int)_ordFlags.Ordinal);
-            long cycle2 = (long)Internals.YearOrdinalToDayCycle(year2Mod400, (int)value._ordFlags.Ordinal);
+            long cycle1 = Internals.YearOrdinalToDayCycle(year1Mod400, (int)_ordFlags.Ordinal);
+            long cycle2 = Internals.YearOrdinalToDayCycle(year2Mod400, (int)value._ordFlags.Ordinal);
             return GameClockDuration.FromDays(((long)year1Div400 - year2Div400) * 146_097 + (cycle1 - cycle2));
         }
 

--- a/source/scripting_v3/GTA.Chrono/GameClockDateTime.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDateTime.cs
@@ -585,9 +585,9 @@ namespace GTA.Chrono
                 // this is the minimum number that is large enough to contain any date time string and is multiple of 4
                 const int BufferLen = 28;
                 char* buffer = stackalloc char[BufferLen];
-                GameClockDateTimeFormat.TryFormatDateS(this._date, buffer, BufferLen, out int charWritten);
+                GameClockDateTimeFormat.TryFormatDateS(_date, buffer, BufferLen, out int charWritten);
                 buffer[charWritten++] = ' ';
-                GameClockDateTimeFormat.TryFormatTimeS(this._time, buffer + charWritten, BufferLen - charWritten,
+                GameClockDateTimeFormat.TryFormatTimeS(_time, buffer + charWritten, BufferLen - charWritten,
                     out int timeWritten);
                 charWritten += timeWritten;
 

--- a/source/scripting_v3/GTA.Chrono/GameClockDateTime.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDateTime.cs
@@ -580,19 +580,16 @@ namespace GTA.Chrono
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private unsafe string ToStringInternal()
         {
-            unsafe
-            {
-                // this is the minimum number that is large enough to contain any date time string and is multiple of 4
-                const int BufferLen = 28;
-                char* buffer = stackalloc char[BufferLen];
-                GameClockDateTimeFormat.TryFormatDateS(_date, buffer, BufferLen, out int charWritten);
-                buffer[charWritten++] = ' ';
-                GameClockDateTimeFormat.TryFormatTimeS(_time, buffer + charWritten, BufferLen - charWritten,
-                    out int timeWritten);
-                charWritten += timeWritten;
+            // this is the minimum number that is large enough to contain any date time string and is multiple of 4
+            const int BufferLen = 28;
+            char* buffer = stackalloc char[BufferLen];
+            GameClockDateTimeFormat.TryFormatDateS(_date, buffer, BufferLen, out int charWritten);
+            buffer[charWritten++] = ' ';
+            GameClockDateTimeFormat.TryFormatTimeS(_time, buffer + charWritten, BufferLen - charWritten,
+                out int timeWritten);
+            charWritten += timeWritten;
 
-                return new string(buffer, 0, charWritten);
-            }
+            return new string(buffer, 0, charWritten);
         }
 
         /// <summary>

--- a/source/scripting_v3/GTA.Chrono/GameClockDuration.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDuration.cs
@@ -41,16 +41,16 @@ namespace GTA.Chrono
         /// The number of days elapsed since January 1st, the -2147483648 year until December 31st, the 2147483647 year,
         /// which will result in 1_568_704_592_609 days. Subtracted by 1 because 1 day is taken for the min date value.
         /// </summary>
-        const long DayCountUInt32YearsLaterSinceInt32MinValueYear = (LeapYearCountOfInt32 * 366)
-            + (NonLeapYearCountOfInt32 * 365) - 1;
+        const long DayCountUInt32YearsLaterSinceInt32MinValueYear = LeapYearCountOfInt32 * 366
+            + NonLeapYearCountOfInt32 * 365 - 1;
 
         /// <summary>
         /// The same value as 135_536_076_801_503_999 seconds.
         /// </summary>
-        const long MaxSecDifference = (DayCountUInt32YearsLaterSinceInt32MinValueYear) * SecsPerDay
+        const long MaxSecDifference = DayCountUInt32YearsLaterSinceInt32MinValueYear * SecsPerDay
                                       + 23 * SecsPerHour + 59 * SecsPerMinute + 59;
 
-        const long MinSecDifference = -((DayCountUInt32YearsLaterSinceInt32MinValueYear) * SecsPerDay
+        const long MinSecDifference = -(DayCountUInt32YearsLaterSinceInt32MinValueYear * SecsPerDay
                                         + 23 * SecsPerHour + 59 * SecsPerMinute + 59);
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace GTA.Chrono
         /// The hour component of the current <see cref="GameClockDuration"/> structure.
         /// The return value ranges from -23 through 23.
         /// </value>
-        public int Hours => (int)((_secs / SecsPerHour) % 24);
+        public int Hours => (int)(_secs / SecsPerHour % 24);
 
         /// <summary>
         /// Gets the minutes component of the time interval represented by the current <see cref="GameClockDuration"/>
@@ -90,7 +90,7 @@ namespace GTA.Chrono
         /// The minute component of the current <see cref="GameClockDuration"/> structure.
         /// The return value ranges from -59 through 59.
         /// </value>
-        public int Minutes => (int)((_secs / SecsPerMinute) % 60);
+        public int Minutes => (int)(_secs / SecsPerMinute % 60);
 
         /// <summary>
         /// Gets the seconds component of the time interval represented by the current <see cref="GameClockDuration"/>
@@ -194,7 +194,7 @@ namespace GTA.Chrono
             if (!(obj is GameClockDuration otherDuration))
                 throw new ArgumentException();
 
-            long t = (otherDuration)._secs;
+            long t = otherDuration._secs;
             if (_secs > t) return 1;
             if (_secs < t) return -1;
             return 0;
@@ -314,7 +314,7 @@ namespace GTA.Chrono
 
         public static GameClockDuration FromTimeSpan(TimeSpan timeSpan) => new(timeSpan.Ticks / TimeSpan.TicksPerSecond);
 
-        public GameClockDuration Abs() => (_secs < 0) ? new GameClockDuration(-_secs) : this;
+        public GameClockDuration Abs() => _secs < 0 ? new GameClockDuration(-_secs) : this;
 
         /// <summary>
         /// Returns the specified instance of <see cref="GameClockDuration"/>.

--- a/source/scripting_v3/GTA.Chrono/GameClockDuration.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockDuration.cs
@@ -312,8 +312,7 @@ namespace GTA.Chrono
             return new GameClockDuration(seconds);
         }
 
-        public static GameClockDuration FromTimeSpan(TimeSpan timeSpan)
-            => new GameClockDuration(timeSpan.Ticks / TimeSpan.TicksPerSecond);
+        public static GameClockDuration FromTimeSpan(TimeSpan timeSpan) => new(timeSpan.Ticks / TimeSpan.TicksPerSecond);
 
         public GameClockDuration Abs() => (_secs < 0) ? new GameClockDuration(-_secs) : this;
 
@@ -480,7 +479,7 @@ namespace GTA.Chrono
         /// <paramref name="divisor"/>.
         /// </returns>
         public static GameClockDuration operator /(GameClockDuration duration, long divisor)
-            => new GameClockDuration(duration._secs / divisor);
+            => new(duration._secs / divisor);
 
         /// <summary>
         /// Returns a new TimeSpan object whose value is the result of dividing the specified

--- a/source/scripting_v3/GTA.Chrono/GameClockTime.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockTime.cs
@@ -316,7 +316,7 @@ namespace GTA.Chrono
         /// The addition wraps around and ignores integral number of days.
         /// </remarks>
         public static GameClockTime operator +(GameClockTime time, GameClockDuration duration)
-            => new GameClockTime((time._secs + 86400 + (int)(duration.WholeSeconds % 86400)) % 86400);
+            => new((time._secs + 86400 + (int)(duration.WholeSeconds % 86400)) % 86400);
 
         /// <summary>
         /// Subtracts a specified duration from a specified time and returns a new time.
@@ -331,7 +331,7 @@ namespace GTA.Chrono
         /// The subtraction wraps around and ignores integral number of days.
         /// </remarks>
         public static GameClockTime operator -(GameClockTime time, GameClockDuration duration)
-            => new GameClockTime((time._secs + 86400 - (int)(duration.WholeSeconds % 86400)) % 86400);
+            => new((time._secs + 86400 - (int)(duration.WholeSeconds % 86400)) % 86400);
 
         /// <summary>
         /// Subtracts a specified from the current time, yielding a signed duration.

--- a/source/scripting_v3/GTA.Chrono/GameClockTime.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockTime.cs
@@ -82,12 +82,12 @@ namespace GTA.Chrono
         /// <summary>
         /// Gets the minute component of the time represented by this instance.
         /// </summary>
-        public int Minute => ((_secs / 60) % 60);
+        public int Minute => _secs / 60 % 60;
 
         /// <summary>
         /// Gets the second component of the time represented by this instance.
         /// </summary>
-        public int Second => (_secs % 60);
+        public int Second => _secs % 60;
 
         /// <summary>
         /// Gets the number of seconds past the last midnight.
@@ -259,7 +259,7 @@ namespace GTA.Chrono
             if (obj is not GameClockTime otherTime)
                 throw new ArgumentException();
 
-            long t = (otherTime)._secs;
+            long t = otherTime._secs;
             if (_secs > t) return 1;
             if (_secs < t) return -1;
             return 0;

--- a/source/scripting_v3/GTA.Chrono/GameClockTime.cs
+++ b/source/scripting_v3/GTA.Chrono/GameClockTime.cs
@@ -297,14 +297,11 @@ namespace GTA.Chrono
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private unsafe string ToStringInternal()
         {
-            unsafe
-            {
-                // this is the minimum number that is large enough to contain any time string
-                const int BufferLen = 8;
-                char* buffer = stackalloc char[BufferLen];
-                GameClockDateTimeFormat.TryFormatTimeS(this, buffer, BufferLen, out int written);
-                return new string(buffer, 0, written);
-            }
+            // this is the minimum number that is large enough to contain any time string
+            const int BufferLen = 8;
+            char* buffer = stackalloc char[BufferLen];
+            GameClockDateTimeFormat.TryFormatTimeS(this, buffer, BufferLen, out int written);
+            return new string(buffer, 0, written);
         }
 
         /// <summary>

--- a/source/scripting_v3/GTA.Chrono/IntExtensions.cs
+++ b/source/scripting_v3/GTA.Chrono/IntExtensions.cs
@@ -23,10 +23,8 @@ namespace GTA.Chrono
                 // We can't use Math.Abs(int) for int.MinValue, because it throws OverflowException for int.MinValue.
                 return (rhs < 0) ? (r - rhs) : (r + rhs);
             }
-            else
-            {
-                return r;
-            }
+
+            return r;
         }
 
         public static int DivEuclid(this int lhs, int rhs)
@@ -56,10 +54,8 @@ namespace GTA.Chrono
                 // We can't use Math.Abs(int) for int.MinValue, because it throws OverflowException for int.MinValue.
                 return (rhs < 0) ? (r - rhs) : (r + rhs);
             }
-            else
-            {
-                return r;
-            }
+
+            return r;
         }
 
         public static long DivEuclid(this long lhs, long rhs)

--- a/source/scripting_v3/GTA.Chrono/IntExtensions.cs
+++ b/source/scripting_v3/GTA.Chrono/IntExtensions.cs
@@ -21,7 +21,7 @@ namespace GTA.Chrono
                 // Otherwise, `rhs` is `int.MinValue`, then we have `r - int.MinValue`, which is what we wanted (and will
                 // not overflow for negative `r`).
                 // We can't use Math.Abs(int) for int.MinValue, because it throws OverflowException for int.MinValue.
-                return (rhs < 0) ? (r - rhs) : (r + rhs);
+                return rhs < 0 ? r - rhs : r + rhs;
             }
 
             return r;
@@ -32,7 +32,7 @@ namespace GTA.Chrono
             int q = lhs / rhs;
             if (lhs % rhs < 0)
             {
-                return (rhs > 0) ? (q - 1) : (q + 1);
+                return rhs > 0 ? q - 1 : q + 1;
             }
 
             return q;
@@ -52,7 +52,7 @@ namespace GTA.Chrono
                 // Otherwise, `rhs` is `int.MinValue`, then we have `r - int.MinValue`, which is what we wanted (and will
                 // not overflow for negative `r`).
                 // We can't use Math.Abs(int) for int.MinValue, because it throws OverflowException for int.MinValue.
-                return (rhs < 0) ? (r - rhs) : (r + rhs);
+                return rhs < 0 ? r - rhs : r + rhs;
             }
 
             return r;
@@ -63,7 +63,7 @@ namespace GTA.Chrono
             long q = lhs / rhs;
             if (lhs % rhs < 0)
             {
-                return (rhs > 0) ? (q - 1) : (q + 1);
+                return rhs > 0 ? q - 1 : q + 1;
             }
 
             return q;

--- a/source/scripting_v3/GTA.Chrono/MathHelpers.cs
+++ b/source/scripting_v3/GTA.Chrono/MathHelpers.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (C) 2024 kagikn & contributors
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
@@ -10,14 +10,14 @@ namespace GTA.Chrono
         internal static uint DivRem(uint left, uint right, out uint remainder)
         {
             uint quotient = left / right;
-            remainder = left - (quotient * right);
+            remainder = left - quotient * right;
             return quotient;
         }
 
         internal static ulong DivRem(ulong left, ulong right, out ulong remainder)
         {
             ulong quotient = left / right;
-            remainder = left - (quotient * right);
+            remainder = left - quotient * right;
             return quotient;
         }
     }

--- a/source/scripting_v3/GTA.Chrono/MonthDayFlags.cs
+++ b/source/scripting_v3/GTA.Chrono/MonthDayFlags.cs
@@ -55,11 +55,9 @@ namespace GTA.Chrono
                 // Array is indexed from `1 to Internals.MaxOl`, with a `0` index having a meaningless value.
                 return new MonthDayFlags(of.Value + ((uint)Internals.OlToMdl[ol] << 3));
             }
-            else
-            {
-                // throwing an exception here would be reasonable, but we are just going on with a safe value.
-                return new MonthDayFlags(0);
-            }
+
+            // throwing an exception here would be reasonable, but we are just going on with a safe value.
+            return new MonthDayFlags(0);
         }
 
         internal bool IsValid

--- a/source/scripting_v3/GTA.Chrono/MonthDayFlags.cs
+++ b/source/scripting_v3/GTA.Chrono/MonthDayFlags.cs
@@ -103,7 +103,7 @@ namespace GTA.Chrono
             return new MonthDayFlags((_value & ~0b1_1111_0000u) | ((uint)day << 4));
         }
 
-        internal MonthDayFlags WithFlags(YearFlags flags) => new((_value & ~0b1111u) | (flags.Value));
+        internal MonthDayFlags WithFlags(YearFlags flags) => new((_value & ~0b1111u) | flags.Value);
 
         public bool Equals(MonthDayFlags other)
         {

--- a/source/scripting_v3/GTA.Chrono/NumberFormatting.cs
+++ b/source/scripting_v3/GTA.Chrono/NumberFormatting.cs
@@ -51,7 +51,7 @@ namespace GTA.Chrono
             {
                 uint temp = '0' + value;
                 value /= 10;
-                *cur = (char)(temp - (value * 10));
+                *cur = (char)(temp - value * 10);
             }
 
             Debug.Assert(value < 10);
@@ -66,7 +66,7 @@ namespace GTA.Chrono
             {
                 ulong temp = '0' + value;
                 value /= 10;
-                *cur = (char)(temp - (value * 10));
+                *cur = (char)(temp - value * 10);
             }
 
             Debug.Assert(value < 10);

--- a/source/scripting_v3/GTA.Chrono/NumberFormatting.cs
+++ b/source/scripting_v3/GTA.Chrono/NumberFormatting.cs
@@ -30,12 +30,10 @@ namespace GTA.Chrono
         // which `DateTime` uses when `ToString` is called in .NET Framework 4.8 (more than 2x faster).
         internal static unsafe void WriteTwoDigits(uint value, char* ptr)
         {
-            unsafe
-            {
-                int offsetFromDigitsCharsArray = (int)(value * 2);
-                ptr[0] = TwoDigitsChars[offsetFromDigitsCharsArray];
-                ptr[1] = TwoDigitsChars[offsetFromDigitsCharsArray + 1];
-            }
+            int offsetFromDigitsCharsArray = (int)(value * 2);
+
+            ptr[0] = TwoDigitsChars[offsetFromDigitsCharsArray];
+            ptr[1] = TwoDigitsChars[offsetFromDigitsCharsArray + 1];
         }
 
         internal static unsafe void WriteFourDigits(uint value, char* ptr)
@@ -48,20 +46,17 @@ namespace GTA.Chrono
 
         internal static unsafe void WriteDigits(uint value, char* ptr, int count)
         {
-            unsafe
+            char* cur;
+            for (cur = ptr + count - 1; cur > ptr; cur--)
             {
-                char* cur;
-                for (cur = ptr + count - 1; cur > ptr; cur--)
-                {
-                    uint temp = '0' + value;
-                    value /= 10;
-                    *cur = (char)(temp - (value * 10));
-                }
-
-                Debug.Assert(value < 10);
-                Debug.Assert(cur == ptr);
-                *cur = (char)('0' + value);
+                uint temp = '0' + value;
+                value /= 10;
+                *cur = (char)(temp - (value * 10));
             }
+
+            Debug.Assert(value < 10);
+            Debug.Assert(cur == ptr);
+            *cur = (char)('0' + value);
         }
 
         internal static unsafe void WriteDigits(ulong value, char* ptr, int count)

--- a/source/scripting_v3/GTA.Chrono/OrdFlags.cs
+++ b/source/scripting_v3/GTA.Chrono/OrdFlags.cs
@@ -43,7 +43,7 @@ namespace GTA.Chrono
 
         internal static OrdFlags? New(int ordinal, YearFlags flags)
         {
-            var of = new OrdFlags((int)ordinal, flags);
+            var of = new OrdFlags(ordinal, flags);
             return of.Validate();
         }
 

--- a/source/scripting_v3/GTA.Chrono/OrdFlags.cs
+++ b/source/scripting_v3/GTA.Chrono/OrdFlags.cs
@@ -39,7 +39,7 @@ namespace GTA.Chrono
 
         internal uint Value => _value;
 
-        internal uint Ordinal => (_value >> 4);
+        internal uint Ordinal => _value >> 4;
 
         internal static OrdFlags? New(int ordinal, YearFlags flags)
         {
@@ -64,7 +64,7 @@ namespace GTA.Chrono
 
         internal YearFlags Flags => new((byte)(_value & 0b1111));
 
-        internal bool IsLeapYear => ((_value & 0b1000) == 0);
+        internal bool IsLeapYear => (_value & 0b1000) == 0;
 
         internal static OrdFlags FromOrdinalDateUnchecked(int year, int ordinal)
         {

--- a/source/scripting_v3/GTA.Chrono/YearFlags.cs
+++ b/source/scripting_v3/GTA.Chrono/YearFlags.cs
@@ -75,7 +75,7 @@ namespace GTA.Chrono
 
         internal int CalcIsoWeekDelta()
         {
-            int delta = (_value & 0b111);
+            int delta = _value & 0b111;
             if (delta < 3)
             {
                 delta += 7;

--- a/source/scripting_v3/GTA.Math/Matrix.cs
+++ b/source/scripting_v3/GTA.Math/Matrix.cs
@@ -321,7 +321,7 @@ namespace GTA.Math
                     ThrowHelper.ThrowArgumentOutOfRangeException(nameof(row), "Rows and columns for matrices run from 0 to 3, inclusive.");
                 }
 
-                return this[(row * 4) + column];
+                return this[row * 4 + column];
             }
 
             set
@@ -336,7 +336,7 @@ namespace GTA.Math
                     ThrowHelper.ThrowArgumentOutOfRangeException(nameof(row), "Rows and columns for matrices run from 0 to 3, inclusive.");
                 }
 
-                this[(row * 4) + column] = value;
+                this[row * 4 + column] = value;
             }
         }
 
@@ -364,7 +364,7 @@ namespace GTA.Math
 
             for (int i = 0; i < 3; i++)
             {
-                float squareSum = (this[i, 0] * this[i, 0]) + (this[i, 1] * this[i, 1]) + (this[i, 2] * this[i, 2]);
+                float squareSum = this[i, 0] * this[i, 0] + this[i, 1] * this[i, 1] + this[i, 2] * this[i, 2];
                 if (squareSum > tolerance)
                 {
                     scale[i] = (float)System.Math.Sqrt(squareSum);
@@ -397,16 +397,16 @@ namespace GTA.Math
         /// <returns>The determinant of the matrix.</returns>
         public readonly float Determinant()
         {
-            float temp1 = (M33 * M44) - (M34 * M43);
-            float temp2 = (M32 * M44) - (M34 * M42);
-            float temp3 = (M32 * M43) - (M33 * M42);
-            float temp4 = (M31 * M44) - (M34 * M41);
-            float temp5 = (M31 * M43) - (M33 * M41);
-            float temp6 = (M31 * M42) - (M32 * M41);
+            float temp1 = M33 * M44 - M34 * M43;
+            float temp2 = M32 * M44 - M34 * M42;
+            float temp3 = M32 * M43 - M33 * M42;
+            float temp4 = M31 * M44 - M34 * M41;
+            float temp5 = M31 * M43 - M33 * M41;
+            float temp6 = M31 * M42 - M32 * M41;
 
-            return ((((M11 * (((M22 * temp1) - (M23 * temp2)) + (M24 * temp3))) - (M12 * (((M21 * temp1) -
-                (M23 * temp4)) + (M24 * temp5)))) + (M13 * (((M21 * temp2) - (M22 * temp4)) + (M24 * temp6)))) -
-                (M14 * (((M21 * temp3) - (M22 * temp5)) + (M23 * temp6))));
+            return M11 * (M22 * temp1 - M23 * temp2 + M24 * temp3) - M12 * (M21 * temp1 -
+                       M23 * temp4 + M24 * temp5) + M13 * (M21 * temp2 - M22 * temp4 + M24 * temp6) -
+                   M14 * (M21 * temp3 - M22 * temp5 + M23 * temp6);
         }
 
         readonly float Det3x3(float M11, float M12, float M13, float M21, float M22, float M23, float M31, float M32, float M33)
@@ -519,9 +519,9 @@ namespace GTA.Math
             res.M33 = M33;
 
             // Set translation to: `transpose([original rotation]) * (-[original translation])`
-            res.M41 = ((M13 * M43) + (M11 * M41) + (M12 * M42)) * -1f;
-            res.M42 = ((M23 * M43) + (M21 * M41) + (M22 * M42)) * -1f;
-            res.M43 = ((M33 * M43) + (M31 * M41) + (M32 * M42)) * -1f;
+            res.M41 = (M13 * M43 + M11 * M41 + M12 * M42) * -1f;
+            res.M42 = (M23 * M43 + M21 * M41 + M22 * M42) * -1f;
+            res.M43 = (M33 * M43 + M31 * M41 + M32 * M42) * -1f;
 
             // Set affine transform to none
             res.M14 = 0f;
@@ -621,9 +621,9 @@ namespace GTA.Math
         /// <returns>The vector transformed by the inverse of the given <see cref="Matrix"/>.</returns>
         public readonly Vector3 InverseTransformVector(Vector3 vector)
         {
-            float scaleXSquared = (new Vector3(M11, M12, M13)).LengthSquared();
-            float scaleYSquared = (new Vector3(M21, M22, M23)).LengthSquared();
-            float scaleZSquared = (new Vector3(M31, M32, M33)).LengthSquared();
+            float scaleXSquared = new Vector3(M11, M12, M13).LengthSquared();
+            float scaleYSquared = new Vector3(M21, M22, M23).LengthSquared();
+            float scaleZSquared = new Vector3(M31, M32, M33).LengthSquared();
 
             if (System.Math.Abs(1f - scaleXSquared) > F32Epsilon || System.Math.Abs(1f - scaleYSquared) > F32Epsilon || System.Math.Abs(1f - scaleZSquared) > F32Epsilon)
             {
@@ -768,22 +768,22 @@ namespace GTA.Math
         public static Matrix Multiply(Matrix left, Matrix right)
         {
             Matrix result;
-            result.M11 = (left.M11 * right.M11) + (left.M12 * right.M21) + (left.M13 * right.M31) + (left.M14 * right.M41);
-            result.M12 = (left.M11 * right.M12) + (left.M12 * right.M22) + (left.M13 * right.M32) + (left.M14 * right.M42);
-            result.M13 = (left.M11 * right.M13) + (left.M12 * right.M23) + (left.M13 * right.M33) + (left.M14 * right.M43);
-            result.M14 = (left.M11 * right.M14) + (left.M12 * right.M24) + (left.M13 * right.M34) + (left.M14 * right.M44);
-            result.M21 = (left.M21 * right.M11) + (left.M22 * right.M21) + (left.M23 * right.M31) + (left.M24 * right.M41);
-            result.M22 = (left.M21 * right.M12) + (left.M22 * right.M22) + (left.M23 * right.M32) + (left.M24 * right.M42);
-            result.M23 = (left.M21 * right.M13) + (left.M22 * right.M23) + (left.M23 * right.M33) + (left.M24 * right.M43);
-            result.M24 = (left.M21 * right.M14) + (left.M22 * right.M24) + (left.M23 * right.M34) + (left.M24 * right.M44);
-            result.M31 = (left.M31 * right.M11) + (left.M32 * right.M21) + (left.M33 * right.M31) + (left.M34 * right.M41);
-            result.M32 = (left.M31 * right.M12) + (left.M32 * right.M22) + (left.M33 * right.M32) + (left.M34 * right.M42);
-            result.M33 = (left.M31 * right.M13) + (left.M32 * right.M23) + (left.M33 * right.M33) + (left.M34 * right.M43);
-            result.M34 = (left.M31 * right.M14) + (left.M32 * right.M24) + (left.M33 * right.M34) + (left.M34 * right.M44);
-            result.M41 = (left.M41 * right.M11) + (left.M42 * right.M21) + (left.M43 * right.M31) + (left.M44 * right.M41);
-            result.M42 = (left.M41 * right.M12) + (left.M42 * right.M22) + (left.M43 * right.M32) + (left.M44 * right.M42);
-            result.M43 = (left.M41 * right.M13) + (left.M42 * right.M23) + (left.M43 * right.M33) + (left.M44 * right.M43);
-            result.M44 = (left.M41 * right.M14) + (left.M42 * right.M24) + (left.M43 * right.M34) + (left.M44 * right.M44);
+            result.M11 = left.M11 * right.M11 + left.M12 * right.M21 + left.M13 * right.M31 + left.M14 * right.M41;
+            result.M12 = left.M11 * right.M12 + left.M12 * right.M22 + left.M13 * right.M32 + left.M14 * right.M42;
+            result.M13 = left.M11 * right.M13 + left.M12 * right.M23 + left.M13 * right.M33 + left.M14 * right.M43;
+            result.M14 = left.M11 * right.M14 + left.M12 * right.M24 + left.M13 * right.M34 + left.M14 * right.M44;
+            result.M21 = left.M21 * right.M11 + left.M22 * right.M21 + left.M23 * right.M31 + left.M24 * right.M41;
+            result.M22 = left.M21 * right.M12 + left.M22 * right.M22 + left.M23 * right.M32 + left.M24 * right.M42;
+            result.M23 = left.M21 * right.M13 + left.M22 * right.M23 + left.M23 * right.M33 + left.M24 * right.M43;
+            result.M24 = left.M21 * right.M14 + left.M22 * right.M24 + left.M23 * right.M34 + left.M24 * right.M44;
+            result.M31 = left.M31 * right.M11 + left.M32 * right.M21 + left.M33 * right.M31 + left.M34 * right.M41;
+            result.M32 = left.M31 * right.M12 + left.M32 * right.M22 + left.M33 * right.M32 + left.M34 * right.M42;
+            result.M33 = left.M31 * right.M13 + left.M32 * right.M23 + left.M33 * right.M33 + left.M34 * right.M43;
+            result.M34 = left.M31 * right.M14 + left.M32 * right.M24 + left.M33 * right.M34 + left.M34 * right.M44;
+            result.M41 = left.M41 * right.M11 + left.M42 * right.M21 + left.M43 * right.M31 + left.M44 * right.M41;
+            result.M42 = left.M41 * right.M12 + left.M42 * right.M22 + left.M43 * right.M32 + left.M44 * right.M42;
+            result.M43 = left.M41 * right.M13 + left.M42 * right.M23 + left.M43 * right.M33 + left.M44 * right.M43;
+            result.M44 = left.M41 * right.M14 + left.M42 * right.M24 + left.M43 * right.M34 + left.M44 * right.M44;
             return result;
         }
 
@@ -925,22 +925,22 @@ namespace GTA.Math
         public static Matrix Lerp(Matrix start, Matrix end, float amount)
         {
             Matrix result;
-            result.M11 = start.M11 + ((end.M11 - start.M11) * amount);
-            result.M12 = start.M12 + ((end.M12 - start.M12) * amount);
-            result.M13 = start.M13 + ((end.M13 - start.M13) * amount);
-            result.M14 = start.M14 + ((end.M14 - start.M14) * amount);
-            result.M21 = start.M21 + ((end.M21 - start.M21) * amount);
-            result.M22 = start.M22 + ((end.M22 - start.M22) * amount);
-            result.M23 = start.M23 + ((end.M23 - start.M23) * amount);
-            result.M24 = start.M24 + ((end.M24 - start.M24) * amount);
-            result.M31 = start.M31 + ((end.M31 - start.M31) * amount);
-            result.M32 = start.M32 + ((end.M32 - start.M32) * amount);
-            result.M33 = start.M33 + ((end.M33 - start.M33) * amount);
-            result.M34 = start.M34 + ((end.M34 - start.M34) * amount);
-            result.M41 = start.M41 + ((end.M41 - start.M41) * amount);
-            result.M42 = start.M42 + ((end.M42 - start.M42) * amount);
-            result.M43 = start.M43 + ((end.M43 - start.M43) * amount);
-            result.M44 = start.M44 + ((end.M44 - start.M44) * amount);
+            result.M11 = start.M11 + (end.M11 - start.M11) * amount;
+            result.M12 = start.M12 + (end.M12 - start.M12) * amount;
+            result.M13 = start.M13 + (end.M13 - start.M13) * amount;
+            result.M14 = start.M14 + (end.M14 - start.M14) * amount;
+            result.M21 = start.M21 + (end.M21 - start.M21) * amount;
+            result.M22 = start.M22 + (end.M22 - start.M22) * amount;
+            result.M23 = start.M23 + (end.M23 - start.M23) * amount;
+            result.M24 = start.M24 + (end.M24 - start.M24) * amount;
+            result.M31 = start.M31 + (end.M31 - start.M31) * amount;
+            result.M32 = start.M32 + (end.M32 - start.M32) * amount;
+            result.M33 = start.M33 + (end.M33 - start.M33) * amount;
+            result.M34 = start.M34 + (end.M34 - start.M34) * amount;
+            result.M41 = start.M41 + (end.M41 - start.M41) * amount;
+            result.M42 = start.M42 + (end.M42 - start.M42) * amount;
+            result.M43 = start.M43 + (end.M43 - start.M43) * amount;
+            result.M44 = start.M44 + (end.M44 - start.M44) * amount;
             return result;
         }
 
@@ -953,7 +953,7 @@ namespace GTA.Math
         {
             Matrix result;
             float cos = (float)System.Math.Cos(angle);
-            float sin = (float)(System.Math.Sin(angle));
+            float sin = (float)System.Math.Sin(angle);
 
             result.M11 = 1.0f;
             result.M12 = 0.0f;
@@ -983,8 +983,8 @@ namespace GTA.Math
         public static Matrix RotationY(float angle)
         {
             Matrix result;
-            float cos = (float)(System.Math.Cos(angle));
-            float sin = (float)(System.Math.Sin(angle));
+            float cos = (float)System.Math.Cos(angle);
+            float sin = (float)System.Math.Sin(angle);
 
             result.M11 = cos;
             result.M12 = 0.0f;
@@ -1014,8 +1014,8 @@ namespace GTA.Math
         public static Matrix RotationZ(float angle)
         {
             Matrix result;
-            float cos = (float)(System.Math.Cos(angle));
-            float sin = (float)(System.Math.Sin(angle));
+            float cos = (float)System.Math.Cos(angle);
+            float sin = (float)System.Math.Sin(angle);
 
             result.M11 = cos;
             result.M12 = sin;
@@ -1054,8 +1054,8 @@ namespace GTA.Math
             float x = axis.X;
             float y = axis.Y;
             float z = axis.Z;
-            float cos = (float)(System.Math.Cos(angle));
-            float sin = (float)(System.Math.Sin(angle));
+            float cos = (float)System.Math.Cos(angle);
+            float sin = (float)System.Math.Sin(angle);
             float xx = x * x;
             float yy = y * y;
             float zz = z * z;
@@ -1063,17 +1063,17 @@ namespace GTA.Math
             float xz = x * z;
             float yz = y * z;
 
-            result.M11 = xx + (cos * (1.0f - xx));
-            result.M12 = (xy - (cos * xy)) + (sin * z);
-            result.M13 = (xz - (cos * xz)) - (sin * y);
+            result.M11 = xx + cos * (1.0f - xx);
+            result.M12 = xy - cos * xy + sin * z;
+            result.M13 = xz - cos * xz - sin * y;
             result.M14 = 0.0f;
-            result.M21 = (xy - (cos * xy)) - (sin * z);
-            result.M22 = yy + (cos * (1.0f - yy));
-            result.M23 = (yz - (cos * yz)) + (sin * x);
+            result.M21 = xy - cos * xy - sin * z;
+            result.M22 = yy + cos * (1.0f - yy);
+            result.M23 = yz - cos * yz + sin * x;
             result.M24 = 0.0f;
-            result.M31 = (xz - (cos * xz)) + (sin * y);
-            result.M32 = (yz - (cos * yz)) - (sin * x);
-            result.M33 = zz + (cos * (1.0f - zz));
+            result.M31 = xz - cos * xz + sin * y;
+            result.M32 = yz - cos * yz - sin * x;
+            result.M33 = zz + cos * (1.0f - zz);
             result.M34 = 0.0f;
             result.M41 = 0.0f;
             result.M42 = 0.0f;
@@ -1101,17 +1101,17 @@ namespace GTA.Math
             float yw = rotation.Y * rotation.W;
             float yz = rotation.Y * rotation.Z;
             float xw = rotation.X * rotation.W;
-            result.M11 = 1.0f - (2.0f * (yy + zz));
+            result.M11 = 1.0f - 2.0f * (yy + zz);
             result.M12 = 2.0f * (xy + zw);
             result.M13 = 2.0f * (zx - yw);
             result.M14 = 0.0f;
             result.M21 = 2.0f * (xy - zw);
-            result.M22 = 1.0f - (2.0f * (zz + xx));
+            result.M22 = 1.0f - 2.0f * (zz + xx);
             result.M23 = 2.0f * (yz + xw);
             result.M24 = 0.0f;
             result.M31 = 2.0f * (zx + yw);
             result.M32 = 2.0f * (yz - xw);
-            result.M33 = 1.0f - (2.0f * (yy + xx));
+            result.M33 = 1.0f - 2.0f * (yy + xx);
             result.M34 = 0.0f;
             result.M41 = 0.0f;
             result.M42 = 0.0f;
@@ -1337,9 +1337,9 @@ namespace GTA.Math
         /// <param name="tolerance">The error tolerance.</param>
         public void RemoveScaling(float tolerance)
         {
-            float scaleXSquared = (new Vector3(M11, M12, M13)).LengthSquared();
-            float scaleYSquared = (new Vector3(M21, M22, M23)).LengthSquared();
-            float scaleZSquared = (new Vector3(M31, M32, M33)).LengthSquared();
+            float scaleXSquared = new Vector3(M11, M12, M13).LengthSquared();
+            float scaleYSquared = new Vector3(M21, M22, M23).LengthSquared();
+            float scaleZSquared = new Vector3(M31, M32, M33).LengthSquared();
 
             if (System.Math.Abs(1f - scaleXSquared) > tolerance)
             {
@@ -1513,22 +1513,22 @@ namespace GTA.Math
         public static Matrix operator *(Matrix left, Matrix right)
         {
             Matrix result;
-            result.M11 = (left.M11 * right.M11) + (left.M12 * right.M21) + (left.M13 * right.M31) + (left.M14 * right.M41);
-            result.M12 = (left.M11 * right.M12) + (left.M12 * right.M22) + (left.M13 * right.M32) + (left.M14 * right.M42);
-            result.M13 = (left.M11 * right.M13) + (left.M12 * right.M23) + (left.M13 * right.M33) + (left.M14 * right.M43);
-            result.M14 = (left.M11 * right.M14) + (left.M12 * right.M24) + (left.M13 * right.M34) + (left.M14 * right.M44);
-            result.M21 = (left.M21 * right.M11) + (left.M22 * right.M21) + (left.M23 * right.M31) + (left.M24 * right.M41);
-            result.M22 = (left.M21 * right.M12) + (left.M22 * right.M22) + (left.M23 * right.M32) + (left.M24 * right.M42);
-            result.M23 = (left.M21 * right.M13) + (left.M22 * right.M23) + (left.M23 * right.M33) + (left.M24 * right.M43);
-            result.M24 = (left.M21 * right.M14) + (left.M22 * right.M24) + (left.M23 * right.M34) + (left.M24 * right.M44);
-            result.M31 = (left.M31 * right.M11) + (left.M32 * right.M21) + (left.M33 * right.M31) + (left.M34 * right.M41);
-            result.M32 = (left.M31 * right.M12) + (left.M32 * right.M22) + (left.M33 * right.M32) + (left.M34 * right.M42);
-            result.M33 = (left.M31 * right.M13) + (left.M32 * right.M23) + (left.M33 * right.M33) + (left.M34 * right.M43);
-            result.M34 = (left.M31 * right.M14) + (left.M32 * right.M24) + (left.M33 * right.M34) + (left.M34 * right.M44);
-            result.M41 = (left.M41 * right.M11) + (left.M42 * right.M21) + (left.M43 * right.M31) + (left.M44 * right.M41);
-            result.M42 = (left.M41 * right.M12) + (left.M42 * right.M22) + (left.M43 * right.M32) + (left.M44 * right.M42);
-            result.M43 = (left.M41 * right.M13) + (left.M42 * right.M23) + (left.M43 * right.M33) + (left.M44 * right.M43);
-            result.M44 = (left.M41 * right.M14) + (left.M42 * right.M24) + (left.M43 * right.M34) + (left.M44 * right.M44);
+            result.M11 = left.M11 * right.M11 + left.M12 * right.M21 + left.M13 * right.M31 + left.M14 * right.M41;
+            result.M12 = left.M11 * right.M12 + left.M12 * right.M22 + left.M13 * right.M32 + left.M14 * right.M42;
+            result.M13 = left.M11 * right.M13 + left.M12 * right.M23 + left.M13 * right.M33 + left.M14 * right.M43;
+            result.M14 = left.M11 * right.M14 + left.M12 * right.M24 + left.M13 * right.M34 + left.M14 * right.M44;
+            result.M21 = left.M21 * right.M11 + left.M22 * right.M21 + left.M23 * right.M31 + left.M24 * right.M41;
+            result.M22 = left.M21 * right.M12 + left.M22 * right.M22 + left.M23 * right.M32 + left.M24 * right.M42;
+            result.M23 = left.M21 * right.M13 + left.M22 * right.M23 + left.M23 * right.M33 + left.M24 * right.M43;
+            result.M24 = left.M21 * right.M14 + left.M22 * right.M24 + left.M23 * right.M34 + left.M24 * right.M44;
+            result.M31 = left.M31 * right.M11 + left.M32 * right.M21 + left.M33 * right.M31 + left.M34 * right.M41;
+            result.M32 = left.M31 * right.M12 + left.M32 * right.M22 + left.M33 * right.M32 + left.M34 * right.M42;
+            result.M33 = left.M31 * right.M13 + left.M32 * right.M23 + left.M33 * right.M33 + left.M34 * right.M43;
+            result.M34 = left.M31 * right.M14 + left.M32 * right.M24 + left.M33 * right.M34 + left.M34 * right.M44;
+            result.M41 = left.M41 * right.M11 + left.M42 * right.M21 + left.M43 * right.M31 + left.M44 * right.M41;
+            result.M42 = left.M41 * right.M12 + left.M42 * right.M22 + left.M43 * right.M32 + left.M44 * right.M42;
+            result.M43 = left.M41 * right.M13 + left.M42 * right.M23 + left.M43 * right.M33 + left.M44 * right.M43;
+            result.M44 = left.M41 * right.M14 + left.M42 * right.M24 + left.M43 * right.M34 + left.M44 * right.M44;
             return result;
         }
 
@@ -1717,10 +1717,10 @@ namespace GTA.Math
         /// <returns><see langword="true" /> if the current instance is equal to the specified object; <see langword="false" /> otherwise.</returns>
         public readonly bool Equals(Matrix other)
         {
-            return (M11 == other.M11 && M12 == other.M12 && M13 == other.M13 && M14 == other.M14 &&
-                M21 == other.M21 && M22 == other.M22 && M23 == other.M23 && M24 == other.M24 &&
-                M31 == other.M31 && M32 == other.M32 && M33 == other.M33 && M34 == other.M34 &&
-                M41 == other.M41 && M42 == other.M42 && M43 == other.M43 && M44 == other.M44);
+            return M11 == other.M11 && M12 == other.M12 && M13 == other.M13 && M14 == other.M14 &&
+                   M21 == other.M21 && M22 == other.M22 && M23 == other.M23 && M24 == other.M24 &&
+                   M31 == other.M31 && M32 == other.M32 && M33 == other.M33 && M34 == other.M34 &&
+                   M41 == other.M41 && M42 == other.M42 && M43 == other.M43 && M44 == other.M44;
         }
     }
 }

--- a/source/scripting_v3/GTA.Math/Plane.cs
+++ b/source/scripting_v3/GTA.Math/Plane.cs
@@ -107,9 +107,9 @@ namespace GTA.Math
                 return false;
             }
 
-            dest = ((Vector3.Cross(normalB, normalC) * a.D) +
-                    (Vector3.Cross(normalC, normalA) * b.D) +
-                    (Vector3.Cross(normalA, normalB) * c.D)) /
+            dest = (Vector3.Cross(normalB, normalC) * a.D +
+                    Vector3.Cross(normalC, normalA) * b.D +
+                    Vector3.Cross(normalA, normalB) * c.D) /
                    det;
 
             return true;

--- a/source/scripting_v3/GTA.Math/Quaternion.cs
+++ b/source/scripting_v3/GTA.Math/Quaternion.cs
@@ -76,8 +76,8 @@ namespace GTA.Math
             axis = Vector3.Normalize(axis);
 
             float half = angle * 0.5f;
-            float sin = (float)(System.Math.Sin(half));
-            float cos = (float)(System.Math.Cos(half));
+            float sin = (float)System.Math.Sin(half);
+            float cos = (float)System.Math.Cos(half);
 
             X = axis.X * sin;
             Y = axis.Y * sin;
@@ -112,7 +112,7 @@ namespace GTA.Math
                     return Vector3.Zero;
                 }
 
-                float length = 1.0f - (W * W);
+                float length = 1.0f - W * W;
                 if (length == 0f)
                 {
                     return Vector3.UnitX;
@@ -126,19 +126,19 @@ namespace GTA.Math
         /// <summary>
         /// Gets the angle of the quaternion.
         /// </summary>
-        public readonly float Angle => ((System.Math.Abs(W) <= 1.0f) ? 2.0f * (float)(System.Math.Acos(W)) : 0.0f);
+        public readonly float Angle => System.Math.Abs(W) <= 1.0f ? 2.0f * (float)System.Math.Acos(W) : 0.0f;
 
         /// <summary>
         /// Calculates the length of the quaternion.
         /// </summary>
         /// <returns>The length of the quaternion.</returns>
-        public readonly float Length() => (float)System.Math.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));
+        public readonly float Length() => (float)System.Math.Sqrt(X * X + Y * Y + Z * Z + W * W);
 
         /// <summary>
         /// Calculates the squared length of the quaternion.
         /// </summary>
         /// <returns>The squared length of the quaternion.</returns>
-        public readonly float LengthSquared() => (X * X) + (Y * Y) + (Z * Z) + (W * W);
+        public readonly float LengthSquared() => X * X + Y * Y + Z * Z + W * W;
 
         /// <summary>
         /// Converts the quaternion into a unit quaternion.
@@ -252,10 +252,10 @@ namespace GTA.Math
             float rz = right.Z;
             float rw = right.W;
 
-            quaternion.X = (lx * rw + rx * lw) + (ly * rz) - (lz * ry);
-            quaternion.Y = (ly * rw + ry * lw) + (lz * rx) - (lx * rz);
-            quaternion.Z = (lz * rw + rz * lw) + (lx * ry) - (ly * rx);
-            quaternion.W = (lw * rw) - (lx * rx + ly * ry + lz * rz);
+            quaternion.X = lx * rw + rx * lw + ly * rz - lz * ry;
+            quaternion.Y = ly * rw + ry * lw + lz * rx - lx * rz;
+            quaternion.Z = lz * rw + rz * lw + lx * ry - ly * rx;
+            quaternion.W = lw * rw - (lx * rx + ly * ry + lz * rz);
 
             return quaternion;
         }
@@ -323,7 +323,7 @@ namespace GTA.Math
         public static Quaternion Invert(Quaternion quaternion)
         {
             Quaternion result = Zero;
-            float lengthSq = 1.0f / ((quaternion.X * quaternion.X) + (quaternion.Y * quaternion.Y) + (quaternion.Z * quaternion.Z) + (quaternion.W * quaternion.W));
+            float lengthSq = 1.0f / (quaternion.X * quaternion.X + quaternion.Y * quaternion.Y + quaternion.Z * quaternion.Z + quaternion.W * quaternion.W);
 
             result.X = -quaternion.X * lengthSq;
             result.Y = -quaternion.Y * lengthSq;
@@ -339,7 +339,7 @@ namespace GTA.Math
         /// <param name="left">First source quaternion.</param>
         /// <param name="right">Second source quaternion.</param>
         /// <returns>The dot product of the two quaternions.</returns>
-        public static float Dot(Quaternion left, Quaternion right) => (left.X * right.X) + (left.Y * right.Y) + (left.Z * right.Z) + (left.W * right.W);
+        public static float Dot(Quaternion left, Quaternion right) => left.X * right.X + left.Y * right.Y + left.Z * right.Z + left.W * right.W;
 
         /// <summary>
         /// Performs a linear interpolation between two quaternion.
@@ -357,21 +357,21 @@ namespace GTA.Math
         {
             Quaternion result = Zero;
             float inverse = 1.0f - amount;
-            float dot = (start.X * end.X) + (start.Y * end.Y) + (start.Z * end.Z) + (start.W * end.W);
+            float dot = start.X * end.X + start.Y * end.Y + start.Z * end.Z + start.W * end.W;
 
             if (dot >= 0.0f)
             {
-                result.X = (inverse * start.X) + (amount * end.X);
-                result.Y = (inverse * start.Y) + (amount * end.Y);
-                result.Z = (inverse * start.Z) + (amount * end.Z);
-                result.W = (inverse * start.W) + (amount * end.W);
+                result.X = inverse * start.X + amount * end.X;
+                result.Y = inverse * start.Y + amount * end.Y;
+                result.Z = inverse * start.Z + amount * end.Z;
+                result.W = inverse * start.W + amount * end.W;
             }
             else
             {
-                result.X = (inverse * start.X) - (amount * end.X);
-                result.Y = (inverse * start.Y) - (amount * end.Y);
-                result.Z = (inverse * start.Z) - (amount * end.Z);
-                result.W = (inverse * start.W) - (amount * end.W);
+                result.X = inverse * start.X - amount * end.X;
+                result.Y = inverse * start.Y - amount * end.Y;
+                result.Z = inverse * start.Z - amount * end.Z;
+                result.W = inverse * start.W - amount * end.W;
             }
 
             float invLength = 1.0f / result.Length();
@@ -398,7 +398,7 @@ namespace GTA.Math
         public static Quaternion Slerp(Quaternion start, Quaternion end, float amount)
         {
             Quaternion result = Zero;
-            float kEpsilon = (float)(1.192093E-07);
+            float kEpsilon = (float)1.192093E-07;
             float opposite;
             float inverse;
             float dot = Dot(start, end);
@@ -406,7 +406,7 @@ namespace GTA.Math
             // exactly zero
             float dotSign = dot >= 0.0f ? 1.0f : -1.0f;
 
-            if (System.Math.Abs(dot) > (1.0f - kEpsilon))
+            if (System.Math.Abs(dot) > 1.0f - kEpsilon)
             {
                 inverse = 1.0f - amount;
                 opposite = amount * dotSign;
@@ -420,10 +420,10 @@ namespace GTA.Math
                 opposite = (float)(System.Math.Sin(amount * aCos) * invSin * dotSign);
             }
 
-            result.X = (inverse * start.X) + (opposite * end.X);
-            result.Y = (inverse * start.Y) + (opposite * end.Y);
-            result.Z = (inverse * start.Z) + (opposite * end.Z);
-            result.W = (inverse * start.W) + (opposite * end.W);
+            result.X = inverse * start.X + opposite * end.X;
+            result.Y = inverse * start.Y + opposite * end.Y;
+            result.Z = inverse * start.Z + opposite * end.Z;
+            result.W = inverse * start.W + opposite * end.W;
 
             return result;
         }
@@ -452,7 +452,7 @@ namespace GTA.Math
         /// </summary>
         public static Quaternion FromToRotation(Vector3 fromDirection, Vector3 toDirection)
         {
-            float NormAB = (float)(System.Math.Sqrt(fromDirection.LengthSquared() * fromDirection.LengthSquared()));
+            float NormAB = (float)System.Math.Sqrt(fromDirection.LengthSquared() * fromDirection.LengthSquared());
 
             float w = NormAB + Vector3.Dot(fromDirection, toDirection);
             Quaternion Result;
@@ -503,11 +503,11 @@ namespace GTA.Math
         public static float AngleBetween(Quaternion a, Quaternion b)
         {
             float dot = Dot(a, b);
-            return (float)((System.Math.Acos(System.Math.Min(System.Math.Abs(dot), 1.0f)) * 2.0 * (180.0f / System.Math.PI)));
+            return (float)(System.Math.Acos(System.Math.Min(System.Math.Abs(dot), 1.0f)) * 2.0 * (180.0f / System.Math.PI));
         }
 
-        const float Deg2Rad = (float)((System.Math.PI / 180.0));
-        const float Rad2Deg = (float)((180.0 / System.Math.PI));
+        const float Deg2Rad = (float)(System.Math.PI / 180.0);
+        const float Rad2Deg = (float)(180.0 / System.Math.PI);
 
         /// <summary>
         /// <para>Returns a rotation that rotates z degrees around the z axis, x degrees around the x-axis, and y degrees around the y-axis (in that order).</para>
@@ -589,52 +589,52 @@ namespace GTA.Math
             Quaternion result = Zero;
 
             float halfX = x * 0.5f * Deg2Rad;
-            float sinX = (float)(System.Math.Sin((halfX)));
-            float cosX = (float)(System.Math.Cos((halfX)));
+            float sinX = (float)System.Math.Sin(halfX);
+            float cosX = (float)System.Math.Cos(halfX);
             float halfY = y * 0.5f * Deg2Rad;
-            float sinY = (float)(System.Math.Sin((halfY)));
-            float cosY = (float)(System.Math.Cos((halfY)));
+            float sinY = (float)System.Math.Sin(halfY);
+            float cosY = (float)System.Math.Cos(halfY);
             float halfZ = z * 0.5f * Deg2Rad;
-            float sinZ = (float)(System.Math.Sin((halfZ)));
-            float cosZ = (float)(System.Math.Cos((halfZ)));
+            float sinZ = (float)System.Math.Sin(halfZ);
+            float cosZ = (float)System.Math.Cos(halfZ);
 
             switch (rotationOrder)
             {
                 case EulerRotationOrder.XYZ:
-                    result.X = (sinX * cosY * cosZ) - (cosX * sinY * sinZ);
-                    result.Y = (cosX * sinY * cosZ) + (sinX * cosY * sinZ);
-                    result.Z = (cosX * cosY * sinZ) - (sinX * sinY * cosZ);
-                    result.W = (cosY * cosX * cosZ) + (sinY * sinX * sinZ);
+                    result.X = sinX * cosY * cosZ - cosX * sinY * sinZ;
+                    result.Y = cosX * sinY * cosZ + sinX * cosY * sinZ;
+                    result.Z = cosX * cosY * sinZ - sinX * sinY * cosZ;
+                    result.W = cosY * cosX * cosZ + sinY * sinX * sinZ;
                     break;
                 case EulerRotationOrder.XZY:
-                    result.X = (cosX * sinY * sinZ) + (sinX * cosY * cosZ);
-                    result.Y = (cosX * sinY * cosZ) + (sinX * cosY * sinZ);
-                    result.Z = (cosX * cosY * sinZ) - (sinX * sinY * cosZ);
-                    result.W = (cosX * cosY * cosZ) - (sinX * sinY * sinZ);
+                    result.X = cosX * sinY * sinZ + sinX * cosY * cosZ;
+                    result.Y = cosX * sinY * cosZ + sinX * cosY * sinZ;
+                    result.Z = cosX * cosY * sinZ - sinX * sinY * cosZ;
+                    result.W = cosX * cosY * cosZ - sinX * sinY * sinZ;
                     break;
                 case EulerRotationOrder.YXZ:
-                    result.X = (sinX * cosY * cosZ) - (cosX * sinY * sinZ);
-                    result.Y = (cosX * sinY * cosZ) + (sinX * cosY * sinZ);
-                    result.Z = (cosX * cosY * sinZ) + (sinX * sinY * cosZ);
-                    result.W = (cosY * cosX * cosZ) - (sinY * sinX * sinZ);
+                    result.X = sinX * cosY * cosZ - cosX * sinY * sinZ;
+                    result.Y = cosX * sinY * cosZ + sinX * cosY * sinZ;
+                    result.Z = cosX * cosY * sinZ + sinX * sinY * cosZ;
+                    result.W = cosY * cosX * cosZ - sinY * sinX * sinZ;
                     break;
                 case EulerRotationOrder.YZX:
-                    result.X = (sinX * cosY * cosZ) - (cosX * sinY * sinZ);
-                    result.Y = (cosX * sinY * cosZ) - (sinX * cosY * sinZ);
-                    result.Z = (cosX * cosY * sinZ) + (sinX * sinY * cosZ);
-                    result.W = (cosY * cosX * cosZ) + (sinY * sinX * sinZ);
+                    result.X = sinX * cosY * cosZ - cosX * sinY * sinZ;
+                    result.Y = cosX * sinY * cosZ - sinX * cosY * sinZ;
+                    result.Z = cosX * cosY * sinZ + sinX * sinY * cosZ;
+                    result.W = cosY * cosX * cosZ + sinY * sinX * sinZ;
                     break;
                 case EulerRotationOrder.ZXY:
-                    result.X = (cosX * sinY * sinZ) + (sinX * cosY * cosZ);
-                    result.Y = (cosX * sinY * cosZ) - (sinX * cosY * sinZ);
-                    result.Z = (cosX * cosY * sinZ) - (sinX * sinY * cosZ);
-                    result.W = (cosY * cosX * cosZ) + (sinY * sinX * sinZ);
+                    result.X = cosX * sinY * sinZ + sinX * cosY * cosZ;
+                    result.Y = cosX * sinY * cosZ - sinX * cosY * sinZ;
+                    result.Z = cosX * cosY * sinZ - sinX * sinY * cosZ;
+                    result.W = cosY * cosX * cosZ + sinY * sinX * sinZ;
                     break;
                 case EulerRotationOrder.ZYX:
-                    result.X = (cosX * sinY * sinZ) + (sinX * cosY * cosZ);
-                    result.Y = (cosX * sinY * cosZ) - (sinX * cosY * sinZ);
-                    result.Z = (cosX * cosY * sinZ) + (sinX * sinY * cosZ);
-                    result.W = (cosY * cosX * cosZ) - (sinY * sinX * sinZ);
+                    result.X = cosX * sinY * sinZ + sinX * cosY * cosZ;
+                    result.Y = cosX * sinY * cosZ - sinX * cosY * sinZ;
+                    result.Z = cosX * cosY * sinZ + sinX * sinY * cosZ;
+                    result.W = cosY * cosX * cosZ - sinY * sinX * sinZ;
                     break;
                 default:
                     ThrowHelper.ThrowArgumentException("Enum value was out of legal range.", nameof(rotationOrder));
@@ -691,93 +691,93 @@ namespace GTA.Math
         const float SingularityThreshold = 0.4999995f;
         private readonly Vector3 ToEulerYXZ()
         {
-            float singularityTest = (Y * Z) + (X * W);
+            float singularityTest = Y * Z + X * W;
 
             if (singularityTest > SingularityThreshold)
             {
-                float m10 = 2 * ((X * Y) + (Z * W));
-                float m00 = 2 * ((W * W) + (X * X)) - 1;
+                float m10 = 2 * (X * Y + Z * W);
+                float m00 = 2 * (W * W + X * X) - 1;
 
                 return new Vector3(90f, (float)System.Math.Atan2(m10, m00) * Rad2Deg, 0f);
             }
             if (singularityTest < -SingularityThreshold)
             {
-                float m10 = 2 * ((X * Y) + (Z * W));
-                float m00 = 2 * ((W * W) + (X * X)) - 1;
+                float m10 = 2 * (X * Y + Z * W);
+                float m00 = 2 * (W * W + X * X) - 1;
 
                 return new Vector3(-90f, (float)System.Math.Atan2(-m10, m00) * Rad2Deg, 0f);
             }
 
             float rotX = (float)System.Math.Asin(2 * singularityTest);
 
-            float m20 = 2 * ((X * Z) - (Y * W));
-            float m22 = 2 * ((W * W) + (Z * Z)) - 1;
+            float m20 = 2 * (X * Z - Y * W);
+            float m22 = 2 * (W * W + Z * Z) - 1;
             float rotY = (float)System.Math.Atan2(-m20, m22);
 
-            float m01 = 2 * ((X * Y) - (Z * W));
-            float m11 = 2 * ((W * W) + (Y * Y)) - 1;
+            float m01 = 2 * (X * Y - Z * W);
+            float m11 = 2 * (W * W + Y * Y) - 1;
             float rotZ = (float)System.Math.Atan2(-m01, m11);
 
             return new Vector3(rotX * Rad2Deg, rotY * Rad2Deg, rotZ * Rad2Deg);
         }
         private readonly Vector3 ToEulerXYZ()
         {
-            float singularityTest = (X * Z) - (Y * W);
+            float singularityTest = X * Z - Y * W;
 
             if (singularityTest < -SingularityThreshold)
             {
-                float m01 = 2 * ((X * Y) - (Z * W));
-                float m11 = 2 * ((W * W) + (Y * Y)) - 1;
+                float m01 = 2 * (X * Y - Z * W);
+                float m11 = 2 * (W * W + Y * Y) - 1;
 
                 return new Vector3((float)System.Math.Atan2(m01, m11) * Rad2Deg, 90f, 0f);
             }
 
             if (singularityTest > SingularityThreshold)
             {
-                float m01 = 2 * ((X * Y) - (Z * W));
-                float m11 = 2 * ((W * W) + (Y * Y)) - 1;
+                float m01 = 2 * (X * Y - Z * W);
+                float m11 = 2 * (W * W + Y * Y) - 1;
 
                 return new Vector3((float)System.Math.Atan2(-m01, m11) * Rad2Deg, -90f, 0f);
             }
 
-            float m21 = 2 * ((Y * Z) + (X * W));
-            float m22 = 2 * ((W * W) + (Z * Z)) - 1;
+            float m21 = 2 * (Y * Z + X * W);
+            float m22 = 2 * (W * W + Z * Z) - 1;
             float rotX = (float)System.Math.Atan2(m21, m22);
 
             float rotY = (float)System.Math.Asin(-2 * singularityTest);
 
-            float m10 = 2 * ((X * Y) + (Z * W));
-            float m00 = 2 * ((W * W) + (X * X)) - 1;
+            float m10 = 2 * (X * Y + Z * W);
+            float m00 = 2 * (W * W + X * X) - 1;
             float rotZ = (float)System.Math.Atan2(m10, m00);
 
             return new Vector3(rotX * Rad2Deg, rotY * Rad2Deg, rotZ * Rad2Deg);
         }
         private readonly Vector3 ToEulerXZY()
         {
-            float singularityTest = (X * Y) + (Z * W);
+            float singularityTest = X * Y + Z * W;
 
             if (singularityTest > SingularityThreshold)
             {
-                float m02 = 2 * ((X * Z) + (Y * W));
-                float m22 = 2 * ((W * W) + (Z * Z)) - 1;
+                float m02 = 2 * (X * Z + Y * W);
+                float m22 = 2 * (W * W + Z * Z) - 1;
 
                 return new Vector3((float)System.Math.Atan2(m02, m22) * Rad2Deg, 0f, 90f);
             }
 
             if (singularityTest < -SingularityThreshold)
             {
-                float m02 = 2 * ((X * Z) + (Y * W));
-                float m22 = 2 * ((W * W) + (Z * Z)) - 1;
+                float m02 = 2 * (X * Z + Y * W);
+                float m22 = 2 * (W * W + Z * Z) - 1;
 
                 return new Vector3((float)System.Math.Atan2(-m02, m22) * Rad2Deg, 0f, -90f);
             }
 
-            float m12 = 2 * ((Y * Z) - (X * W));
-            float m11 = 2 * ((W * W) + (Y * Y)) - 1;
+            float m12 = 2 * (Y * Z - X * W);
+            float m11 = 2 * (W * W + Y * Y) - 1;
             float rotX = (float)System.Math.Atan2(-m12, m11);
 
-            float m20 = 2 * ((X * Z) - (Y * W));
-            float m00 = 2 * ((W * W) + (X * X)) - 1;
+            float m20 = 2 * (X * Z - Y * W);
+            float m00 = 2 * (W * W + X * X) - 1;
             float rotY = (float)System.Math.Atan2(-m20, m00);
 
             float rotZ = (float)System.Math.Asin(2 * singularityTest);
@@ -786,30 +786,30 @@ namespace GTA.Math
         }
         private readonly Vector3 ToEulerYZX()
         {
-            float singularityTest = (X * Y) - (Z * W);
+            float singularityTest = X * Y - Z * W;
 
             if (singularityTest > SingularityThreshold)
             {
-                float m12 = 2 * ((Y * Z) - (X * W));
-                float m22 = 2 * ((W * W) + (Z * Z)) - 1;
+                float m12 = 2 * (Y * Z - X * W);
+                float m22 = 2 * (W * W + Z * Z) - 1;
 
                 return new Vector3(0f, (float)System.Math.Atan2(-m12, m22) * Rad2Deg, -90f);
             }
 
             if (singularityTest < -SingularityThreshold)
             {
-                float m12 = 2 * ((Y * Z) - (X * W));
-                float m22 = 2 * ((W * W) + (Z * Z)) - 1;
+                float m12 = 2 * (Y * Z - X * W);
+                float m22 = 2 * (W * W + Z * Z) - 1;
 
                 return new Vector3(0f, (float)System.Math.Atan2(m12, m22) * Rad2Deg, 90f);
             }
 
-            float m21 = 2 * ((Y * Z) + (X * W));
-            float m11 = 2 * ((W * W) + (Y * Y)) - 1;
+            float m21 = 2 * (Y * Z + X * W);
+            float m11 = 2 * (W * W + Y * Y) - 1;
             float rotX = (float)System.Math.Atan2(m21, m11);
 
-            float m02 = 2 * ((X * Z) + (Y * W));
-            float m00 = 2 * ((W * W) + (X * X)) - 1;
+            float m02 = 2 * (X * Z + Y * W);
+            float m00 = 2 * (W * W + X * X) - 1;
             float rotY = (float)System.Math.Atan2(m02, m00);
 
             float rotZ = (float)System.Math.Asin(-2 * singularityTest);
@@ -818,64 +818,64 @@ namespace GTA.Math
         }
         private readonly Vector3 ToEulerZXY()
         {
-            float singularityTest = (Y * Z) - (X * W);
+            float singularityTest = Y * Z - X * W;
 
             if (singularityTest > SingularityThreshold)
             {
-                float m20 = 2 * ((X * Z) - (Y * W));
-                float m00 = 2 * ((W * W) + (X * X)) - 1;
+                float m20 = 2 * (X * Z - Y * W);
+                float m00 = 2 * (W * W + X * X) - 1;
 
                 return new Vector3(-90f, 0f, (float)System.Math.Atan2(-m20, m00) * Rad2Deg);
             }
 
             if (singularityTest < -SingularityThreshold)
             {
-                float m20 = 2 * ((X * Z) - (Y * W));
-                float m00 = 2 * ((W * W) + (X * X)) - 1;
+                float m20 = 2 * (X * Z - Y * W);
+                float m00 = 2 * (W * W + X * X) - 1;
 
                 return new Vector3(90f, 0f, (float)System.Math.Atan2(m20, m00) * Rad2Deg);
             }
 
             float rotX = (float)System.Math.Asin(-2 * singularityTest);
 
-            float m02 = 2 * ((X * Z) + (Y * W));
-            float m22 = 2 * ((W * W) + (Z * Z)) - 1;
+            float m02 = 2 * (X * Z + Y * W);
+            float m22 = 2 * (W * W + Z * Z) - 1;
             float rotY = (float)System.Math.Atan2(m02, m22);
 
-            float m10 = 2 * ((X * Y) + (Z * W));
-            float m11 = 2 * ((W * W) + (Y * Y)) - 1;
+            float m10 = 2 * (X * Y + Z * W);
+            float m11 = 2 * (W * W + Y * Y) - 1;
             float rotZ = (float)System.Math.Atan2(m10, m11);
 
             return new Vector3(rotX * Rad2Deg, rotY * Rad2Deg, rotZ * Rad2Deg);
         }
         private readonly Vector3 ToEulerZYX()
         {
-            float singularityTest = (X * Z) + (Y * W);
+            float singularityTest = X * Z + Y * W;
 
             if (singularityTest > SingularityThreshold)
             {
-                float m21 = 2 * ((Y * Z) + (X * W));
-                float m11 = 2 * ((W * W) + (Y * Y)) - 1;
+                float m21 = 2 * (Y * Z + X * W);
+                float m11 = 2 * (W * W + Y * Y) - 1;
 
                 return new Vector3(0f, 90f, (float)System.Math.Atan2(m21, m11) * Rad2Deg);
             }
 
             if (singularityTest < -SingularityThreshold)
             {
-                float m21 = 2 * ((Y * Z) + (X * W));
-                float m11 = 2 * ((W * W) + (Y * Y)) - 1;
+                float m21 = 2 * (Y * Z + X * W);
+                float m11 = 2 * (W * W + Y * Y) - 1;
 
                 return new Vector3(0f, -90f, (float)System.Math.Atan2(-m21, m11) * Rad2Deg);
             }
 
-            float m12 = 2 * ((Y * Z) - (X * W));
-            float m22 = 2 * ((W * W) + (Z * Z)) - 1;
+            float m12 = 2 * (Y * Z - X * W);
+            float m22 = 2 * (W * W + Z * Z) - 1;
             float rotX = (float)System.Math.Atan2(-m12, m22);
 
             float rotY = (float)System.Math.Asin(2 * singularityTest);
 
-            float m01 = 2 * ((X * Y) - (Z * W));
-            float m00 = 2 * ((W * W) + (X * X)) - 1;
+            float m01 = 2 * (X * Y - Z * W);
+            float m00 = 2 * (W * W + X * X) - 1;
             float rotZ = (float)System.Math.Atan2(-m01, m00);
 
             return new Vector3(rotX * Rad2Deg, rotY * Rad2Deg, rotZ * Rad2Deg);
@@ -896,8 +896,8 @@ namespace GTA.Math
             axis = Vector3.Normalize(axis);
 
             float half = angle * 0.5f;
-            float sin = (float)(System.Math.Sin((half)));
-            float cos = (float)(System.Math.Cos((half)));
+            float sin = (float)System.Math.Sin(half);
+            float cos = (float)System.Math.Cos(half);
 
             result.X = axis.X * sin;
             result.Y = axis.Y * sin;
@@ -930,7 +930,7 @@ namespace GTA.Math
                 result.Y = (matrix.M31 - matrix.M13) * sqrt;
                 result.Z = (matrix.M12 - matrix.M21) * sqrt;
             }
-            else if ((matrix.M11 >= matrix.M22) && (matrix.M11 >= matrix.M33))
+            else if (matrix.M11 >= matrix.M22 && matrix.M11 >= matrix.M33)
             {
                 sqrt = (float)System.Math.Sqrt(1.0f + matrix.M11 - matrix.M22 - matrix.M33);
                 half = 0.5f / sqrt;
@@ -984,19 +984,19 @@ namespace GTA.Math
             Quaternion result = Zero;
 
             float halfYaw = yaw * 0.5f;
-            float sinYaw = (float)(System.Math.Sin((halfYaw)));
-            float cosYaw = (float)(System.Math.Cos((halfYaw)));
+            float sinYaw = (float)System.Math.Sin(halfYaw);
+            float cosYaw = (float)System.Math.Cos(halfYaw);
             float halfPitch = pitch * 0.5f;
-            float sinPitch = (float)(System.Math.Sin((halfPitch)));
-            float cosPitch = (float)(System.Math.Cos((halfPitch)));
+            float sinPitch = (float)System.Math.Sin(halfPitch);
+            float cosPitch = (float)System.Math.Cos(halfPitch);
             float halfRoll = roll * 0.5f;
-            float sinRoll = (float)(System.Math.Sin((halfRoll)));
-            float cosRoll = (float)(System.Math.Cos((halfRoll)));
+            float sinRoll = (float)System.Math.Sin(halfRoll);
+            float cosRoll = (float)System.Math.Cos(halfRoll);
 
-            result.X = (cosRoll * sinPitch * cosYaw) + (sinRoll * cosPitch * sinYaw);
-            result.Y = (sinRoll * cosPitch * cosYaw) - (cosRoll * sinPitch * sinYaw);
-            result.Z = (cosRoll * cosPitch * sinYaw) - (sinRoll * sinPitch * cosYaw);
-            result.W = (cosRoll * cosPitch * cosYaw) + (sinRoll * sinPitch * sinYaw);
+            result.X = cosRoll * sinPitch * cosYaw + sinRoll * cosPitch * sinYaw;
+            result.Y = sinRoll * cosPitch * cosYaw - cosRoll * sinPitch * sinYaw;
+            result.Z = cosRoll * cosPitch * sinYaw - sinRoll * sinPitch * cosYaw;
+            result.W = cosRoll * cosPitch * cosYaw + sinRoll * sinPitch * sinYaw;
 
             return result;
         }
@@ -1111,10 +1111,10 @@ namespace GTA.Math
             float rz = right.Z;
             float rw = right.W;
 
-            quaternion.X = (lx * rw + rx * lw) + (ly * rz) - (lz * ry);
-            quaternion.Y = (ly * rw + ry * lw) + (lz * rx) - (lx * rz);
-            quaternion.Z = (lz * rw + rz * lw) + (lx * ry) - (ly * rx);
-            quaternion.W = (lw * rw) - (lx * rx + ly * ry + lz * rz);
+            quaternion.X = lx * rw + rx * lw + ly * rz - lz * ry;
+            quaternion.Y = ly * rw + ry * lw + lz * rx - lx * rz;
+            quaternion.Z = lz * rw + rz * lw + lx * ry - ly * rx;
+            quaternion.W = lw * rw - (lx * rx + ly * ry + lz * rz);
 
             return quaternion;
         }
@@ -1177,10 +1177,10 @@ namespace GTA.Math
             float rw = right.W * invNorm;
 
             // Multiply part.
-            quaternion.X = (lx * rw + rx * lw) + (ly * rz) - (lz * ry);
-            quaternion.Y = (ly * rw + ry * lw) + (lz * rx) - (lx * rz);
-            quaternion.Z = (lz * rw + rz * lw) + (lx * ry) - (ly * rx);
-            quaternion.W = (lw * rw) - (lx * rx + ly * ry + lz * rz);
+            quaternion.X = lx * rw + rx * lw + ly * rz - lz * ry;
+            quaternion.Y = ly * rw + ry * lw + lz * rx - lx * rz;
+            quaternion.Z = lz * rw + rz * lw + lx * ry - ly * rx;
+            quaternion.W = lw * rw - (lx * rx + ly * ry + lz * rz);
 
             return quaternion;
         }
@@ -1214,7 +1214,7 @@ namespace GTA.Math
             float q0 = rotation.W;
             float q0Square = rotation.W * rotation.W;
             var q = new Vector3(rotation.X, rotation.Y, rotation.Z);
-            return ((q0Square - q.LengthSquared()) * point) + (2 * Vector3.Dot(q, point) * q) + (2 * q0 * Vector3.Cross(q, point));
+            return (q0Square - q.LengthSquared()) * point + 2 * Vector3.Dot(q, point) * q + 2 * q0 * Vector3.Cross(q, point);
         }
 
         /// <summary>
@@ -1321,6 +1321,6 @@ namespace GTA.Math
         /// </summary>
         /// <param name="other">Object to make the comparison with.</param>
         /// <returns><see langword="true" /> if the current instance is equal to the specified object; <see langword="false" /> otherwise.</returns>
-        public readonly bool Equals(Quaternion other) => (X == other.X && Y == other.Y && Z == other.Z && W == other.W);
+        public readonly bool Equals(Quaternion other) => X == other.X && Y == other.Y && Z == other.Z && W == other.W;
     }
 }

--- a/source/scripting_v3/GTA.Math/Quaternion.cs
+++ b/source/scripting_v3/GTA.Math/Quaternion.cs
@@ -76,8 +76,8 @@ namespace GTA.Math
             axis = Vector3.Normalize(axis);
 
             float half = angle * 0.5f;
-            float sin = (float)(System.Math.Sin((double)(half)));
-            float cos = (float)(System.Math.Cos((double)(half)));
+            float sin = (float)(System.Math.Sin(half));
+            float cos = (float)(System.Math.Cos(half));
 
             X = axis.X * sin;
             Y = axis.Y * sin;
@@ -589,14 +589,14 @@ namespace GTA.Math
             Quaternion result = Zero;
 
             float halfX = x * 0.5f * Deg2Rad;
-            float sinX = (float)(System.Math.Sin((double)(halfX)));
-            float cosX = (float)(System.Math.Cos((double)(halfX)));
+            float sinX = (float)(System.Math.Sin((halfX)));
+            float cosX = (float)(System.Math.Cos((halfX)));
             float halfY = y * 0.5f * Deg2Rad;
-            float sinY = (float)(System.Math.Sin((double)(halfY)));
-            float cosY = (float)(System.Math.Cos((double)(halfY)));
+            float sinY = (float)(System.Math.Sin((halfY)));
+            float cosY = (float)(System.Math.Cos((halfY)));
             float halfZ = z * 0.5f * Deg2Rad;
-            float sinZ = (float)(System.Math.Sin((double)(halfZ)));
-            float cosZ = (float)(System.Math.Cos((double)(halfZ)));
+            float sinZ = (float)(System.Math.Sin((halfZ)));
+            float cosZ = (float)(System.Math.Cos((halfZ)));
 
             switch (rotationOrder)
             {
@@ -896,8 +896,8 @@ namespace GTA.Math
             axis = Vector3.Normalize(axis);
 
             float half = angle * 0.5f;
-            float sin = (float)(System.Math.Sin((double)(half)));
-            float cos = (float)(System.Math.Cos((double)(half)));
+            float sin = (float)(System.Math.Sin((half)));
+            float cos = (float)(System.Math.Cos((half)));
 
             result.X = axis.X * sin;
             result.Y = axis.Y * sin;
@@ -984,14 +984,14 @@ namespace GTA.Math
             Quaternion result = Zero;
 
             float halfYaw = yaw * 0.5f;
-            float sinYaw = (float)(System.Math.Sin((double)(halfYaw)));
-            float cosYaw = (float)(System.Math.Cos((double)(halfYaw)));
+            float sinYaw = (float)(System.Math.Sin((halfYaw)));
+            float cosYaw = (float)(System.Math.Cos((halfYaw)));
             float halfPitch = pitch * 0.5f;
-            float sinPitch = (float)(System.Math.Sin((double)(halfPitch)));
-            float cosPitch = (float)(System.Math.Cos((double)(halfPitch)));
+            float sinPitch = (float)(System.Math.Sin((halfPitch)));
+            float cosPitch = (float)(System.Math.Cos((halfPitch)));
             float halfRoll = roll * 0.5f;
-            float sinRoll = (float)(System.Math.Sin((double)(halfRoll)));
-            float cosRoll = (float)(System.Math.Cos((double)(halfRoll)));
+            float sinRoll = (float)(System.Math.Sin((halfRoll)));
+            float cosRoll = (float)(System.Math.Cos((halfRoll)));
 
             result.X = (cosRoll * sinPitch * cosYaw) + (sinRoll * cosPitch * sinYaw);
             result.Y = (sinRoll * cosPitch * cosYaw) - (cosRoll * sinPitch * sinYaw);

--- a/source/scripting_v3/GTA.Math/Vector2.cs
+++ b/source/scripting_v3/GTA.Math/Vector2.cs
@@ -146,7 +146,7 @@ namespace GTA.Math
         /// <returns>The length of the vector.</returns>
         public readonly float Length()
         {
-            return (float)System.Math.Sqrt((X * X) + (Y * Y));
+            return (float)System.Math.Sqrt(X * X + Y * Y);
         }
 
         /// <summary>
@@ -155,7 +155,7 @@ namespace GTA.Math
         /// <returns>The squared length of the vector.</returns>
         public readonly float LengthSquared()
         {
-            return (X * X) + (Y * Y);
+            return X * X + Y * Y;
         }
 
         /// <summary>
@@ -248,8 +248,8 @@ namespace GTA.Math
         {
             Vector2 v;
             double radian = RandomHelper.Instance.NextDouble() * 2 * System.Math.PI;
-            v.X = (float)(System.Math.Cos(radian));
-            v.Y = (float)(System.Math.Sin(radian));
+            v.X = (float)System.Math.Cos(radian);
+            v.Y = (float)System.Math.Sin(radian);
             v.Normalize();
             return v;
         }
@@ -311,12 +311,12 @@ namespace GTA.Math
         public static Vector2 Clamp(Vector2 value, Vector2 min, Vector2 max)
         {
             float x = value.X;
-            x = (x > max.X) ? max.X : x;
-            x = (x < min.X) ? min.X : x;
+            x = x > max.X ? max.X : x;
+            x = x < min.X ? min.X : x;
 
             float y = value.Y;
-            y = (y > max.Y) ? max.Y : y;
-            y = (y < min.Y) ? min.Y : y;
+            y = y > max.Y ? max.Y : y;
+            y = y < min.Y ? min.Y : y;
 
             return new Vector2(x, y);
         }
@@ -337,8 +337,8 @@ namespace GTA.Math
         {
             Vector2 vector;
 
-            vector.X = start.X + ((end.X - start.X) * amount);
-            vector.Y = start.Y + ((end.Y - start.Y) * amount);
+            vector.X = start.X + (end.X - start.X) * amount;
+            vector.Y = start.Y + (end.Y - start.Y) * amount;
 
             return vector;
         }
@@ -360,7 +360,7 @@ namespace GTA.Math
         /// <param name="left">First source vector.</param>
         /// <param name="right">Second source vector.</param>
         /// <returns>The dot product of the two vectors.</returns>
-        public static float Dot(Vector2 left, Vector2 right) => (left.X * right.X + left.Y * right.Y);
+        public static float Dot(Vector2 left, Vector2 right) => left.X * right.X + left.Y * right.Y;
 
         /// <summary>
         /// Returns the reflection of a vector off a surface that has the specified normal.
@@ -373,10 +373,10 @@ namespace GTA.Math
         public static Vector2 Reflect(Vector2 vector, Vector2 normal)
         {
             Vector2 result;
-            float dot = ((vector.X * normal.X) + (vector.Y * normal.Y));
+            float dot = vector.X * normal.X + vector.Y * normal.Y;
 
-            result.X = vector.X - ((2.0f * dot) * normal.X);
-            result.Y = vector.Y - ((2.0f * dot) * normal.Y);
+            result.X = vector.X - 2.0f * dot * normal.X;
+            result.Y = vector.Y - 2.0f * dot * normal.Y;
 
             return result;
         }
@@ -390,8 +390,8 @@ namespace GTA.Math
         public static Vector2 Minimize(Vector2 left, Vector2 right)
         {
             Vector2 vector;
-            vector.X = (left.X < right.X) ? left.X : right.X;
-            vector.Y = (left.Y < right.Y) ? left.Y : right.Y;
+            vector.X = left.X < right.X ? left.X : right.X;
+            vector.Y = left.Y < right.Y ? left.Y : right.Y;
             return vector;
         }
         /// <summary>
@@ -403,8 +403,8 @@ namespace GTA.Math
         public static Vector2 Maximize(Vector2 left, Vector2 right)
         {
             Vector2 vector;
-            vector.X = (left.X > right.X) ? left.X : right.X;
-            vector.Y = (left.Y > right.Y) ? left.Y : right.Y;
+            vector.X = left.X > right.X ? left.X : right.X;
+            vector.Y = left.Y > right.Y ? left.Y : right.Y;
             return vector;
         }
 
@@ -548,6 +548,6 @@ namespace GTA.Math
         /// </summary>
         /// <param name="other">Object to make the comparison with.</param>
         /// <returns><see langword="true" /> if the current instance is equal to the specified object; <see langword="false" /> otherwise.</returns>
-        public readonly bool Equals(Vector2 other) => (X == other.X && Y == other.Y);
+        public readonly bool Equals(Vector2 other) => X == other.X && Y == other.Y;
     }
 }

--- a/source/scripting_v3/GTA.Math/Vector3.cs
+++ b/source/scripting_v3/GTA.Math/Vector3.cs
@@ -222,13 +222,13 @@ namespace GTA.Math
         /// Calculates the length of the vector.
         /// </summary>
         /// <returns>The length of the vector.</returns>
-        public readonly float Length() => (float)(System.Math.Sqrt((X * X) + (Y * Y) + (Z * Z)));
+        public readonly float Length() => (float)System.Math.Sqrt(X * X + Y * Y + Z * Z);
 
         /// <summary>
         /// Calculates the squared length of the vector.
         /// </summary>
         /// <returns>The squared length of the vector.</returns>
-        public readonly float LengthSquared() => (X * X) + (Y * Y) + (Z * Z);
+        public readonly float LengthSquared() => X * X + Y * Y + Z * Z;
 
         /// <summary>
         /// Converts the vector into a unit vector.
@@ -338,7 +338,7 @@ namespace GTA.Math
         public static float Angle(Vector3 from, Vector3 to)
         {
             double dot = Dot(from.Normalized, to.Normalized);
-            return (float)(System.Math.Acos((dot)) * (180.0 / System.Math.PI));
+            return (float)(System.Math.Acos(dot) * (180.0 / System.Math.PI));
         }
 
         /// <summary>
@@ -366,7 +366,7 @@ namespace GTA.Math
         /// <summary>
         /// Creates a random vector inside the circle around this position.
         /// </summary>
-        public readonly Vector3 Around(float distance) => this + (RandomXY() * distance);
+        public readonly Vector3 Around(float distance) => this + RandomXY() * distance;
 
         /// <summary>
         /// Rounds each float inside the vector to a select amount of decimal places (2 by default).
@@ -386,8 +386,8 @@ namespace GTA.Math
             Vector3 v = Zero;
             double radian = RandomHelper.Instance.NextDouble() * 2 * System.Math.PI;
 
-            v.X = (float)(System.Math.Cos(radian));
-            v.Y = (float)(System.Math.Sin(radian));
+            v.X = (float)System.Math.Cos(radian);
+            v.Y = (float)System.Math.Sin(radian);
             v.Normalize();
             return v;
         }
@@ -399,12 +399,13 @@ namespace GTA.Math
         {
             Vector3 v = Zero;
             double radian = RandomHelper.Instance.NextDouble() * 2.0 * System.Math.PI;
-            double cosTheta = (RandomHelper.Instance.NextDouble() * 2.0) - 1.0;
+            double cosTheta = RandomHelper.Instance.NextDouble() * 2.0 - 1.0;
+
             double theta = System.Math.Acos(cosTheta);
 
             v.X = (float)(System.Math.Sin(theta) * System.Math.Cos(radian));
             v.Y = (float)(System.Math.Sin(theta) * System.Math.Sin(radian));
-            v.Z = (float)(System.Math.Cos(theta));
+            v.Z = (float)System.Math.Cos(theta);
             v.Normalize();
             return v;
         }
@@ -466,16 +467,16 @@ namespace GTA.Math
         public static Vector3 Clamp(Vector3 value, Vector3 min, Vector3 max)
         {
             float x = value.X;
-            x = (x > max.X) ? max.X : x;
-            x = (x < min.X) ? min.X : x;
+            x = x > max.X ? max.X : x;
+            x = x < min.X ? min.X : x;
 
             float y = value.Y;
-            y = (y > max.Y) ? max.Y : y;
-            y = (y < min.Y) ? min.Y : y;
+            y = y > max.Y ? max.Y : y;
+            y = y < min.Y ? min.Y : y;
 
             float z = value.Z;
-            z = (z > max.Z) ? max.Z : z;
-            z = (z < min.Z) ? min.Z : z;
+            z = z > max.Z ? max.Z : z;
+            z = z < min.Z ? min.Z : z;
 
             return new Vector3(x, y, z);
         }
@@ -496,9 +497,9 @@ namespace GTA.Math
         {
             Vector3 vector = Zero;
 
-            vector.X = start.X + ((end.X - start.X) * amount);
-            vector.Y = start.Y + ((end.Y - start.Y) * amount);
-            vector.Z = start.Z + ((end.Z - start.Z) * amount);
+            vector.X = start.X + (end.X - start.X) * amount;
+            vector.Y = start.Y + (end.Y - start.Y) * amount;
+            vector.Z = start.Z + (end.Z - start.Z) * amount;
 
             return vector;
         }
@@ -520,7 +521,7 @@ namespace GTA.Math
         /// <param name="left">First source vector.</param>
         /// <param name="right">Second source vector.</param>
         /// <returns>The dot product of the two vectors.</returns>
-        public static float Dot(Vector3 left, Vector3 right) => (left.X * right.X + left.Y * right.Y + left.Z * right.Z);
+        public static float Dot(Vector3 left, Vector3 right) => left.X * right.X + left.Y * right.Y + left.Z * right.Z;
 
         /// <summary>
         /// Calculates the cross product of two vectors.
@@ -550,7 +551,7 @@ namespace GTA.Math
         /// <param name="vector">The vector to project.</param>
         /// <param name="planeNormal">Normal of the plane,  does not assume it is normalized.</param>
         /// <returns>The Projection of vector onto plane.</returns>
-        public static Vector3 ProjectOnPlane(Vector3 vector, Vector3 planeNormal) => (vector - Project(vector, planeNormal));
+        public static Vector3 ProjectOnPlane(Vector3 vector, Vector3 planeNormal) => vector - Project(vector, planeNormal);
 
         /// <summary>
         /// Returns the reflection of a vector off a surface that has the specified normal.
@@ -563,11 +564,11 @@ namespace GTA.Math
         public static Vector3 Reflect(Vector3 vector, Vector3 normal)
         {
             Vector3 result = Zero;
-            float dot = ((vector.X * normal.X) + (vector.Y * normal.Y)) + (vector.Z * normal.Z);
+            float dot = vector.X * normal.X + vector.Y * normal.Y + vector.Z * normal.Z;
 
-            result.X = vector.X - ((2.0f * dot) * normal.X);
-            result.Y = vector.Y - ((2.0f * dot) * normal.Y);
-            result.Z = vector.Z - ((2.0f * dot) * normal.Z);
+            result.X = vector.X - 2.0f * dot * normal.X;
+            result.Y = vector.Y - 2.0f * dot * normal.Y;
+            result.Z = vector.Z - 2.0f * dot * normal.Z;
 
             return result;
         }
@@ -581,9 +582,9 @@ namespace GTA.Math
         public static Vector3 Minimize(Vector3 left, Vector3 right)
         {
             Vector3 vector = Zero;
-            vector.X = (left.X < right.X) ? left.X : right.X;
-            vector.Y = (left.Y < right.Y) ? left.Y : right.Y;
-            vector.Z = (left.Z < right.Z) ? left.Z : right.Z;
+            vector.X = left.X < right.X ? left.X : right.X;
+            vector.Y = left.Y < right.Y ? left.Y : right.Y;
+            vector.Z = left.Z < right.Z ? left.Z : right.Z;
             return vector;
         }
 
@@ -596,9 +597,9 @@ namespace GTA.Math
         public static Vector3 Maximize(Vector3 left, Vector3 right)
         {
             Vector3 vector = Zero;
-            vector.X = (left.X > right.X) ? left.X : right.X;
-            vector.Y = (left.Y > right.Y) ? left.Y : right.Y;
-            vector.Z = (left.Z > right.Z) ? left.Z : right.Z;
+            vector.X = left.X > right.X ? left.X : right.X;
+            vector.Y = left.Y > right.Y ? left.Y : right.Y;
+            vector.Z = left.Z > right.Z ? left.Z : right.Z;
             return vector;
         }
 
@@ -757,7 +758,7 @@ namespace GTA.Math
         /// </summary>
         /// <param name="other">Object to make the comparison with.</param>
         /// <returns><see langword="true" /> if the current instance is equal to the specified object; <see langword="false" /> otherwise.</returns>
-        public readonly bool Equals(Vector3 other) => (X == other.X && Y == other.Y && Z == other.Z);
+        public readonly bool Equals(Vector3 other) => X == other.X && Y == other.Y && Z == other.Z;
 
         internal readonly SHVDN.FVector3 ToInternalFVector3() => new SHVDN.FVector3(X, Y, Z);
     }

--- a/source/scripting_v3/GTA.Math/Vector4.cs
+++ b/source/scripting_v3/GTA.Math/Vector4.cs
@@ -130,7 +130,7 @@ namespace GTA.Math
         /// <returns>The length of the vector.</returns>
         public readonly float Length()
         {
-            return (float)System.Math.Sqrt((X * X) + (Y * Y) + (Z * Z) + (W * W));
+            return (float)System.Math.Sqrt(X * X + Y * Y + Z * Z + W * W);
         }
 
         /// <summary>
@@ -139,7 +139,7 @@ namespace GTA.Math
         /// <returns>The squared length of the vector.</returns>
         public readonly float LengthSquared()
         {
-            return (X * X) + (Y * Y) + (Z * Z) + (W * W);
+            return X * X + Y * Y + Z * Z + W * W;
         }
 
         /// <summary>
@@ -170,20 +170,20 @@ namespace GTA.Math
         public static Vector4 Clamp(Vector4 value, Vector4 min, Vector4 max)
         {
             float x = value.X;
-            x = (x > max.X) ? max.X : x;
-            x = (x < min.X) ? min.X : x;
+            x = x > max.X ? max.X : x;
+            x = x < min.X ? min.X : x;
 
             float y = value.Y;
-            y = (y > max.Y) ? max.Y : y;
-            y = (y < min.Y) ? min.Y : y;
+            y = y > max.Y ? max.Y : y;
+            y = y < min.Y ? min.Y : y;
 
             float z = value.Z;
-            z = (z > max.Z) ? max.Z : z;
-            z = (z < min.Z) ? min.Z : z;
+            z = z > max.Z ? max.Z : z;
+            z = z < min.Z ? min.Z : z;
 
             float w = value.W;
-            w = (w > max.W) ? max.W : w;
-            w = (w < min.W) ? min.W : w;
+            w = w > max.W ? max.W : w;
+            w = w < min.W ? min.W : w;
 
             return new Vector4(x, y, z, w);
         }
@@ -204,10 +204,10 @@ namespace GTA.Math
         {
             Vector4 vector = default;
 
-            vector.X = start.X + ((end.X - start.X) * amount);
-            vector.Y = start.Y + ((end.Y - start.Y) * amount);
-            vector.Z = start.Z + ((end.Z - start.Z) * amount);
-            vector.W = start.W + ((end.W - start.W) * amount);
+            vector.X = start.X + (end.X - start.X) * amount;
+            vector.Y = start.Y + (end.Y - start.Y) * amount;
+            vector.Z = start.Z + (end.Z - start.Z) * amount;
+            vector.W = start.W + (end.W - start.W) * amount;
 
             return vector;
         }
@@ -230,7 +230,7 @@ namespace GTA.Math
         /// <param name="right">Second source vector.</param>
         /// <returns>The dot product of the two vectors.</returns>
         public static float Dot(Vector4 left, Vector4 right)
-            => (left.X * right.X + left.Y * right.Y + left.Z * right.Z + left.W * right.W);
+            => left.X * right.X + left.Y * right.Y + left.Z * right.Z + left.W * right.W;
 
         /// <summary>
         /// Returns a vector containing the smallest components of the specified vectors.
@@ -241,10 +241,10 @@ namespace GTA.Math
         public static Vector4 Min(Vector4 left, Vector4 right)
         {
             Vector4 vector = default;
-            vector.X = (left.X < right.X) ? left.X : right.X;
-            vector.Y = (left.Y < right.Y) ? left.Y : right.Y;
-            vector.Z = (left.Z < right.Z) ? left.Z : right.Z;
-            vector.W = (left.W < right.W) ? left.W : right.W;
+            vector.X = left.X < right.X ? left.X : right.X;
+            vector.Y = left.Y < right.Y ? left.Y : right.Y;
+            vector.Z = left.Z < right.Z ? left.Z : right.Z;
+            vector.W = left.W < right.W ? left.W : right.W;
             return vector;
         }
         /// <summary>
@@ -256,10 +256,10 @@ namespace GTA.Math
         public static Vector4 Max(Vector4 left, Vector4 right)
         {
             Vector4 vector = default;
-            vector.X = (left.X > right.X) ? left.X : right.X;
-            vector.Y = (left.Y > right.Y) ? left.Y : right.Y;
-            vector.Z = (left.Z > right.Z) ? left.Z : right.Z;
-            vector.W = (left.W > right.W) ? left.W : right.W;
+            vector.X = left.X > right.X ? left.X : right.X;
+            vector.Y = left.Y > right.Y ? left.Y : right.Y;
+            vector.Z = left.Z > right.Z ? left.Z : right.Z;
+            vector.W = left.W > right.W ? left.W : right.W;
             return vector;
         }
 

--- a/source/scripting_v3/GTA.Math/Vector4.cs
+++ b/source/scripting_v3/GTA.Math/Vector4.cs
@@ -240,7 +240,7 @@ namespace GTA.Math
         /// <returns>A vector containing the smallest components of the source vectors.</returns>
         public static Vector4 Min(Vector4 left, Vector4 right)
         {
-            Vector4 vector = default;;
+            Vector4 vector = default;
             vector.X = (left.X < right.X) ? left.X : right.X;
             vector.Y = (left.Y < right.Y) ? left.Y : right.Y;
             vector.Z = (left.Z < right.Z) ? left.Z : right.Z;
@@ -255,7 +255,7 @@ namespace GTA.Math
         /// <returns>A vector containing the largest components of the source vectors.</returns>
         public static Vector4 Max(Vector4 left, Vector4 right)
         {
-            Vector4 vector = default;;
+            Vector4 vector = default;
             vector.X = (left.X > right.X) ? left.X : right.X;
             vector.Y = (left.Y > right.Y) ? left.Y : right.Y;
             vector.Z = (left.Z > right.Z) ? left.Z : right.Z;

--- a/source/scripting_v3/GTA.Native/Native.cs
+++ b/source/scripting_v3/GTA.Native/Native.cs
@@ -43,7 +43,7 @@ namespace GTA.Native
         static NativeHelper()
         {
             var ptrToStrMethod = new DynamicMethod("PtrToStructure<" + typeof(T) + ">", typeof(T),
-                new Type[] { typeof(IntPtr) }, typeof(NativeHelper<T>), true);
+                new [] { typeof(IntPtr) }, typeof(NativeHelper<T>), true);
 
             ILGenerator generator = ptrToStrMethod.GetILGenerator();
             generator.Emit(OpCodes.Ldarg_0);
@@ -341,7 +341,7 @@ namespace GTA.Native
         {
             unsafe
             {
-                *(ulong*)(_storage) = Function.ObjectToNative(value);
+                *(ulong*)_storage = Function.ObjectToNative(value);
             }
         }
         // Specify the private visibility to avoid breaking changes for scripts built against v3.6.0 or earlier,
@@ -3063,7 +3063,7 @@ namespace GTA.Native
             }
             if (typeof(T) == typeof(IntPtr)) // Has to be before 'IsPrimitive' check
             {
-                return InstanceCreator<long, T>.Create((long)(*value));
+                return InstanceCreator<long, T>.Create((long)*value);
             }
 
             if (typeof(T) == typeof(Vector2))
@@ -3125,7 +3125,7 @@ namespace GTA.Native
             if (typeof(INativeValue).IsAssignableFrom(type))
             {
                 // Edge case. Warning: Requires classes implementing 'INativeValue' to repeat all constructor work in the setter of 'NativeValue'
-                var result = (INativeValue)(System.Runtime.Serialization.FormatterServices.GetUninitializedObject(type));
+                var result = (INativeValue)System.Runtime.Serialization.FormatterServices.GetUninitializedObject(type);
                 result.NativeValue = *value;
 
                 return result;
@@ -3192,7 +3192,7 @@ namespace GTA.Native
                 return (T)(object)SHVDN.StringMarshal.PtrToStringUtf8(MemoryAddress);
             }
 
-            return Function.ReturnValueFromResultAddress<T>((ulong*)(MemoryAddress.ToPointer()));
+            return Function.ReturnValueFromResultAddress<T>((ulong*)MemoryAddress.ToPointer());
         }
 
         /// <summary>
@@ -3209,7 +3209,7 @@ namespace GTA.Native
             if (typeof(T) == typeof(Vector2))
             {
                 var val = (Vector2)(object)value;
-                float* data = (float*)(MemoryAddress.ToPointer());
+                float* data = (float*)MemoryAddress.ToPointer();
 
                 data[0] = val.X;
                 data[2] = val.Y;
@@ -3217,8 +3217,8 @@ namespace GTA.Native
             }
             if (typeof(T) == typeof(Vector3))
             {
-                var val = (Vector3)(object)(value);
-                float* data = (float*)(MemoryAddress.ToPointer());
+                var val = (Vector3)(object)value;
+                float* data = (float*)MemoryAddress.ToPointer();
 
                 data[0] = val.X;
                 data[2] = val.Y;
@@ -3228,27 +3228,27 @@ namespace GTA.Native
 
             if (typeof(T) == typeof(bool))
             {
-                *(ulong*)(MemoryAddress.ToPointer()) = NativeHelper<ulong>.Convert(value);
+                *(ulong*)MemoryAddress.ToPointer() = NativeHelper<ulong>.Convert(value);
             }
             else if (typeof(T) == typeof(double))
             {
-                *(ulong*)(MemoryAddress.ToPointer()) = 0; // padding
-                *(float*)(MemoryAddress.ToPointer()) = NativeHelper<float>.Convert(value);
+                *(ulong*)MemoryAddress.ToPointer() = 0; // padding
+                *(float*)MemoryAddress.ToPointer() = NativeHelper<float>.Convert(value);
             }
             else if (typeof(T).IsPrimitive)
             {
                 if (typeof(T) == typeof(IntPtr))
                 {
-                    *(long*)(MemoryAddress.ToPointer()) = NativeHelper<long>.Convert(value);
+                    *(long*)MemoryAddress.ToPointer() = NativeHelper<long>.Convert(value);
                 }
                 else
                 {
-                    *(ulong*)(MemoryAddress.ToPointer()) = NativeHelper<ulong>.Convert(value);
+                    *(ulong*)MemoryAddress.ToPointer() = NativeHelper<ulong>.Convert(value);
                 }
             }
             else
             {
-                *(ulong*)(MemoryAddress.ToPointer()) = Function.ObjectToNative(value);
+                *(ulong*)MemoryAddress.ToPointer() = Function.ObjectToNative(value);
             }
         }
         /// <summary>
@@ -3288,7 +3288,7 @@ namespace GTA.Native
                 throw new IndexOutOfRangeException("The bit index has to be between 0 and 63");
             }
 
-            *(ulong*)(MemoryAddress.ToPointer()) |= (1u << index);
+            *(ulong*)MemoryAddress.ToPointer() |= 1u << index;
         }
         /// <summary>
         /// Set the value of a specific bit of the <see cref="GlobalVariable"/> to false.
@@ -3301,7 +3301,7 @@ namespace GTA.Native
                 throw new IndexOutOfRangeException("The bit index has to be between 0 and 63");
             }
 
-            *(ulong*)(MemoryAddress.ToPointer()) &= ~(1u << index);
+            *(ulong*)MemoryAddress.ToPointer() &= ~(1u << index);
         }
         /// <summary>
         /// Gets a value indicating whether a specific bit of the <see cref="GlobalVariable"/> is set.
@@ -3314,7 +3314,7 @@ namespace GTA.Native
                 throw new IndexOutOfRangeException("The bit index has to be between 0 and 63");
             }
 
-            return ((*(ulong*)(MemoryAddress.ToPointer()) >> index) & 1) != 0;
+            return ((*(ulong*)MemoryAddress.ToPointer() >> index) & 1) != 0;
         }
 
         /// <summary>
@@ -3329,7 +3329,7 @@ namespace GTA.Native
                 throw new IndexOutOfRangeException("The structure item index cannot be negative.");
             }
 
-            return new GlobalVariable(MemoryAddress + (8 * index));
+            return new GlobalVariable(MemoryAddress + 8 * index);
         }
 
         /// <summary>
@@ -3356,7 +3356,7 @@ namespace GTA.Native
 
             for (int i = 0; i < count; i++)
             {
-                result[i] = new GlobalVariable(MemoryAddress + 8 + (8 * itemSize * i));
+                result[i] = new GlobalVariable(MemoryAddress + 8 + 8 * itemSize * i);
             }
 
             return result;
@@ -3387,7 +3387,7 @@ namespace GTA.Native
                 throw new IndexOutOfRangeException($"The index {index.ToString()} was outside the array bounds.");
             }
 
-            return new GlobalVariable(MemoryAddress + 8 + (8 * itemSize * index));
+            return new GlobalVariable(MemoryAddress + 8 + 8 * itemSize * index);
         }
     }
     #endregion

--- a/source/scripting_v3/GTA.Native/Native.cs
+++ b/source/scripting_v3/GTA.Native/Native.cs
@@ -43,7 +43,7 @@ namespace GTA.Native
         static NativeHelper()
         {
             var ptrToStrMethod = new DynamicMethod("PtrToStructure<" + typeof(T) + ">", typeof(T),
-                new [] { typeof(IntPtr) }, typeof(NativeHelper<T>), true);
+                new[] { typeof(IntPtr) }, typeof(NativeHelper<T>), true);
 
             ILGenerator generator = ptrToStrMethod.GetILGenerator();
             generator.Emit(OpCodes.Ldarg_0);

--- a/source/scripting_v3/GTA.Native/Native.cs
+++ b/source/scripting_v3/GTA.Native/Native.cs
@@ -3075,13 +3075,13 @@ namespace GTA.Native
                 return InstanceCreator<long, T>.Create((long)(*value));
             }
 
-            if (typeof(T) == typeof(Math.Vector2))
+            if (typeof(T) == typeof(Vector2))
             {
                 float* data = (float*)value;
                 return InstanceCreator<float, float, T>.Create(data[0], data[2]);
 
             }
-            if (typeof(T) == typeof(Math.Vector3))
+            if (typeof(T) == typeof(Vector3))
             {
                 float* data = (float*)value;
                 return InstanceCreator<float, float, float, T>.Create(data[0], data[2], data[4]);
@@ -3215,18 +3215,18 @@ namespace GTA.Native
                 throw new InvalidOperationException("Cannot write string values via 'Write<string>', use 'WriteString' instead.");
             }
 
-            if (typeof(T) == typeof(Math.Vector2))
+            if (typeof(T) == typeof(Vector2))
             {
-                var val = (Math.Vector2)(object)value;
+                var val = (Vector2)(object)value;
                 float* data = (float*)(MemoryAddress.ToPointer());
 
                 data[0] = val.X;
                 data[2] = val.Y;
                 return;
             }
-            if (typeof(T) == typeof(Math.Vector3))
+            if (typeof(T) == typeof(Vector3))
             {
-                var val = (Math.Vector3)(object)(value);
+                var val = (Vector3)(object)(value);
                 float* data = (float*)(MemoryAddress.ToPointer());
 
                 data[0] = val.X;

--- a/source/scripting_v3/GTA.Native/Native.cs
+++ b/source/scripting_v3/GTA.Native/Native.cs
@@ -164,10 +164,7 @@ namespace GTA.Native
         /// <param name="value">The value.</param>
         public InputArgument(IntPtr value)
         {
-            unsafe
-            {
-                _data = (ulong)value.ToInt64();
-            }
+            _data = (ulong)value.ToInt64();
         }
         /// <summary>
         /// Initializes a new instance of the <see cref="InputArgument"/> class and converts a managed object to a script function input argument.
@@ -175,10 +172,7 @@ namespace GTA.Native
         /// <param name="value">The object to convert.</param>
         public InputArgument(object value)
         {
-            unsafe
-            {
-                _data = Function.ObjectToNative(value);
-            }
+            _data = Function.ObjectToNative(value);
         }
 
         /// <summary>
@@ -389,10 +383,7 @@ namespace GTA.Native
         /// </summary>
         public static OutputArgument Alloc(int size)
         {
-            unsafe
-            {
-                return new OutputArgument(size);
-            }
+            return new OutputArgument(size);
         }
         /// <summary>
         /// Initializes a new instance of the <see cref="OutputArgument"/> where the storage has a block of memory of
@@ -3265,7 +3256,7 @@ namespace GTA.Native
         /// </summary>
         /// <param name="value">The string to set the <see cref="GlobalVariable"/> to.</param>
         /// <param name="maxSize">The maximum size of the string. Can be found for a given global variable by checking the decompiled scripts from the game.</param>
-        public unsafe void WriteString(string value, int maxSize)
+        public void WriteString(string value, int maxSize)
         {
             if (maxSize % 8 != 0 || maxSize <= 0 || maxSize > 64)
             {
@@ -3331,7 +3322,7 @@ namespace GTA.Native
         /// </summary>
         /// <param name="index">The index the <see cref="GlobalVariable"/> is stored in the structure. For example the Y component of a Vector3 is at index 1.</param>
         /// <returns>The <see cref="GlobalVariable"/> at the index given.</returns>
-        public unsafe GlobalVariable GetStructField(int index)
+        public GlobalVariable GetStructField(int index)
         {
             if (index < 0)
             {
@@ -3346,7 +3337,7 @@ namespace GTA.Native
         /// </summary>
         /// <param name="itemSize">The number of items stored in each array index. For example an array of Vector3s takes up 3 items.</param>
         /// <returns>The array of <see cref="GlobalVariable"/>s.</returns>
-        public unsafe GlobalVariable[] GetArray(int itemSize)
+        public GlobalVariable[] GetArray(int itemSize)
         {
             if (itemSize <= 0)
             {
@@ -3376,7 +3367,7 @@ namespace GTA.Native
         /// <param name="index">The array index.</param>
         /// <param name="itemSize">The number of items stored in each array index. For example an array of Vector3s takes up 3 items.</param>
         /// <returns>The <see cref="GlobalVariable"/> at the index given.</returns>
-        public unsafe GlobalVariable GetArrayItem(int index, int itemSize)
+        public GlobalVariable GetArrayItem(int index, int itemSize)
         {
             if (itemSize <= 0)
             {

--- a/source/scripting_v3/GTA.Native/Native.cs
+++ b/source/scripting_v3/GTA.Native/Native.cs
@@ -1792,10 +1792,8 @@ namespace GTA.Native
             {
                 return ObjectFromNative<T>(result);
             }
-            else
-            {
-                return (T)ObjectFromNative(typeof(T), result);
-            }
+
+            return (T)ObjectFromNative(typeof(T), result);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -3202,10 +3200,8 @@ namespace GTA.Native
             {
                 return (T)(object)SHVDN.StringMarshal.PtrToStringUtf8(MemoryAddress);
             }
-            else
-            {
-                return Function.ReturnValueFromResultAddress<T>((ulong*)(MemoryAddress.ToPointer()));
-            }
+
+            return Function.ReturnValueFromResultAddress<T>((ulong*)(MemoryAddress.ToPointer()));
         }
 
         /// <summary>

--- a/source/scripting_v3/GTA.UI/TextElement.cs
+++ b/source/scripting_v3/GTA.UI/TextElement.cs
@@ -303,7 +303,7 @@ namespace GTA.UI
                 switch (Alignment)
                 {
                     case Alignment.Center:
-                        Function.Call(Hash.SET_TEXT_WRAP, x - (w / 2), x + (w / 2));
+                        Function.Call(Hash.SET_TEXT_WRAP, x - w / 2, x + w / 2);
                         break;
                     case Alignment.Left:
                         Function.Call(Hash.SET_TEXT_WRAP, x, x + w);
@@ -477,7 +477,7 @@ namespace GTA.UI
                 switch (Alignment)
                 {
                     case Alignment.Center:
-                        Function.Call(Hash.SET_TEXT_WRAP, x - (w / 2), x + (w / 2));
+                        Function.Call(Hash.SET_TEXT_WRAP, x - w / 2, x + w / 2);
                         break;
                     case Alignment.Left:
                         Function.Call(Hash.SET_TEXT_WRAP, x, x + w);

--- a/source/scripting_v3/GTA/AnimationBlendDuration.cs
+++ b/source/scripting_v3/GTA/AnimationBlendDuration.cs
@@ -75,11 +75,10 @@ namespace GTA
         public static AnimationBlendDuration FromBlendDelta(AnimationBlendDelta blendDelta)
         {
             // Performs the same calculation as how `fwAnimHelpers::CalcBlendDuration(float blendDelta)` does
-            float deltaFloat = (blendDelta.Value < 0 ? -blendDelta.Value : blendDelta.Value);
-            float duration = (deltaFloat == (float)AnimationBlendDelta.InstantBlendIn
+            float deltaFloat = blendDelta.Value < 0 ? -blendDelta.Value : blendDelta.Value;
+            float duration = deltaFloat == (float)AnimationBlendDelta.InstantBlendIn
                 ? 0.0f
-                : (1.0f / deltaFloat)
-                );
+                : 1.0f / deltaFloat;
 
             return new AnimationBlendDuration(duration);
         }

--- a/source/scripting_v3/GTA/AtHashValue.cs
+++ b/source/scripting_v3/GTA/AtHashValue.cs
@@ -49,7 +49,7 @@ namespace GTA
         /// <summary>
         /// Gets the null value of <see cref="AtHashValue"/>, whose hash is zero.
         /// </summary>
-        public static AtHashValue Null => new AtHashValue(0);
+        public static AtHashValue Null => new(0);
 
         /// <summary>
         /// Returns a value that indicates whether this instance is the null <see cref="AtHashValue"/>, whose hash is
@@ -71,14 +71,14 @@ namespace GTA
         /// instead.
         /// </remarks>
         public static AtHashValue FromString(string input)
-            => new AtHashValue(StringHash.AtStringHash(input));
+            => new(StringHash.AtStringHash(input));
         /// <summary>
         /// Computes an <see cref="AtHashValue"/> from an array of <see cref="byte"/>.
         /// </summary>
         /// <param name="input">An array of <see cref="byte"/>.</param>
         /// <returns>An <see cref="AtHashValue"/> that contains the calculated hash.</returns>
         public static AtHashValue FromBytes(byte[] input)
-            => new AtHashValue(StringHash.AtStringHash(input));
+            => new(StringHash.AtStringHash(input));
         /// <summary>
         /// Computes an <see cref="AtHashValue"/> from a <see cref="string"/>.
         /// <paramref name="input"/> will be converted to a UTF-8 sequence before hashing.
@@ -89,7 +89,7 @@ namespace GTA
         /// </param>
         /// <returns>An <see cref="AtHashValue"/> that contains the calculated hash.</returns>
         public static AtHashValue FromStringUtf8(string input)
-            => new AtHashValue(StringHash.AtStringHashUtf8(input));
+            => new(StringHash.AtStringHashUtf8(input));
 
         /// <summary>
         /// Computes a joaat hash as an <see langword="uint"/> from a <see cref="string"/> that contains only ASCII

--- a/source/scripting_v3/GTA/AtLiteralHashValue.cs
+++ b/source/scripting_v3/GTA/AtLiteralHashValue.cs
@@ -31,7 +31,7 @@ namespace GTA
         /// <summary>
         /// Gets the null value of <see cref="AtLiteralHashValue"/>, whose hash is zero.
         /// </summary>
-        public static AtLiteralHashValue Null => new AtLiteralHashValue(0);
+        public static AtLiteralHashValue Null => new(0);
 
         /// <summary>
         /// Returns a value that indicates whether this instance is the null <see cref="AtLiteralHashValue"/>,
@@ -54,14 +54,14 @@ namespace GTA
         /// instead.
         /// </remarks>
         public static AtLiteralHashValue FromString(string input)
-            => new AtLiteralHashValue(StringHash.AtLiteralStringHash(input));
+            => new(StringHash.AtLiteralStringHash(input));
         /// <summary>
         /// Computes an <see cref="AtLiteralHashValue"/> from an array of <see cref="byte"/>.
         /// </summary>
         /// <param name="input">An array of <see cref="byte"/>.</param>
         /// <returns>An <see cref="AtLiteralHashValue"/> that contains the calculated hash.</returns>
         public static AtLiteralHashValue FromBytes(byte[] input)
-            => new AtLiteralHashValue(StringHash.AtLiteralStringHash(input));
+            => new(StringHash.AtLiteralStringHash(input));
         /// <summary>
         /// Computes an <see cref="AtLiteralHashValue"/> from a <see cref="string"/>.
         /// <paramref name="input"/> will be converted to a UTF-8 sequence before hashing.
@@ -72,7 +72,7 @@ namespace GTA
         /// </param>
         /// <returns>An <see cref="AtLiteralHashValue"/> that contains the calculated hash.</returns>
         public static AtLiteralHashValue FromStringUtf8(string input)
-            => new AtLiteralHashValue(StringHash.AtLiteralStringHashUtf8(input));
+            => new(StringHash.AtLiteralStringHashUtf8(input));
 
         /// <summary>
         /// Compares this instance for equality with <paramref name="other"/>.

--- a/source/scripting_v3/GTA/Blip/Blip.cs
+++ b/source/scripting_v3/GTA/Blip/Blip.cs
@@ -78,7 +78,7 @@ namespace GTA
         public int Alpha
         {
             get => Function.Call<int>(Hash.GET_BLIP_ALPHA, Handle);
-            set => Function.Call(Hash.SET_BLIP_ALPHA, Handle, (int)value);
+            set => Function.Call(Hash.SET_BLIP_ALPHA, Handle, value);
         }
 
         /// <summary>

--- a/source/scripting_v3/GTA/Blip/Blip.cs
+++ b/source/scripting_v3/GTA/Blip/Blip.cs
@@ -274,11 +274,9 @@ namespace GTA
                 {
                     return (int)SHVDN.MemDataMarshal.ReadFloat(address + 0x58);
                 }
-                else
-                {
-                    int offset = gameVersion >= ExeVersionConsts.v1_0_463_1 ? 0x58 : 0x54;
-                    return SHVDN.MemDataMarshal.ReadInt16(address + offset);
-                }
+
+                int offset = gameVersion >= ExeVersionConsts.v1_0_463_1 ? 0x58 : 0x54;
+                return SHVDN.MemDataMarshal.ReadInt16(address + offset);
             }
             set => Function.Call(Hash.SET_BLIP_ROTATION, Handle, value);
         }
@@ -302,11 +300,9 @@ namespace GTA
                 {
                     return SHVDN.MemDataMarshal.ReadFloat(address + 0x58);
                 }
-                else
-                {
-                    int offset = gameVersion >= ExeVersionConsts.v1_0_463_1 ? 0x58 : 0x54;
-                    return (float)SHVDN.MemDataMarshal.ReadInt16(address + offset);
-                }
+
+                int offset = gameVersion >= ExeVersionConsts.v1_0_463_1 ? 0x58 : 0x54;
+                return (float)SHVDN.MemDataMarshal.ReadInt16(address + offset);
             }
             set
             {
@@ -325,11 +321,9 @@ namespace GTA
                     SHVDN.MemDataMarshal.WriteFloat(address + 0x58, valueNormalized);
                     return;
                 }
-                else
-                {
-                    int offset = gameVersion >= ExeVersionConsts.v1_0_463_1 ? 0x58 : 0x54;
-                    SHVDN.MemDataMarshal.WriteInt16(address + offset, (short)valueNormalized);
-                }
+
+                int offset = gameVersion >= ExeVersionConsts.v1_0_463_1 ? 0x58 : 0x54;
+                SHVDN.MemDataMarshal.WriteInt16(address + offset, (short)valueNormalized);
             }
         }
 

--- a/source/scripting_v3/GTA/CheckpointCustomIcon.cs
+++ b/source/scripting_v3/GTA/CheckpointCustomIcon.cs
@@ -134,7 +134,7 @@ namespace GTA
 
         public override string ToString()
         {
-            return Style.ToString() + Number.ToString();
+            return Style + Number.ToString();
         }
     }
 }

--- a/source/scripting_v3/GTA/CheckpointCustomIcon.cs
+++ b/source/scripting_v3/GTA/CheckpointCustomIcon.cs
@@ -38,7 +38,7 @@ namespace GTA
                     return Number;
                 }
 
-                return (byte)(90 + (int)_style * 10 + Number);
+                return (byte)((int)_style * 10 + 90 + Number);
             }
             set
             {

--- a/source/scripting_v3/GTA/Entities/Entity.cs
+++ b/source/scripting_v3/GTA/Entities/Entity.cs
@@ -133,7 +133,7 @@ namespace GTA
             IntPtr address = SHVDN.NativeMemory.GetEntityAddress(handle);
             if (address == IntPtr.Zero)
             {
-                return (EntityTypeInternal)0 /* ENTITY_TYPE_MASK_NOTHING */;
+                return 0 /* ENTITY_TYPE_MASK_NOTHING */;
             }
 
             return (EntityTypeInternal)SHVDN.MemDataMarshal.ReadByte(address + 0x28);

--- a/source/scripting_v3/GTA/Entities/Entity.cs
+++ b/source/scripting_v3/GTA/Entities/Entity.cs
@@ -843,7 +843,7 @@ namespace GTA
                 unsafe
                 {
                     float* returnVectorPtr = SHVDN.NativeMemory.GetEntityAngularVelocity(address);
-                    return (quaternionInverted * new Vector3(returnVectorPtr[0], returnVectorPtr[1], returnVectorPtr[2]));
+                    return quaternionInverted * new Vector3(returnVectorPtr[0], returnVectorPtr[1], returnVectorPtr[2]);
                 }
             }
             set

--- a/source/scripting_v3/GTA/Entities/EntityBone.cs
+++ b/source/scripting_v3/GTA/Entities/EntityBone.cs
@@ -30,7 +30,7 @@ namespace GTA
         {
             Owner = owner;
             Index = boneIndex;
-            Tag = (boneIndex != -1) ? boneTag : -1;
+            Tag = boneIndex != -1 ? boneTag : -1;
         }
         internal EntityBone(Entity owner, string boneName) : this(owner, Function.Call<int>(Hash.GET_ENTITY_BONE_INDEX_BY_NAME, owner.NativeValue, boneName))
         {
@@ -350,7 +350,7 @@ namespace GTA
                     return;
                 }
 
-                SHVDN.MemDataMarshal.WriteVector3((address + 0x30), value.ToInternalFVector3());
+                SHVDN.MemDataMarshal.WriteVector3(address + 0x30, value.ToInternalFVector3());
             }
         }
 

--- a/source/scripting_v3/GTA/Entities/InteriorInstance.cs
+++ b/source/scripting_v3/GTA/Entities/InteriorInstance.cs
@@ -137,9 +137,6 @@ namespace GTA
         {
             get
             {
-                if (!TryGetMemoryAddress(out IntPtr address))
-                    return null;
-
                 int interiorProxyHandle = SHVDN.NativeMemory.GetInteriorProxyHandleFromInteriorInst(Handle);
                 return interiorProxyHandle != 0 ? new InteriorProxy(interiorProxyHandle) : null;
             }

--- a/source/scripting_v3/GTA/Entities/Peds/DecisionMaker.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/DecisionMaker.cs
@@ -50,7 +50,7 @@ namespace GTA
         /// <summary>
         /// Indicates whether <see cref="Hash"/> of this <see cref="DecisionMaker"/> is set to <c>0</c>, which can be created by <see langword="default"/> operator.
         /// </summary>
-        public bool IsNullValue => (Hash == 0);
+        public bool IsNullValue => Hash == 0;
 
         public bool Equals(DecisionMaker group)
         {

--- a/source/scripting_v3/GTA/Entities/Peds/Ped.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Ped.cs
@@ -1723,7 +1723,7 @@ namespace GTA
                     return VehicleSeat.None;
 
                 int seatIndex = SHVDN.MemDataMarshal.ReadByte(address + SHVDN.NativeMemory.Ped.AttachCarSeatIndexOffset);
-                return (seatIndex >= 0 && IsInVehicle()) ? (VehicleSeat)(seatIndex - 1) : VehicleSeat.None;
+                return seatIndex >= 0 && IsInVehicle() ? (VehicleSeat)(seatIndex - 1) : VehicleSeat.None;
             }
         }
 

--- a/source/scripting_v3/GTA/Entities/Peds/PedConfigFlags.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/PedConfigFlags.cs
@@ -166,7 +166,7 @@ namespace GTA
                 // While `SET_PED_GROUP_MEMBER_PASSENGER_INDEX` does not set a new value if it's -1 or less,
                 // which is the default value, the native can set the internal value to -1 by passing a positive value
                 // like 31 or 63 as the 2nd argument.
-                if (((int)value < (int)VehicleSeat.Any || (int)value > (int)VehicleSeat.ExtraSeat12))
+                if ((int)value < (int)VehicleSeat.Any || (int)value > (int)VehicleSeat.ExtraSeat12)
                 {
                     ThrowHelper.ThrowArgumentOutOfRangeException(
                         nameof(value),

--- a/source/scripting_v3/GTA/Entities/Peds/PedGroup.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/PedGroup.cs
@@ -35,7 +35,7 @@ namespace GTA
 
             public bool MoveNext()
             {
-                if (currentIndex++ < (collection.MemberCount - 1))
+                if (currentIndex++ < collection.MemberCount - 1)
                 {
                     current = currentIndex < 0 ? collection.Leader : collection.GetMember(currentIndex);
 

--- a/source/scripting_v3/GTA/Entities/Peds/PedProp.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/PedProp.cs
@@ -98,9 +98,9 @@ namespace GTA
         /// variations.
         /// </summary>
         private static bool IsPedPropDrawableVariationValid(Ped ped, PedPropAnchorPoint anchorPoint, int drawableIndex)
-            => (drawableIndex >= 0 &&
-                (drawableIndex < Function.Call<int>(Hash.GET_NUMBER_OF_PED_PROP_DRAWABLE_VARIATIONS, ped.Handle,
-                    (int)anchorPoint)));
+            => drawableIndex >= 0 &&
+                drawableIndex < Function.Call<int>(Hash.GET_NUMBER_OF_PED_PROP_DRAWABLE_VARIATIONS, ped.Handle,
+                    (int)anchorPoint);
 
         /// <summary>
         /// Returns a value that indicates whether the drawable index is valid for the specified <see cref="Ped"/>
@@ -110,9 +110,9 @@ namespace GTA
         /// </summary>
         private static bool IsPedPropTextureVariationValid(Ped ped, PedPropAnchorPoint anchorPoint, int drawableIndex,
             int textureIndex)
-            => (textureIndex >= 0 &&
-                (textureIndex < Function.Call<int>(Hash.GET_NUMBER_OF_PED_PROP_TEXTURE_VARIATIONS, ped.Handle,
-                    (int)anchorPoint, drawableIndex)));
+            => textureIndex >= 0 &&
+                textureIndex < Function.Call<int>(Hash.GET_NUMBER_OF_PED_PROP_TEXTURE_VARIATIONS, ped.Handle,
+                    (int)anchorPoint, drawableIndex);
 
         public bool HasVariations => Count > 1;
 

--- a/source/scripting_v3/GTA/Entities/Peds/PedResetFlags.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/PedResetFlags.cs
@@ -111,7 +111,7 @@ namespace GTA
                     return 0;
                 }
 
-                int offset = (NativeMemory.Ped.CPed__PedResetFlagsOffset + 1);
+                int offset = NativeMemory.Ped.CPed__PedResetFlagsOffset + 1;
                 return MemDataMarshal.ReadByte(address + offset);
             }
             set
@@ -127,7 +127,7 @@ namespace GTA
                     return;
                 }
 
-                int offset = (NativeMemory.Ped.CPed__PedResetFlagsOffset + 1);
+                int offset = NativeMemory.Ped.CPed__PedResetFlagsOffset + 1;
                 SHVDN.MemDataMarshal.WriteByte(address + offset, value);
             }
         }
@@ -154,7 +154,7 @@ namespace GTA
                     return 0;
                 }
 
-                int offset = (NativeMemory.Ped.CPed__PedResetFlagsOffset + 4);
+                int offset = NativeMemory.Ped.CPed__PedResetFlagsOffset + 4;
                 return MemDataMarshal.ReadUInt32BitField(address + offset, 0, 2);
             }
             set
@@ -172,7 +172,7 @@ namespace GTA
                     return;
                 }
 
-                int offset = (NativeMemory.Ped.CPed__PedResetFlagsOffset + 4);
+                int offset = NativeMemory.Ped.CPed__PedResetFlagsOffset + 4;
                 MemDataMarshal.WriteBitFieldAsUInt32(address + offset, value, 0, 2);
             }
         }
@@ -203,7 +203,7 @@ namespace GTA
                     return 0;
                 }
 
-                int offset = (NativeMemory.Ped.CPed__PedResetFlagsOffset + 4);
+                int offset = NativeMemory.Ped.CPed__PedResetFlagsOffset + 4;
                 return MemDataMarshal.ReadUInt32BitField(address + offset, 2, 2);
             }
             set
@@ -221,7 +221,7 @@ namespace GTA
                     return;
                 }
 
-                int offset = (NativeMemory.Ped.CPed__PedResetFlagsOffset + 4);
+                int offset = NativeMemory.Ped.CPed__PedResetFlagsOffset + 4;
                 MemDataMarshal.WriteBitFieldAsUInt32(address + offset, value, 2, 2);
             }
         }
@@ -248,7 +248,7 @@ namespace GTA
                     return 0;
                 }
 
-                int offset = (NativeMemory.Ped.CPed__PedResetFlagsOffset + 4);
+                int offset = NativeMemory.Ped.CPed__PedResetFlagsOffset + 4;
                 return MemDataMarshal.ReadUInt32BitField(address + offset, 4, 4);
             }
             set
@@ -266,7 +266,7 @@ namespace GTA
                     return;
                 }
 
-                int offset = (NativeMemory.Ped.CPed__PedResetFlagsOffset + 4);
+                int offset = NativeMemory.Ped.CPed__PedResetFlagsOffset + 4;
                 MemDataMarshal.WriteBitFieldAsUInt32(address + offset, value, 4, 4);
             }
         }
@@ -293,7 +293,7 @@ namespace GTA
                     return 0;
                 }
 
-                int offset = (NativeMemory.Ped.CPed__PedResetFlagsOffset + 4);
+                int offset = NativeMemory.Ped.CPed__PedResetFlagsOffset + 4;
                 return MemDataMarshal.ReadUInt32BitField(address + offset, 8, 2);
             }
             set
@@ -311,7 +311,7 @@ namespace GTA
                     return;
                 }
 
-                int offset = (NativeMemory.Ped.CPed__PedResetFlagsOffset + 4);
+                int offset = NativeMemory.Ped.CPed__PedResetFlagsOffset + 4;
                 MemDataMarshal.WriteBitFieldAsUInt32(address + offset, value, 8, 2);
             }
         }
@@ -336,7 +336,7 @@ namespace GTA
                     return 0;
                 }
 
-                int offset = (NativeMemory.Ped.CPed__PedResetFlagsOffset + 24);
+                int offset = NativeMemory.Ped.CPed__PedResetFlagsOffset + 24;
                 return MemDataMarshal.ReadFloat(address + offset);
             }
             set
@@ -352,7 +352,7 @@ namespace GTA
                     return;
                 }
 
-                int offset = (NativeMemory.Ped.CPed__PedResetFlagsOffset + 24);
+                int offset = NativeMemory.Ped.CPed__PedResetFlagsOffset + 24;
                 MemDataMarshal.WriteFloat(address + offset, value);
             }
         }
@@ -377,7 +377,7 @@ namespace GTA
                     return 0;
                 }
 
-                int offset = (NativeMemory.Ped.CPed__PedResetFlagsOffset + 28);
+                int offset = NativeMemory.Ped.CPed__PedResetFlagsOffset + 28;
                 return MemDataMarshal.ReadFloat(address + offset);
             }
             set
@@ -393,7 +393,7 @@ namespace GTA
                     return;
                 }
 
-                int offset = (NativeMemory.Ped.CPed__PedResetFlagsOffset + 28);
+                int offset = NativeMemory.Ped.CPed__PedResetFlagsOffset + 28;
                 MemDataMarshal.WriteFloat(address + offset, value);
             }
         }

--- a/source/scripting_v3/GTA/Entities/Peds/Task/TaskInvoker.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Task/TaskInvoker.cs
@@ -405,7 +405,7 @@ namespace GTA
             Function.Call(Hash.TASK_FOLLOW_NAV_MESH_TO_COORD_ADVANCED, _ped.Handle, position.X, position.Y, position.Z, moveBlendRatio.Value, timeBeforeWarp, radius, (int)navigationFlags, slideToCoordHeading, maxSlopeNavigable, clampMaxSearchDistance, finalHeading);
         }
 
-        public void GoTo(Entity target, Vector3 offset = default(Vector3), int timeout = -1)
+        public void GoTo(Entity target, Vector3 offset = default, int timeout = -1)
         {
             Function.Call(Hash.TASK_GOTO_ENTITY_OFFSET_XY, _ped.Handle, target.Handle, timeout, offset.X, offset.Y, offset.Z, 1f, true);
         }

--- a/source/scripting_v3/GTA/Entities/Peds/Task/TaskInvoker.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Task/TaskInvoker.cs
@@ -2067,8 +2067,8 @@ namespace GTA
         {
             (CrClipDictionary clipDict, string clipName) = crClipAsset;
             float deltaArg = blendOutDelta.HasValue
-                ? (float)(blendOutDelta.GetValueOrDefault())
-                : (AnimationBlendDelta.NormalBlendOut.Value);
+                ? (float)blendOutDelta.GetValueOrDefault()
+                : AnimationBlendDelta.NormalBlendOut.Value;
 
             Function.Call(Hash.STOP_ANIM_TASK, _ped.Handle, clipDict, clipName, deltaArg);
         }

--- a/source/scripting_v3/GTA/Entities/Peds/Task/TaskMoVEScriptedInitialParameters.cs
+++ b/source/scripting_v3/GTA/Entities/Peds/Task/TaskMoVEScriptedInitialParameters.cs
@@ -267,33 +267,33 @@ namespace GTA
             _disposed = false;
         }
 
-        internal readonly AtHashValue ClipSet0 { get; }
+        internal AtHashValue ClipSet0 { get; }
 
-        internal readonly AtHashValue VarClipSet0 { get; }
+        internal AtHashValue VarClipSet0 { get; }
 
-        internal readonly AtHashValue ClipSet1 { get; }
+        internal AtHashValue ClipSet1 { get; }
 
-        internal readonly AtHashValue VarClipSet1 { get; }
+        internal AtHashValue VarClipSet1 { get; }
 
-        internal readonly IntPtr FloatParamNamePtr0 { get; }
+        internal IntPtr FloatParamNamePtr0 { get; }
 
-        internal readonly float FloatParamValue0 { get; }
+        internal float FloatParamValue0 { get; }
 
-        internal readonly float FloatParamLerpValue0 { get; }
+        internal float FloatParamLerpValue0 { get; }
 
-        internal readonly IntPtr FloatParamNamePtr1 { get; }
+        internal IntPtr FloatParamNamePtr1 { get; }
 
-        internal readonly float FloatParamValue1 { get; }
+        internal float FloatParamValue1 { get; }
 
-        internal readonly float FloatParamLerpValue1 { get; }
+        internal float FloatParamLerpValue1 { get; }
 
-        internal readonly IntPtr BoolParamNamePtr0 { get; }
+        internal IntPtr BoolParamNamePtr0 { get; }
 
-        internal readonly bool BoolParamValue0 { get; }
+        internal bool BoolParamValue0 { get; }
 
-        internal readonly IntPtr BoolParamNamePtr1 { get; }
+        internal IntPtr BoolParamNamePtr1 { get; }
 
-        internal readonly bool BoolParamValue1 { get; }
+        internal bool BoolParamValue1 { get; }
 
         private bool _disposed;
 

--- a/source/scripting_v3/GTA/Entities/Vehicles/HandlingData/VehicleWeaponHandlingData.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/HandlingData/VehicleWeaponHandlingData.cs
@@ -93,7 +93,7 @@ namespace GTA
                 const int MemberOffset = 0x8;
                 for (int i = 0; i < arrayToFill.Length; i++)
                 {
-                    SHVDN.MemDataMarshal.WriteInt32(MemoryAddress + MemberOffset + i * 4, (int)arrayToFill[i]);
+                    SHVDN.MemDataMarshal.WriteInt32(MemoryAddress + MemberOffset + i * 4, arrayToFill[i]);
                 }
             }
         }

--- a/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs
@@ -349,7 +349,7 @@ namespace GTA
             get
             {
                 VehicleType vehicleType = Type;
-                return ((uint)vehicleType - 8) <= 1;
+                return (uint)vehicleType - 8 <= 1;
             }
         }
 
@@ -362,7 +362,7 @@ namespace GTA
             get
             {
                 VehicleType vehicleType = Type;
-                return ((uint)vehicleType - 8) <= 2;
+                return (uint)vehicleType - 8 <= 2;
             }
         }
 
@@ -384,7 +384,7 @@ namespace GTA
             get
             {
                 VehicleType vehicleType = Type;
-                return (vehicleType == VehicleType.Motorcycle || vehicleType == VehicleType.Bicycle);
+                return vehicleType == VehicleType.Motorcycle || vehicleType == VehicleType.Bicycle;
             }
         }
 

--- a/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs
@@ -874,13 +874,7 @@ namespace GTA
         /// </summary>
         public float OilVolume
         {
-            get
-            {
-                if (!TryGetMemoryAddress(out IntPtr address))
-                    return 0.0f;
-
-                return HandlingData.OilVolume;
-            }
+            get => HandlingData.OilVolume;
         }
 
         /// <summary>
@@ -910,13 +904,7 @@ namespace GTA
         /// </summary>
         public float PetrolTankVolume
         {
-            get
-            {
-                if (!TryGetMemoryAddress(out IntPtr address))
-                    return 0.0f;
-
-                return HandlingData.PetrolTankVolume;
-            }
+            get => HandlingData.PetrolTankVolume;
         }
 
         #endregion

--- a/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs
@@ -621,7 +621,7 @@ namespace GTA
                 if (!TryGetMemoryAddress(out IntPtr address) || SHVDN.NativeMemory.Vehicle.HandlingDataOffset == 0)
                     return new HandlingData(IntPtr.Zero);
 
-                return new HandlingData(SHVDN.MemDataMarshal.ReadAddress(MemoryAddress + SHVDN.NativeMemory.Vehicle.HandlingDataOffset));
+                return new HandlingData(SHVDN.MemDataMarshal.ReadAddress(address + SHVDN.NativeMemory.Vehicle.HandlingDataOffset));
             }
         }
 
@@ -2692,7 +2692,7 @@ namespace GTA
                 if (!TryGetMemoryAddress(out IntPtr address) || SHVDN.NativeMemory.Vehicle.SpecialFlightTargetRatioOffset == 0)
                     return 0f;
 
-                return SHVDN.MemDataMarshal.ReadFloat(MemoryAddress + SHVDN.NativeMemory.Vehicle.SpecialFlightTargetRatioOffset);
+                return SHVDN.MemDataMarshal.ReadFloat(address + SHVDN.NativeMemory.Vehicle.SpecialFlightTargetRatioOffset);
             }
             set
             {
@@ -2715,7 +2715,7 @@ namespace GTA
                 if (!TryGetMemoryAddress(out IntPtr address) || SHVDN.NativeMemory.Vehicle.SpecialFlightCurrentRatioOffset == 0)
                     return 0f;
 
-                return SHVDN.MemDataMarshal.ReadFloat(MemoryAddress + SHVDN.NativeMemory.Vehicle.SpecialFlightCurrentRatioOffset);
+                return SHVDN.MemDataMarshal.ReadFloat(address + SHVDN.NativeMemory.Vehicle.SpecialFlightCurrentRatioOffset);
             }
             set
             {
@@ -2738,7 +2738,7 @@ namespace GTA
                 if (!TryGetMemoryAddress(out IntPtr address) || SHVDN.NativeMemory.Vehicle.SpecialFlightWingRatioOffset == 0)
                     return 0f;
 
-                return SHVDN.MemDataMarshal.ReadFloat(MemoryAddress + SHVDN.NativeMemory.Vehicle.SpecialFlightWingRatioOffset);
+                return SHVDN.MemDataMarshal.ReadFloat(address + SHVDN.NativeMemory.Vehicle.SpecialFlightWingRatioOffset);
             }
             set
             {
@@ -2749,7 +2749,7 @@ namespace GTA
 
                     return;
 
-                SHVDN.MemDataMarshal.WriteFloat(MemoryAddress + SHVDN.NativeMemory.Vehicle.SpecialFlightWingRatioOffset, value);
+                SHVDN.MemDataMarshal.WriteFloat(address + SHVDN.NativeMemory.Vehicle.SpecialFlightWingRatioOffset, value);
             }
         }
 
@@ -2770,7 +2770,7 @@ namespace GTA
                 if (!TryGetMemoryAddress(out IntPtr address) || SHVDN.NativeMemory.Vehicle.SpecialFlightAreWingsDisabledOffset == 0)
                     return false;
 
-                return SHVDN.MemDataMarshal.ReadByte(MemoryAddress + SHVDN.NativeMemory.Vehicle.SpecialFlightAreWingsDisabledOffset) != 0;
+                return SHVDN.MemDataMarshal.ReadByte(address + SHVDN.NativeMemory.Vehicle.SpecialFlightAreWingsDisabledOffset) != 0;
             }
             set
             {

--- a/source/scripting_v3/GTA/Entities/Vehicles/VehicleMod.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/VehicleMod.cs
@@ -149,20 +149,16 @@ namespace GTA
                         {
                             return Game.GetLocalizedString("CMOD_WHE_0");
                         }
-                        else
-                        {
-                            return Game.GetLocalizedString("CMOD_WHE_B_0");
-                        }
+
+                        return Game.GetLocalizedString("CMOD_WHE_B_0");
                     }
                     if (index >= count / 2)
                     {
                         return Game.GetLocalizedString("CHROME") + " " +
                                Game.GetLocalizedString(Function.Call<string>(Hash.GET_MOD_TEXT_LABEL, Vehicle.Handle, (int)Type, index));
                     }
-                    else
-                    {
-                        return Game.GetLocalizedString(Function.Call<string>(Hash.GET_MOD_TEXT_LABEL, Vehicle.Handle, (int)Type, index));
-                    }
+
+                    return Game.GetLocalizedString(Function.Call<string>(Hash.GET_MOD_TEXT_LABEL, Vehicle.Handle, (int)Type, index));
                 }
 
                 switch (Type)
@@ -197,28 +193,26 @@ namespace GTA
                     }
                     return LocalizedTypeName + " " + (index + 1).ToString();
                 }
-                else
-                {
-                    switch (Type)
-                    {
-                        case VehicleModType.AirFilter:
-                            if (Vehicle.Model == VehicleHash.Tornado)
-                            {
-                            }
-                            break;
-                        case VehicleModType.Struts:
-                            switch ((VehicleHash)Vehicle.Model)
-                            {
-                                case VehicleHash.Banshee:
-                                case VehicleHash.Banshee2:
-                                case VehicleHash.SultanRS:
-                                    return Game.GetLocalizedString("CMOD_COL5_41");
-                            }
-                            break;
 
-                    }
-                    return Game.GetLocalizedString("CMOD_DEF_0");
+                switch (Type)
+                {
+                    case VehicleModType.AirFilter:
+                        if (Vehicle.Model == VehicleHash.Tornado)
+                        {
+                        }
+                        break;
+                    case VehicleModType.Struts:
+                        switch ((VehicleHash)Vehicle.Model)
+                        {
+                            case VehicleHash.Banshee:
+                            case VehicleHash.Banshee2:
+                            case VehicleHash.SultanRS:
+                                return Game.GetLocalizedString("CMOD_COL5_41");
+                        }
+                        break;
+
                 }
+                return Game.GetLocalizedString("CMOD_DEF_0");
             }
         }
 

--- a/source/scripting_v3/GTA/Entities/Vehicles/VehicleModCollection.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/VehicleModCollection.cs
@@ -198,10 +198,8 @@ namespace GTA
                 {
                     return this[VehicleModType.Livery].Index;
                 }
-                else
-                {
-                    return Function.Call<int>(Hash.GET_VEHICLE_LIVERY, _owner.Handle);
-                }
+
+                return Function.Call<int>(Hash.GET_VEHICLE_LIVERY, _owner.Handle);
             }
             set
             {

--- a/source/scripting_v3/GTA/Entities/Vehicles/VehicleModCollection.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/VehicleModCollection.cs
@@ -97,7 +97,7 @@ namespace GTA
             {
                 if (_owner.Model.IsBicycle || _owner.Model.IsBike)
                 {
-                    return new VehicleWheelType[] { VehicleWheelType.BikeWheels };
+                    return new[] { VehicleWheelType.BikeWheels };
                 }
 
                 if (!_owner.Model.IsCar)
@@ -129,7 +129,7 @@ namespace GTA
                     case VehicleHash.Minivan2:
                     case VehicleHash.SlamVan3:
                     case VehicleHash.Faction3:
-                        res.AddRange(new VehicleWheelType[] { VehicleWheelType.BennysOriginals, VehicleWheelType.BennysBespoke });
+                        res.AddRange(new[] { VehicleWheelType.BennysOriginals, VehicleWheelType.BennysBespoke });
                         break;
                     case VehicleHash.SultanRS:
                     case VehicleHash.Banshee2:

--- a/source/scripting_v3/GTA/Entities/Vehicles/VehicleWheel.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/VehicleWheel.cs
@@ -30,7 +30,7 @@ namespace GTA
         };
 
         internal static readonly Dictionary<VehicleWheelBoneId, ScriptVehicleWheelIndex> vehicleScriptWheelIndicesForBoneIds
-            = new Dictionary<VehicleWheelBoneId, ScriptVehicleWheelIndex>(10)
+            = new(10)
         {
             { VehicleWheelBoneId.WheelLeftFront, ScriptVehicleWheelIndex.CarFrontLeft },
             { VehicleWheelBoneId.WheelRightFront, ScriptVehicleWheelIndex.CarFrontRight },

--- a/source/scripting_v3/GTA/FwSyncedScene.cs
+++ b/source/scripting_v3/GTA/FwSyncedScene.cs
@@ -224,7 +224,7 @@ namespace GTA
         /// <see langword="true"/> if <paramref name="scene"/> is the same synced scene as
         /// this <see cref="FwSyncedScene"/>; otherwise, <see langword="false"/>.
         /// </returns>
-        public bool Equals(FwSyncedScene scene) => scene != null && (Handle == scene.Handle);
+        public bool Equals(FwSyncedScene scene) => scene != null && Handle == scene.Handle;
 
         /// <summary>
         /// Determines if two <see cref="PathNode"/>s refer to the same path node.

--- a/source/scripting_v3/GTA/Game.cs
+++ b/source/scripting_v3/GTA/Game.cs
@@ -400,13 +400,13 @@ namespace GTA
             foreach (Button button in buttons)
             {
                 hash += (uint)button;
-                hash += (hash << 10);
-                hash ^= (hash >> 6);
+                hash += hash << 10;
+                hash ^= hash >> 6;
             }
 
-            hash += (hash << 3);
-            hash ^= (hash >> 11);
-            hash += (hash << 15);
+            hash += hash << 3;
+            hash ^= hash >> 11;
+            hash += hash << 15;
 
             return Function.Call<bool>(Hash.HAS_CHEAT_WITH_HASH_BEEN_ACTIVATED, hash, buttons.Length);
         }
@@ -764,7 +764,7 @@ namespace GTA
         {
             unsafe
             {
-                byte* address = (startAddress == IntPtr.Zero ? SHVDN.MemScanner.FindPatternNaive(pattern, mask) : SHVDN.MemScanner.FindPatternNaive(pattern, mask, startAddress));
+                byte* address = startAddress == IntPtr.Zero ? SHVDN.MemScanner.FindPatternNaive(pattern, mask) : SHVDN.MemScanner.FindPatternNaive(pattern, mask, startAddress);
                 return address == null ? IntPtr.Zero : new IntPtr(address);
             }
         }

--- a/source/scripting_v3/GTA/GameVersionNotSupportedException.cs
+++ b/source/scripting_v3/GTA/GameVersionNotSupportedException.cs
@@ -42,7 +42,7 @@ namespace GTA
         public Version MinimumSupportedGameFileVersion { get; }
 
         private readonly Dictionary<Version, GameVersion> _supportedGameVersionEnumMaps
-            = new Dictionary<Version, GameVersion>
+            = new()
         {
             { ExeVersionConsts.v1_0_335_2, GameVersion.v1_0_335_2_Steam },
             { ExeVersionConsts.v1_0_350_1, GameVersion.v1_0_350_1_Steam },

--- a/source/scripting_v3/GTA/InteriorProxy.cs
+++ b/source/scripting_v3/GTA/InteriorProxy.cs
@@ -82,9 +82,6 @@ namespace GTA
         {
             get
             {
-                if (!TryGetMemoryAddress(out IntPtr address))
-                    return null;
-
                 int interiorInstHandle = SHVDN.NativeMemory.GetAssociatedInteriorInstHandleFromInteriorProxy(Handle);
                 return interiorInstHandle != 0 ? new InteriorInstance(interiorInstHandle) : null;
             }

--- a/source/scripting_v3/GTA/PathNode.cs
+++ b/source/scripting_v3/GTA/PathNode.cs
@@ -36,7 +36,7 @@ namespace GTA
             get
             {
                 uint areaIdAndNodeIdCorrected = (uint)Handle - 1;
-                return ((ushort)areaIdAndNodeIdCorrected >> 0x10);
+                return (ushort)areaIdAndNodeIdCorrected >> 0x10;
             }
         }
 

--- a/source/scripting_v3/GTA/Scaleform.cs
+++ b/source/scripting_v3/GTA/Scaleform.cs
@@ -121,7 +121,7 @@ namespace GTA
                         Function.Call(Hash.SCALEFORM_MOVIE_METHOD_ADD_PARAM_FLOAT, (float)argDouble);
                         break;
                     case bool argBool:
-                        Function.Call(Hash.SCALEFORM_MOVIE_METHOD_ADD_PARAM_BOOL, (bool)argBool);
+                        Function.Call(Hash.SCALEFORM_MOVIE_METHOD_ADD_PARAM_BOOL, argBool);
                         break;
                     case ScaleformArgumentTXD argTxd:
                         Function.Call(Hash.SCALEFORM_MOVIE_METHOD_ADD_PARAM_TEXTURE_NAME_STRING, argTxd._txd);

--- a/source/scripting_v3/GTA/Scaleform.cs
+++ b/source/scripting_v3/GTA/Scaleform.cs
@@ -169,7 +169,7 @@ namespace GTA
             float w = size.X / UI.Screen.Width;
             float h = size.Y / UI.Screen.Height;
 
-            Function.Call(Hash.DRAW_SCALEFORM_MOVIE, Handle, x + (w * 0.5f), y + (h * 0.5f), w, h, 255, 255, 255, 255);
+            Function.Call(Hash.DRAW_SCALEFORM_MOVIE, Handle, x + w * 0.5f, y + h * 0.5f, w, h, 255, 255, 255, 255);
         }
 
         public void Render3D(Vector3 position, Vector3 rotation, Vector3 scale)

--- a/source/scripting_v3/GTA/ScriptFire.cs
+++ b/source/scripting_v3/GTA/ScriptFire.cs
@@ -19,7 +19,7 @@ namespace GTA
         /// <summary>Creates a new <see cref="ScriptFire"/> from an existing handle.</summary>
         /// <param name="handle">The handle of the fire.</param>
         /// <returns>A new <see cref="ScriptFire"/> instance.</returns>
-        public static ScriptFire FromHandle(int handle) => new ScriptFire(handle);
+        public static ScriptFire FromHandle(int handle) => new(handle);
 
         /// <summary>Removes this <see cref="ScriptFire"/> from the game world.</summary>
         public override void Delete() => Function.Call(Hash.REMOVE_SCRIPT_FIRE, Handle);

--- a/source/scripting_v3/GTA/Shvdn/Script/ScriptSettings.cs
+++ b/source/scripting_v3/GTA/Shvdn/Script/ScriptSettings.cs
@@ -73,7 +73,8 @@ namespace GTA
                         tempSectionName = line.Substring(1, line.IndexOf("]", StringComparison.Ordinal) - 1).Trim();
                         continue;
                     }
-                    else if (line.Contains("="))
+
+                    if (line.Contains("="))
                     {
                         int index = line.IndexOf("=", StringComparison.Ordinal);
                         string key = line.Substring(0, index).Trim();

--- a/source/scripting_v3/GTA/Shvdn/Script/ScriptSettings.cs
+++ b/source/scripting_v3/GTA/Shvdn/Script/ScriptSettings.cs
@@ -280,12 +280,12 @@ namespace GTA
         {
             if (!_values.TryGetValue(sectionName, out Dictionary<string, List<string>> keyValuePairs))
             {
-                value = default(T);
+                value = default;
                 return false;
             }
             if (!keyValuePairs.TryGetValue(keyName, out List<string> valueList))
             {
-                value = default(T);
+                value = default;
                 return false;
             }
 
@@ -307,7 +307,7 @@ namespace GTA
             }
             catch (Exception)
             {
-                value = default(T);
+                value = default;
                 return false;
             }
         }

--- a/source/scripting_v3/GTA/StringHash.cs
+++ b/source/scripting_v3/GTA/StringHash.cs
@@ -139,8 +139,8 @@ namespace GTA
             foreach (byte c in input)
             {
                 hash += s_normalizeCaseAndSlashLookup[c];
-                hash += (hash << 10);
-                hash ^= (hash >> 6);
+                hash += hash << 10;
+                hash ^= hash >> 6;
             }
 
             return hash;
@@ -339,8 +339,8 @@ namespace GTA
             foreach (byte c in input)
             {
                 hash += c;
-                hash += (hash << 10);
-                hash ^= (hash >> 6);
+                hash += hash << 10;
+                hash ^= hash >> 6;
             }
 
             return AtFinalizeHash(hash);
@@ -375,9 +375,9 @@ namespace GTA
         public static uint AtFinalizeHash(uint partialHashValue)
         {
             uint hash = partialHashValue;
-            hash += (hash << 3);
-            hash ^= (hash >> 11);
-            hash += (hash << 15);
+            hash += hash << 3;
+            hash ^= hash >> 11;
+            hash += hash << 15;
             return hash;
         }
 
@@ -394,8 +394,8 @@ namespace GTA
                 }
 
                 hash += s_normalizeCaseAndSlashLookup[c];
-                hash += (hash << 10);
-                hash ^= (hash >> 6);
+                hash += hash << 10;
+                hash ^= hash >> 6;
             }
 
             return hash;

--- a/source/scripting_v3/GTA/Weapons/Weapon.cs
+++ b/source/scripting_v3/GTA/Weapons/Weapon.cs
@@ -22,7 +22,7 @@ namespace GTA
         }
         internal Weapon(Ped owner, WeaponHash hash)
         {
-            this._owner = owner;
+            _owner = owner;
             Hash = hash;
         }
 

--- a/source/scripting_v3/GTA/Weapons/WeaponCollection.cs
+++ b/source/scripting_v3/GTA/Weapons/WeaponCollection.cs
@@ -185,7 +185,7 @@ namespace GTA
                     return bestWeapon;
                 }
 
-                var weapon = new Weapon(owner, (WeaponHash)hash);
+                var weapon = new Weapon(owner, hash);
                 weapons.Add(hash, weapon);
 
                 return weapon;

--- a/source/scripting_v3/GTA/Weapons/WeaponComponent.cs
+++ b/source/scripting_v3/GTA/Weapons/WeaponComponent.cs
@@ -59,7 +59,7 @@ namespace GTA
         {
             // According to NativeDB and the internal .sch, this should return a boolean,
             // but the actual implementation behaves like a void function instead.
-            set => Function.Call(Native.Hash.SET_FLASH_LIGHT_FADE_DISTANCE, value);
+            set => Function.Call(Hash.SET_FLASH_LIGHT_FADE_DISTANCE, value);
         }
 
         public WeaponComponentHash ComponentHash

--- a/source/scripting_v3/GTA/Weapons/WeaponComponentCollection.cs
+++ b/source/scripting_v3/GTA/Weapons/WeaponComponentCollection.cs
@@ -42,10 +42,8 @@ namespace GTA
                     _weaponComponents.Add(componentHash, component);
                     return component;
                 }
-                else
-                {
-                    return _invalidComponent;
-                }
+
+                return _invalidComponent;
             }
         }
 

--- a/source/scripting_v3/GTA/World.cs
+++ b/source/scripting_v3/GTA/World.cs
@@ -2679,7 +2679,8 @@ namespace GTA
                 {
                     return outPos;
                 }
-                else if (Function.Call<bool>(Hash.GET_SAFE_COORD_FOR_PED, position.X, position.Y, position.Z, false, &outPos, 0))
+
+                if (Function.Call<bool>(Hash.GET_SAFE_COORD_FOR_PED, position.X, position.Y, position.Z, false, &outPos, 0))
                 {
                     return outPos;
                 }

--- a/source/scripting_v3/GTA/World.cs
+++ b/source/scripting_v3/GTA/World.cs
@@ -21,7 +21,7 @@ namespace GTA
         static readonly GregorianCalendar s_calendar = new();
 
         // removes gang and animal ped models just like CREATE_RANDOM_PED does
-        static readonly Func<Model, bool> s_defaultPredicateForCreateRandomPed = (x => x.IsHumanPed && !x.IsGangPed);
+        static readonly Func<Model, bool> s_defaultPredicateForCreateRandomPed = x => x.IsHumanPed && !x.IsGangPed;
         #endregion
 
         #region Weather & Effects


### PR DESCRIPTION
This PR focuses on removing redundancies in the code.

The changes from https://github.com/scripthookvdotnet/scripthookvdotnet/commit/948c62bcf120eea5c9e87e78696d552e87de2394 in `Vehicle.cs` can be simplified this way because the `HandlingData` property returns an instance of HandlingData with `IntPtr.Zero`.

Therefore, when the instance is validated when retrieving either `OilVolume` or `PetrolTankVolume`, the default value of `0.0f` is returned.

https://github.com/scripthookvdotnet/scripthookvdotnet/blob/b80531567eab11bc3c81230c0cb852ad031f5c28/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs#L617-L626

https://github.com/scripthookvdotnet/scripthookvdotnet/blob/b80531567eab11bc3c81230c0cb852ad031f5c28/source/scripting_v3/GTA/Entities/Vehicles/HandlingData/HandlingData.cs#L768-L778