### PR TITLE
feat(core, api-v3): add `Player.IsAimingInAccurateMode`

### DIFF
--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -728,6 +728,12 @@ namespace SHVDN
                 s_radarZoomValueAddress = (int*)(*(int*)(address + 5) + address + 9);
             }
 
+            address = MemScanner.FindPatternBmh("\x84\x00\x74\x00\x49\x8B\x00\xE8\x00\x00\x00\x00\x80\x00\x00\x00\x0F", "x?x?xx?x????x??xx");
+            if (address != null)
+            {
+                s_isCameraInAccurateMode = (delegate* unmanaged[Stdcall]<byte>)(new IntPtr(*(int*)(address + 0x17) + address + 0x1B));
+            }
+
             // Nopping this enables to spawn some drawable objects without a dedicated collision (e.g. prop_fan_palm_01a)
             address = MemScanner.FindPatternBmh("\x74\x00\x00\x00\x00\x74\x00\xe8\x00\x00\x00\x00\x48\x85\xc0\x75\x00\x38\x00\x00\x0f\x84\x00\x00\x00\x00\x48\x8d\x4d\x00\xe8\x00\x00\x00\x00\x66\x89\x45\x00\x8b\x45\x00\x8b\xc8\x33\x4d", "x????x?x????xxxx?x??xx????xxx?x????xxx?xx?xxxx");
             if (address != null)
@@ -1049,8 +1055,13 @@ namespace SHVDN
 
         #region -- Cameras --
 
+        private static delegate* unmanaged[Stdcall]<byte> s_isCameraInAccurateMode;
+
         private static ulong* s_cameraPoolAddress;
         private static ulong* s_gameplayCameraAddress;
+
+        public static bool IsCameraInAccurateMode
+            => s_isCameraInAccurateMode() != 0;
 
         public static IntPtr GetCameraAddress(int handle)
         {

--- a/source/scripting_v3/GTA/Player.cs
+++ b/source/scripting_v3/GTA/Player.cs
@@ -598,6 +598,14 @@ namespace GTA
         public bool IsAiming => Function.Call<bool>(Hash.IS_PLAYER_FREE_AIMING, Handle);
 
         /// <summary>
+        /// Gets a value that indicates whether this <see cref="Player"/> is aiming with the weapon "AccurateModeAccuracyModifier" applied. 
+        /// </summary>
+        /// <value>
+        ///   <see langword="true" /> if this <see cref="Player"/> is aiming; otherwise, <see langword="false" />.
+        /// </value>
+        public bool IsAimingInAccurateMode => SHVDN.NativeMemory.IsCameraInAccurateMode;
+
+        /// <summary>
         /// Gets a value indicating whether this <see cref="Player"/> is climbing.
         /// </summary>
         /// <value>


### PR DESCRIPTION
This PR adds `Player.IsAimingInAccurateMode` which returns whether the player is aiming with the `AccurateModeAccuracyModifier` of the weapon applied.

This was mentioned by @kagikn in  https://github.com/scripthookvdotnet/scripthookvdotnet/issues/1213#issuecomment-156296944.