### PR TITLE
feat(api-v3): store attribute constructor arguments in properties

### DIFF
--- a/source/scripting_v3/GTA/Shvdn/Script/MinimumRequiredGameBuildAttribute.cs
+++ b/source/scripting_v3/GTA/Shvdn/Script/MinimumRequiredGameBuildAttribute.cs
@@ -4,8 +4,11 @@ namespace GTA
     [AttributeUsage(AttributeTargets.Class)]
     public sealed class MinimumRequiredGameBuildAttribute : Attribute
     {
+        public int Build { get; }
+
         public MinimumRequiredGameBuildAttribute(int build)
         {
+            Build = build;
         }
     }
 }

--- a/source/scripting_v3/GTA/Shvdn/Script/RequireScript.cs
+++ b/source/scripting_v3/GTA/Shvdn/Script/RequireScript.cs
@@ -10,8 +10,11 @@ namespace GTA
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public sealed class RequireScript : Attribute
     {
+        public Type Dependency { get; }
+
         public RequireScript(Type dependency)
         {
+            Dependency = dependency;
         }
     }
 }


### PR DESCRIPTION
This PR stores the values of `MinimumRequiredGameBuildAttribute` and `RequireScript` in a property.

Note that the actual implementation for retrieving each attribute's value has not changed.

This should close #1773 and #1774.

