### PR TITLE
feat(api-v3): add `Blip.BlipType`

### DIFF
--- a/source/scripting_v3/GTA/Blip/Blip.Obsolete.cs
+++ b/source/scripting_v3/GTA/Blip/Blip.Obsolete.cs
@@ -7,6 +7,12 @@ namespace GTA
     public sealed partial class Blip
     {
         /// <summary>
+        /// Gets the type of this <see cref="Blip"/>.
+        /// </summary>
+        [Obsolete("Use Blip.BlipType instead.")]
+        public int Type => Function.Call<int>(Hash.GET_BLIP_INFO_ID_TYPE, Handle);
+
+        /// <summary>
         /// Gets or sets a value indicating whether this <see cref="Blip"/> shows the dollar sign at the top left corner of the <see cref="Blip"/>.
         /// </summary>
         /// <value>

--- a/source/scripting_v3/GTA/Blip/Blip.cs
+++ b/source/scripting_v3/GTA/Blip/Blip.cs
@@ -40,10 +40,12 @@ namespace GTA
         /// </summary>
         public IntPtr MemoryAddress => SHVDN.NativeMemory.GetBlipAddress(Handle);
 
+        // We currently cannot name this "Type" because there is already an obsolete member named "Type" that returns an integer.
+        // Therefore, this name is temporary and will be changed to "Type" in v4.
         /// <summary>
-        /// Gets the type of this <see cref="Blip"/>.
+        /// Gets the type of this <see cref="Blip"/> .
         /// </summary>
-        public int Type => Function.Call<int>(Hash.GET_BLIP_INFO_ID_TYPE, Handle);
+        public BlipType BlipType => (BlipType)Function.Call<int>(Hash.GET_BLIP_INFO_ID_TYPE, Handle);
 
         /// <summary>
         /// Gets or sets the display type of this <see cref="Blip"/>.

--- a/source/scripting_v3/GTA/Blip/BlipType.cs
+++ b/source/scripting_v3/GTA/Blip/BlipType.cs
@@ -1,0 +1,23 @@
+namespace GTA
+{
+    /// <summary>
+    /// An enumeration of the types of <see cref="Blip"/>s.
+    /// </summary>
+    public enum BlipType
+    {
+        Unused = 0,
+        Vehicle = 1,
+        Character,
+        Object,
+        Coords,
+        Contact,
+        Pickup,
+        Radius,
+        WeaponPickup,
+        Cop,
+        Stealth,
+        Area,
+        Custom,
+        PickupObject
+    }
+}


### PR DESCRIPTION
While `Blip` already had a property for its type. It returned an integer which is not very useful for most cases.
The property name `BlipType` should be changed to `Type` once the name is made free in v4.