### PR TITLE
feat(api-v3): allow changing the color of a blip to any ARGB value

### DIFF
--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -728,6 +728,12 @@ namespace SHVDN
                 s_radarZoomValueAddress = (int*)(*(int*)(address + 5) + address + 9);
             }
 
+            address = MemScanner.FindPatternBmh("\x8D\x4F\x07\x44\x0B\xC0\x41\x81\xC8\x00\x00\x00\xFF\xE8", "xxxxxxxxxxxxxx");
+            if (address != null)
+            {
+                s_setBlipParameterFunc_Color32 = (delegate* unmanaged[Stdcall]<int, int, uint, void>)(Rel32(address, 0xE));
+            }
+
             // Nopping this enables to spawn some drawable objects without a dedicated collision (e.g. prop_fan_palm_01a)
             address = MemScanner.FindPatternBmh("\x74\x00\x00\x00\x00\x74\x00\xe8\x00\x00\x00\x00\x48\x85\xc0\x75\x00\x38\x00\x00\x0f\x84\x00\x00\x00\x00\x48\x8d\x4d\x00\xe8\x00\x00\x00\x00\x66\x89\x45\x00\x8b\x45\x00\x8b\xc8\x33\x4d", "x????x?x????xxxx?x??xx????xxx?x????xxx?xx?xxxx");
             if (address != null)
@@ -4673,6 +4679,8 @@ namespace SHVDN
         private static int* s_northRadarBlipHandleAddress;
         private static int* s_centerRadarBlipHandleAddress;
 
+        private static delegate* unmanaged[Stdcall]<int, int, uint, void> s_setBlipParameterFunc_Color32;
+
         private static bool CheckBlip(ulong blipAddress, FVector3? position, float radius, params int[] spriteTypes)
         {
             if (spriteTypes.Length > 0)
@@ -4827,6 +4835,11 @@ namespace SHVDN
             }
 
             return value;
+        }
+
+        public static void SetBlipSecondaryColor(int handle, uint argb)
+        {
+            s_setBlipParameterFunc_Color32(7, handle, argb);
         }
 
         #endregion

--- a/source/scripting_v3/GTA/Blip/Blip.cs
+++ b/source/scripting_v3/GTA/Blip/Blip.cs
@@ -186,7 +186,7 @@ namespace GTA
 
                 return System.Drawing.Color.FromArgb(SHVDN.MemDataMarshal.ReadInt32(address + 0x4C));
             }
-            set => Function.Call(Hash.SET_BLIP_SECONDARY_COLOUR, Handle, value.R, value.G, value.B);
+            set => SHVDN.NativeMemory.SetBlipSecondaryColor(Handle, (uint)value.ToArgb());
         }
 
         /// <summary>

--- a/source/scripting_v3/GTA/Blip/Blip.cs
+++ b/source/scripting_v3/GTA/Blip/Blip.cs
@@ -93,6 +93,9 @@ namespace GTA
         /// Gets or sets the alpha of this <see cref="Blip"/> on the map.
         /// The value is up to 255.
         /// </summary>
+        /// <remarks>
+        /// This value will be ignored when using <see cref="SecondaryColor"/>.
+        /// </remarks>
         public int Alpha
         {
             get => Function.Call<int>(Hash.GET_BLIP_ALPHA, Handle);
@@ -165,6 +168,9 @@ namespace GTA
         /// <summary>
         /// Gets or sets the color of this <see cref="Blip"/>.
         /// </summary>
+        /// <remarks>
+        /// If you want to set a custom color, set this to <see cref="BlipColor.UseColor32"/> and use <see cref="SecondaryColor"/> instead.
+        /// </remarks>
         public BlipColor Color
         {
             get => (BlipColor)Function.Call<int>(Hash.GET_BLIP_COLOUR, Handle);

--- a/source/scripting_v3/GTA/Blip/BlipColor.cs
+++ b/source/scripting_v3/GTA/Blip/BlipColor.cs
@@ -160,5 +160,7 @@ namespace GTA
         /// This color is always the same as <see cref="BlipColor.Blue"></see>, the only difference is color index.
         /// </summary>
         Blue7,
+
+        UseColor32 = 84,
     }
 }


### PR DESCRIPTION
While this was technically possible before, you had to use `blip.Color = (BlipColor)84;`. Also this behaviour was not documented anywhere.