### PR TITLE
feat(api-v3): add `IsBurst` to `VehicleWheel`

### DIFF
--- a/source/scripting_v3/GTA/Entities/Vehicles/VehicleWheel.Obsolete.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/VehicleWheel.Obsolete.cs
@@ -11,5 +11,20 @@ namespace GTA
         [Obsolete("Use VehicleWheel.BoneId or VehicleWheel.ScriptIndex instead."),
         EditorBrowsable(EditorBrowsableState.Never)]
         public int Index => (int)ScriptIndex;
+
+        /// <summary>                              
+        /// Sets a value indicating whether this <see cref="VehicleWheel"/> is burst.
+        /// </summary>
+        [Obsolete("Use VehicleWheel.IsBurst instead.")]
+        public bool IsBursted
+        {
+            get
+            {
+                if (!TryGetMemoryAddress(out IntPtr address) || SHVDN.NativeMemory.Vehicle.CWheelTireHealthOffset == 0)
+                    return false;
+
+                return SHVDN.MemDataMarshal.ReadFloat(address + SHVDN.NativeMemory.Vehicle.CWheelTireHealthOffset) <= 0f;
+            }
+        }
     }
 }

--- a/source/scripting_v3/GTA/Entities/Vehicles/VehicleWheel.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/VehicleWheel.cs
@@ -344,19 +344,15 @@ namespace GTA
                 return SHVDN.MemDataMarshal.ReadFloat(address + SHVDN.NativeMemory.Vehicle.CWheelTireHealthOffset) < 1000f;
             }
         }
-        /// <summary>
-        /// Sets a value indicating whether this <see cref="VehicleWheel"/> is bursted.
-        /// </summary>
-        public bool IsBursted
-        {
-            get
-            {
-                if (!TryGetMemoryAddress(out IntPtr address) || SHVDN.NativeMemory.Vehicle.CWheelTireHealthOffset == 0)
-                    return false;
 
-                return SHVDN.MemDataMarshal.ReadFloat(address + SHVDN.NativeMemory.Vehicle.CWheelTireHealthOffset) <= 0f;
-            }
+        /// <summary>
+        /// Gets a value indicating whether this <see cref="VehicleWheel"/> is burst.
+        /// </summary>
+        public bool IsBurst
+        {
+            get => TireHealth == 0f;
         }
+
         /// <summary>
         /// Gets or sets the suspension health.
         /// </summary>


### PR DESCRIPTION
While `VehicleWheel` already has a property called `IsBursted`, which was added in 2021, the word "bursted" is not a valid tense of "burst" in standard English and is only used in informal contexts or dialects. 

Because `TireHealth` returns **0f** for any negative values, the check can be simplified to `TireHealth == 0f;`.

