### PR TITLE
feat(api-v3): mark `World.GetDistance(Vector3, Vector3)` as obsolete

### DIFF
--- a/source/scripting_v3/GTA/World.Obsolete.cs
+++ b/source/scripting_v3/GTA/World.Obsolete.cs
@@ -301,5 +301,17 @@ namespace GTA
             }
             return Vector3.Zero;
         }
+
+        /// <summary>
+        /// Gets the straight line distance between 2 positions.
+        /// </summary>
+        /// <param name="origin">The origin.</param>
+        /// <param name="destination">The destination.</param>
+        /// <returns>The distance.</returns>
+        [Obsolete("Use Vector3.Distance(Vector3, Vector3) instead.")]
+        public static float GetDistance(Vector3 origin, Vector3 destination)
+        {
+            return Function.Call<float>(Hash.GET_DISTANCE_BETWEEN_COORDS, origin.X, origin.Y, origin.Z, destination.X, destination.Y, destination.Z, 1);
+        }
     }
 }

--- a/source/scripting_v3/GTA/World.cs
+++ b/source/scripting_v3/GTA/World.cs
@@ -2312,16 +2312,6 @@ namespace GTA
         #region Positioning
 
         /// <summary>
-        /// Gets the straight line distance between 2 positions.
-        /// </summary>
-        /// <param name="origin">The origin.</param>
-        /// <param name="destination">The destination.</param>
-        /// <returns>The distance.</returns>
-        public static float GetDistance(Vector3 origin, Vector3 destination)
-        {
-            return Function.Call<float>(Hash.GET_DISTANCE_BETWEEN_COORDS, origin.X, origin.Y, origin.Z, destination.X, destination.Y, destination.Z, 1);
-        }
-        /// <summary>
         /// Calculates the travel distance using roads and paths between 2 positions.
         /// </summary>
         /// <param name="origin">The origin.</param>


### PR DESCRIPTION
`World.GetDistance(Vector3, Vector3)` simply computes the distance between two vectors. There is no need to have a dedicated method for this in `World`.

