### PR TITLE
feat(api-v2): add obsolete attribute to all public types

### DIFF
--- a/source/scripting_v2/GTA.Math/Matrix.cs
+++ b/source/scripting_v2/GTA.Math/Matrix.cs
@@ -28,6 +28,7 @@ namespace GTA.Math
     /// </summary>
     [Serializable]
     [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public struct Matrix : IEquatable<Matrix>
     {
         /// <summary>

--- a/source/scripting_v2/GTA.Math/Quaternion.cs
+++ b/source/scripting_v2/GTA.Math/Quaternion.cs
@@ -25,6 +25,7 @@ namespace GTA.Math
 {
     [Serializable]
     [StructLayout(LayoutKind.Sequential)]
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public struct Quaternion : IEquatable<Quaternion>
     {
         /// <summary>

--- a/source/scripting_v2/GTA.Math/Vector2.cs
+++ b/source/scripting_v2/GTA.Math/Vector2.cs
@@ -34,6 +34,7 @@ namespace GTA.Math
     /// </remarks>
     [Serializable]
     [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public struct Vector2 : IEquatable<Vector2>
     {
         /// <summary>

--- a/source/scripting_v2/GTA.Math/Vector3.cs
+++ b/source/scripting_v2/GTA.Math/Vector3.cs
@@ -39,6 +39,7 @@ namespace GTA.Math
     /// </remarks>
     [Serializable]
     [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public struct Vector3 : IEquatable<Vector3>
     {
         /// <summary>

--- a/source/scripting_v2/GTA.Native/Native.cs
+++ b/source/scripting_v2/GTA.Native/Native.cs
@@ -72,6 +72,7 @@ namespace GTA.Native
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public class InputArgument
     {
         internal ulong data;
@@ -249,6 +250,7 @@ namespace GTA.Native
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public class OutputArgument : InputArgument, IDisposable
     {
         public OutputArgument() : base(Marshal.AllocCoTaskMem(24))
@@ -356,6 +358,7 @@ namespace GTA.Native
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public static class Function
     {
         private const int MaxArgCount = 63;

--- a/source/scripting_v2/GTA.Native/NativeHashes.cs
+++ b/source/scripting_v2/GTA.Native/NativeHashes.cs
@@ -1,9 +1,12 @@
 // This file was generated with https://github.com/scripthookvdotnet/scripthookvdotnet-nativegen
 
+using System;
+
 namespace GTA
 {
     namespace Native
     {
+        [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
         public enum Hash : ulong
         {
             /*

--- a/source/scripting_v2/GTA.Native/PedHash.cs
+++ b/source/scripting_v2/GTA.Native/PedHash.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA.Native
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum PedHash : uint
     {
         // Player Characters

--- a/source/scripting_v2/GTA.Native/VehicleHash.cs
+++ b/source/scripting_v2/GTA.Native/VehicleHash.cs
@@ -8,6 +8,7 @@ using System.ComponentModel;
 
 namespace GTA.Native
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum VehicleHash : uint
     {
         Adder = 3078201489u,

--- a/source/scripting_v2/GTA.Native/WeaponComponent.cs
+++ b/source/scripting_v2/GTA.Native/WeaponComponent.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA.Native
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum WeaponComponent : uint
     {
         AdvancedRifleClip01 = 0xFA8FA10F,

--- a/source/scripting_v2/GTA.Native/WeaponHash.cs
+++ b/source/scripting_v2/GTA.Native/WeaponHash.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA.Native
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum WeaponHash : uint
     {
         Knife = 0x99B507EA,

--- a/source/scripting_v2/GTA.NaturalMotion/CustomHelper.cs
+++ b/source/scripting_v2/GTA.NaturalMotion/CustomHelper.cs
@@ -3,11 +3,14 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA.NaturalMotion
 {
     /// <summary>
     /// A helper class for building a <seealso cref="Message"/> and sending it to a given <see cref="Ped"/>.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public abstract class CustomHelper : Message
     {
         #region Fields

--- a/source/scripting_v2/GTA.NaturalMotion/Euphoria.cs
+++ b/source/scripting_v2/GTA.NaturalMotion/Euphoria.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 
 namespace GTA.NaturalMotion
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class Euphoria
     {
         #region Fields

--- a/source/scripting_v2/GTA.NaturalMotion/EuphoriaHelpers.cs
+++ b/source/scripting_v2/GTA.NaturalMotion/EuphoriaHelpers.cs
@@ -9,6 +9,7 @@ using GTA.Math;
 
 namespace GTA.NaturalMotion
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum ArmDirections
     {
         Backwards = -1,
@@ -16,6 +17,7 @@ namespace GTA.NaturalMotion
         Forwards
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum AnimSource
     {
         CurrentItems,
@@ -23,6 +25,7 @@ namespace GTA.NaturalMotion
         AnimItems
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum FallType
     {
         RampDownStiffness,
@@ -31,6 +34,7 @@ namespace GTA.NaturalMotion
         Slump
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum Synchroisation
     {
         NotSynced,
@@ -38,6 +42,7 @@ namespace GTA.NaturalMotion
         SyncedAtStart
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum TurnType
     {
         DontTurn,
@@ -45,6 +50,7 @@ namespace GTA.NaturalMotion
         AwayFromTarget
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum TorqueMode
     {
         Disabled,
@@ -52,6 +58,7 @@ namespace GTA.NaturalMotion
         Additive
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum TorqueSpinMode
     {
         FromImpulse,
@@ -59,6 +66,7 @@ namespace GTA.NaturalMotion
         Flipping
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum TorqueFilterMode
     {
         ApplyEveryBullet,
@@ -66,12 +74,14 @@ namespace GTA.NaturalMotion
         ApplyIfSpinDifferent
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum RbTwistAxis
     {
         WorldUp,
         CharacterComUp
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum WeaponMode
     {
         None = -1,
@@ -83,12 +93,14 @@ namespace GTA.NaturalMotion
         PistolRight
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum Hand
     {
         Left,
         Right
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum MirrorMode
     {
         Independant,
@@ -96,6 +108,7 @@ namespace GTA.NaturalMotion
         Parallel
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum AdaptiveMode
     {
         NotAdaptive,
@@ -104,6 +117,7 @@ namespace GTA.NaturalMotion
         DirectionSpeedAndStrength
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ActivePoseHelper : CustomHelper
     {
         /// <summary>
@@ -145,6 +159,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ApplyImpulseHelper : CustomHelper
     {
         /// <summary>
@@ -265,6 +280,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ApplyBulletImpulseHelper : CustomHelper
     {
         /// <summary>
@@ -392,6 +408,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// Set the amount of relaxation across the whole body; Used to collapse the character into a rag-doll-like state.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class BodyRelaxHelper : CustomHelper
     {
         /// <summary>
@@ -493,6 +510,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// This single message allows you to configure various parameters used on any behavior that uses the dynamic balance.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ConfigureBalanceHelper : CustomHelper
     {
         /// <summary>
@@ -1899,6 +1917,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// Reset the values configurable by the Configure Balance message to their defaults.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ConfigureBalanceResetHelper : CustomHelper
     {
         /// <summary>
@@ -1916,6 +1935,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// This single message allows to configure self avoidance for the character.BBDD Self avoidance tech.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ConfigureSelfAvoidanceHelper : CustomHelper
     {
         /// <summary>
@@ -2089,6 +2109,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ConfigureBulletsHelper : CustomHelper
     {
         /// <summary>
@@ -3402,6 +3423,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ConfigureBulletsExtraHelper : CustomHelper
     {
         /// <summary>
@@ -4629,6 +4651,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// Enable/disable/edit character limits in real time.  This adjusts limits in RAGE-native space and will *not* reorient the joint.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ConfigureLimitsHelper : CustomHelper
     {
         /// <summary>
@@ -4820,6 +4843,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ConfigureSoftLimitHelper : CustomHelper
     {
         /// <summary>
@@ -4982,6 +5006,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// This single message allows you to configure the injured arm reaction during shot.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ConfigureShotInjuredArmHelper : CustomHelper
     {
         /// <summary>
@@ -5241,6 +5266,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// This single message allows you to configure the injured leg reaction during shot.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ConfigureShotInjuredLegHelper : CustomHelper
     {
         /// <summary>
@@ -5504,6 +5530,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class DefineAttachedObjectHelper : CustomHelper
     {
         /// <summary>
@@ -5575,6 +5602,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// Apply an impulse to a named body part.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ForceToBodyPartHelper : CustomHelper
     {
         /// <summary>
@@ -5639,6 +5667,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class LeanInDirectionHelper : CustomHelper
     {
         /// <summary>
@@ -5688,6 +5717,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class LeanRandomHelper : CustomHelper
     {
         /// <summary>
@@ -5803,6 +5833,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class LeanToPositionHelper : CustomHelper
     {
         /// <summary>
@@ -5851,6 +5882,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class LeanTowardsObjectHelper : CustomHelper
     {
         /// <summary>
@@ -5942,6 +5974,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class HipsLeanInDirectionHelper : CustomHelper
     {
         /// <summary>
@@ -5991,6 +6024,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class HipsLeanRandomHelper : CustomHelper
     {
         /// <summary>
@@ -6106,6 +6140,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class HipsLeanToPositionHelper : CustomHelper
     {
         /// <summary>
@@ -6154,6 +6189,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class HipsLeanTowardsObjectHelper : CustomHelper
     {
         /// <summary>
@@ -6245,6 +6281,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ForceLeanInDirectionHelper : CustomHelper
     {
         /// <summary>
@@ -6320,6 +6357,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ForceLeanRandomHelper : CustomHelper
     {
         /// <summary>
@@ -6461,6 +6499,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ForceLeanToPositionHelper : CustomHelper
     {
         /// <summary>
@@ -6535,6 +6574,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ForceLeanTowardsObjectHelper : CustomHelper
     {
         /// <summary>
@@ -6655,6 +6695,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// Use this message to manually set the body stiffness values -before using Active Pose to drive to an animated pose, for example.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class SetStiffnessHelper : CustomHelper
     {
         /// <summary>
@@ -6735,6 +6776,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// Use this message to manually set the muscle stiffness values -before using Active Pose to drive to an animated pose, for example.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class SetMuscleStiffnessHelper : CustomHelper
     {
         /// <summary>
@@ -6789,6 +6831,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// Use this message to set the character's weapon mode.  This is an alternativeto the setWeaponMode public function.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class SetWeaponModeHelper : CustomHelper
     {
         /// <summary>
@@ -6816,6 +6859,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// Use this message to register weapon.  This is an alternativeto the registerWeapon public function.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class RegisterWeaponHelper : CustomHelper
     {
         /// <summary>
@@ -6950,6 +6994,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ShotRelaxHelper : CustomHelper
     {
         /// <summary>
@@ -7016,6 +7061,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// One shot message apply a force to the hand as we fire the gun that should be in this hand.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class FireWeaponHelper : CustomHelper
     {
         /// <summary>
@@ -7144,6 +7190,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// One shot to give state of constraints on character and response to constraints.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ConfigureConstraintsHelper : CustomHelper
     {
         /// <summary>
@@ -7263,6 +7310,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class StayUprightHelper : CustomHelper
     {
         /// <summary>
@@ -7915,6 +7963,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// Send this message to immediately stop all behaviors from executing.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class StopAllBehavioursHelper : CustomHelper
     {
         /// <summary>
@@ -7932,6 +7981,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// Sets character's strength on the dead-granny-to-healthy-terminator scale: [0..1].
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class SetCharacterStrengthHelper : CustomHelper
     {
         /// <summary>
@@ -7975,6 +8025,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// Sets character's health on the dead-to-alive scale: [0..1].
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class SetCharacterHealthHelper : CustomHelper
     {
         /// <summary>
@@ -8018,6 +8069,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// Sets the type of reaction if catchFall is called.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class SetFallingReactionHelper : CustomHelper
     {
         /// <summary>
@@ -8440,6 +8492,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// Sets viscosity applied to damping limbs.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class SetCharacterUnderwaterHelper : CustomHelper
     {
         /// <summary>
@@ -8557,6 +8610,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// SetCharacterCollisions:.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class SetCharacterCollisionsHelper : CustomHelper
     {
         /// <summary>
@@ -8713,6 +8767,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// Damp out cartwheeling and somersaulting above a certain threshold.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class SetCharacterDampingHelper : CustomHelper
     {
         /// <summary>
@@ -8871,6 +8926,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// SetFrictionScale:.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class SetFrictionScaleHelper : CustomHelper
     {
         /// <summary>
@@ -8974,6 +9030,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class AnimPoseHelper : CustomHelper
     {
         /// <summary>
@@ -9795,6 +9852,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ArmsWindmillHelper : CustomHelper
     {
         /// <summary>
@@ -10409,6 +10467,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ArmsWindmillAdaptiveHelper : CustomHelper
     {
         /// <summary>
@@ -10756,6 +10815,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class BalancerCollisionsReactionHelper : CustomHelper
     {
         /// <summary>
@@ -11717,6 +11777,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class BodyBalanceHelper : CustomHelper
     {
         /// <summary>
@@ -12925,6 +12986,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class BodyFoetalHelper : CustomHelper
     {
         /// <summary>
@@ -13071,6 +13133,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class BodyRollUpHelper : CustomHelper
     {
         /// <summary>
@@ -13364,6 +13427,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class BodyWritheHelper : CustomHelper
     {
         /// <summary>
@@ -14038,6 +14102,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class BraceForImpactHelper : CustomHelper
     {
         /// <summary>
@@ -15058,6 +15123,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// Simple buoyancy model.  No character movement just fluid forces/torques added to parts.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class BuoyancyHelper : CustomHelper
     {
         /// <summary>
@@ -15206,6 +15272,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class CatchFallHelper : CustomHelper
     {
         /// <summary>
@@ -15421,6 +15488,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ElectrocuteHelper : CustomHelper
     {
         /// <summary>
@@ -15843,6 +15911,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class FallOverWallHelper : CustomHelper
     {
         /// <summary>
@@ -16447,6 +16516,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class GrabHelper : CustomHelper
     {
         /// <summary>
@@ -17161,6 +17231,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class HeadLookHelper : CustomHelper
     {
         /// <summary>
@@ -17322,6 +17393,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class HighFallHelper : CustomHelper
     {
         /// <summary>
@@ -18145,6 +18217,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class IncomingTransformsHelper : CustomHelper
     {
         /// <summary>
@@ -18159,6 +18232,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// InjuredOnGround.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class InjuredOnGroundHelper : CustomHelper
     {
         /// <summary>
@@ -18324,6 +18398,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// Carried.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class CarriedHelper : CustomHelper
     {
         /// <summary>
@@ -18341,6 +18416,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// Dangle.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class DangleHelper : CustomHelper
     {
         /// <summary>
@@ -18390,6 +18466,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class OnFireHelper : CustomHelper
     {
         /// <summary>
@@ -18778,6 +18855,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class PedalLegsHelper : CustomHelper
     {
         /// <summary>
@@ -19231,6 +19309,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// BEHAVIOURS REFERENCED: AnimPose - allows animPose to override body parts: Arms (useLeftArm, useRightArm).
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class PointArmHelper : CustomHelper
     {
         /// <summary>
@@ -19607,6 +19686,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class PointGunHelper : CustomHelper
     {
         /// <summary>
@@ -20952,6 +21032,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// Seldom set parameters for pointGun - just to keep number of parameters in any message less than or equal to 64.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class PointGunExtraHelper : CustomHelper
     {
         /// <summary>
@@ -21179,6 +21260,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class RollDownStairsHelper : CustomHelper
     {
         /// <summary>
@@ -21881,6 +21963,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ShotHelper : CustomHelper
     {
         /// <summary>
@@ -23118,6 +23201,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// Send new wound information to the shot.  Can cause shot to restart it's performance in part or in whole.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ShotNewBulletHelper : CustomHelper
     {
         /// <summary>
@@ -23207,6 +23291,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ShotSnapHelper : CustomHelper
     {
         /// <summary>
@@ -23576,6 +23661,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// Configure the shockSpin effect in shot.  Spin/Lift the character using cheat torques/forces.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ShotShockSpinHelper : CustomHelper
     {
         /// <summary>
@@ -23897,6 +23983,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// Configure the fall to knees shot.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ShotFallToKneesHelper : CustomHelper
     {
         /// <summary>
@@ -24449,6 +24536,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// Configure the shot from behind reaction.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ShotFromBehindHelper : CustomHelper
     {
         /// <summary>
@@ -24740,6 +24828,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// Configure the shot in guts reaction.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ShotInGutsHelper : CustomHelper
     {
         /// <summary>
@@ -24947,6 +25036,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ShotHeadLookHelper : CustomHelper
     {
         /// <summary>
@@ -25089,6 +25179,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// Configure the arm reactions in shot.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ShotConfigureArmsHelper : CustomHelper
     {
         /// <summary>
@@ -25922,6 +26013,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// Clone of High Fall with a wider range of operating conditions.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class SmartFallHelper : CustomHelper
     {
         /// <summary>
@@ -27178,6 +27270,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class StaggerFallHelper : CustomHelper
     {
         /// <summary>
@@ -28209,6 +28302,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class TeeterHelper : CustomHelper
     {
         /// <summary>
@@ -28392,6 +28486,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class UpperBodyFlinchHelper : CustomHelper
     {
         /// <summary>
@@ -28712,6 +28807,7 @@ namespace GTA.NaturalMotion
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class YankedHelper : CustomHelper
     {
         /// <summary>

--- a/source/scripting_v2/GTA.NaturalMotion/Message.cs
+++ b/source/scripting_v2/GTA.NaturalMotion/Message.cs
@@ -14,6 +14,7 @@ namespace GTA.NaturalMotion
     /// <summary>
     /// A base class for manually building a NaturalMotion Euphoria message.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public class Message
     {
         #region Fields

--- a/source/scripting_v2/GTA/Audio.cs
+++ b/source/scripting_v2/GTA/Audio.cs
@@ -5,9 +5,11 @@
 
 using GTA.Math;
 using GTA.Native;
+using System;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public static class Audio
     {
         public static int PlaySoundAt(Entity entity, string soundFile)

--- a/source/scripting_v2/GTA/AudioFlag.cs
+++ b/source/scripting_v2/GTA/AudioFlag.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum AudioFlag
     {
         ActivateSwitchWheelAudio,

--- a/source/scripting_v2/GTA/Blip.cs
+++ b/source/scripting_v2/GTA/Blip.cs
@@ -9,6 +9,7 @@ using System;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class Blip : IEquatable<Blip>, IHandleable
     {
         public Blip(int handle)

--- a/source/scripting_v2/GTA/BlipColor.cs
+++ b/source/scripting_v2/GTA/BlipColor.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum BlipColor
     {
         /// <summary>

--- a/source/scripting_v2/GTA/BlipSprite.cs
+++ b/source/scripting_v2/GTA/BlipSprite.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum BlipSprite
     {
         /// <summary>

--- a/source/scripting_v2/GTA/Camera.cs
+++ b/source/scripting_v2/GTA/Camera.cs
@@ -9,6 +9,7 @@ using System;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class Camera : IEquatable<Camera>, IHandleable, ISpatial
     {
         internal static readonly string[] s_shakeNames = {

--- a/source/scripting_v2/GTA/CameraShake.cs
+++ b/source/scripting_v2/GTA/CameraShake.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum CameraShake
     {
         Hand,

--- a/source/scripting_v2/GTA/Control.cs
+++ b/source/scripting_v2/GTA/Control.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum Control
     {
         NextCamera,

--- a/source/scripting_v2/GTA/Entities/Entity.cs
+++ b/source/scripting_v2/GTA/Entities/Entity.cs
@@ -19,6 +19,7 @@ namespace GTA
     /// that can work only with physical entities (`<c>CPhysical</c>`s) but not with non-physical entities such as
     /// buildings (`<c>CBuilding</c>`s).
     /// </remarks>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public abstract class Entity : IEquatable<Entity>, IHandleable, ISpatial
     {
         public Entity(int handle)

--- a/source/scripting_v2/GTA/Entities/Model.cs
+++ b/source/scripting_v2/GTA/Entities/Model.cs
@@ -9,6 +9,7 @@ using System;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public struct Model : IEquatable<Model>
     {
         public Model(int hash)

--- a/source/scripting_v2/GTA/Entities/Peds/AnimationFlags.cs
+++ b/source/scripting_v2/GTA/Entities/Peds/AnimationFlags.cs
@@ -8,6 +8,7 @@ using System;
 namespace GTA
 {
     [Flags]
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum AnimationFlags
     {
         None = 0,

--- a/source/scripting_v2/GTA/Entities/Peds/Bone.cs
+++ b/source/scripting_v2/GTA/Entities/Peds/Bone.cs
@@ -3,11 +3,14 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
     /// <summary>
     /// An enumeration of possible bone tag values for <see cref="Ped"/>, which is for <c>eAnimBoneTag</c>.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum Bone
     {
         SKEL_ROOT = 0x0,

--- a/source/scripting_v2/GTA/Entities/Peds/DrivingStyle.cs
+++ b/source/scripting_v2/GTA/Entities/Peds/DrivingStyle.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum DrivingStyle
     {
         Normal = 0xC00AB,

--- a/source/scripting_v2/GTA/Entities/Peds/FiringPattern.cs
+++ b/source/scripting_v2/GTA/Entities/Peds/FiringPattern.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum FiringPattern : uint
     {
         Default = 0,

--- a/source/scripting_v2/GTA/Entities/Peds/FormationType.cs
+++ b/source/scripting_v2/GTA/Entities/Peds/FormationType.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum FormationType
     {
         Default,

--- a/source/scripting_v2/GTA/Entities/Peds/Gender.cs
+++ b/source/scripting_v2/GTA/Entities/Peds/Gender.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum Gender
     {
         Male,

--- a/source/scripting_v2/GTA/Entities/Peds/HelmetType.cs
+++ b/source/scripting_v2/GTA/Entities/Peds/HelmetType.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum HelmetType : uint
     {
         RegularMotorcycleHelmet = 4096,

--- a/source/scripting_v2/GTA/Entities/Peds/LeaveVehicleFlags.cs
+++ b/source/scripting_v2/GTA/Entities/Peds/LeaveVehicleFlags.cs
@@ -8,6 +8,7 @@ using System;
 namespace GTA
 {
     [Flags]
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum LeaveVehicleFlags
     {
         None = 0,

--- a/source/scripting_v2/GTA/Entities/Peds/Ped.cs
+++ b/source/scripting_v2/GTA/Entities/Peds/Ped.cs
@@ -10,6 +10,7 @@ using System;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class Ped : Entity
     {
         #region Fields

--- a/source/scripting_v2/GTA/Entities/Peds/PedGroup.cs
+++ b/source/scripting_v2/GTA/Entities/Peds/PedGroup.cs
@@ -10,8 +10,10 @@ using System.Collections.Generic;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public class PedGroup : IEquatable<PedGroup>, IEnumerable<Ped>, IHandleable, IDisposable
     {
+        [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
         public class enumerator : IEnumerator<Ped>
         {
             #region Fields

--- a/source/scripting_v2/GTA/Entities/Peds/Relationship.cs
+++ b/source/scripting_v2/GTA/Entities/Peds/Relationship.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum Relationship
     {
         Hate = 5,

--- a/source/scripting_v2/GTA/Entities/Peds/TaskSequence.cs
+++ b/source/scripting_v2/GTA/Entities/Peds/TaskSequence.cs
@@ -13,6 +13,7 @@ namespace GTA
     /// After you create a <see cref="TaskSequence"/> instance, call <see cref="AddTask"/> as many as you want and call <see cref="Close()"/> or <see cref="Close(bool)"/>
     /// right after the instance creation statement.
     /// </summary>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class TaskSequence : IDisposable
     {
         #region Fields

--- a/source/scripting_v2/GTA/Entities/Peds/Tasks.cs
+++ b/source/scripting_v2/GTA/Entities/Peds/Tasks.cs
@@ -9,6 +9,7 @@ using System;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class Tasks
     {
         private Ped _ped;

--- a/source/scripting_v2/GTA/Entities/Prop.cs
+++ b/source/scripting_v2/GTA/Entities/Prop.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class Prop : Entity
     {
         public Prop(int handle) : base(handle)

--- a/source/scripting_v2/GTA/Entities/Vehicles/CargobobHook.cs
+++ b/source/scripting_v2/GTA/Entities/Vehicles/CargobobHook.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum CargobobHook
     {
         Hook,

--- a/source/scripting_v2/GTA/Entities/Vehicles/NumberPlateMounting.cs
+++ b/source/scripting_v2/GTA/Entities/Vehicles/NumberPlateMounting.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum NumberPlateMounting
     {
         FrontAndRear = 0,

--- a/source/scripting_v2/GTA/Entities/Vehicles/NumberPlateType.cs
+++ b/source/scripting_v2/GTA/Entities/Vehicles/NumberPlateType.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum NumberPlateType
     {
         BlueOnWhite1 = 0,

--- a/source/scripting_v2/GTA/Entities/Vehicles/Vehicle.cs
+++ b/source/scripting_v2/GTA/Entities/Vehicles/Vehicle.cs
@@ -11,6 +11,7 @@ using System.Drawing;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class Vehicle : Entity
     {
         public Vehicle(int handle) : base(handle)

--- a/source/scripting_v2/GTA/Entities/Vehicles/VehicleClass.cs
+++ b/source/scripting_v2/GTA/Entities/Vehicles/VehicleClass.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum VehicleClass
     {
         Compacts,

--- a/source/scripting_v2/GTA/Entities/Vehicles/VehicleColor.cs
+++ b/source/scripting_v2/GTA/Entities/Vehicles/VehicleColor.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum VehicleColor
     {
         MetallicBlack,

--- a/source/scripting_v2/GTA/Entities/Vehicles/VehicleDoor.cs
+++ b/source/scripting_v2/GTA/Entities/Vehicles/VehicleDoor.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum VehicleDoor
     {
         FrontRightDoor = 1,

--- a/source/scripting_v2/GTA/Entities/Vehicles/VehicleLandingGear.cs
+++ b/source/scripting_v2/GTA/Entities/Vehicles/VehicleLandingGear.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum VehicleLandingGear
     {
         Deployed = 0,

--- a/source/scripting_v2/GTA/Entities/Vehicles/VehicleLockStatus.cs
+++ b/source/scripting_v2/GTA/Entities/Vehicles/VehicleLockStatus.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum VehicleLockStatus
     {
         None,

--- a/source/scripting_v2/GTA/Entities/Vehicles/VehicleMod.cs
+++ b/source/scripting_v2/GTA/Entities/Vehicles/VehicleMod.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum VehicleMod
     {
         Spoilers = 0,

--- a/source/scripting_v2/GTA/Entities/Vehicles/VehicleNeonLight.cs
+++ b/source/scripting_v2/GTA/Entities/Vehicles/VehicleNeonLight.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum VehicleNeonLight
     {
         Left,

--- a/source/scripting_v2/GTA/Entities/Vehicles/VehicleRoofState.cs
+++ b/source/scripting_v2/GTA/Entities/Vehicles/VehicleRoofState.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum VehicleRoofState
     {
         Closed,

--- a/source/scripting_v2/GTA/Entities/Vehicles/VehicleSeat.cs
+++ b/source/scripting_v2/GTA/Entities/Vehicles/VehicleSeat.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum VehicleSeat
     {
         None = -3,

--- a/source/scripting_v2/GTA/Entities/Vehicles/VehicleToggleMod.cs
+++ b/source/scripting_v2/GTA/Entities/Vehicles/VehicleToggleMod.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum VehicleToggleMod
     {
         Turbo = 18,

--- a/source/scripting_v2/GTA/Entities/Vehicles/VehicleWheelType.cs
+++ b/source/scripting_v2/GTA/Entities/Vehicles/VehicleWheelType.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum VehicleWheelType
     {
         Stock = -1,

--- a/source/scripting_v2/GTA/Entities/Vehicles/VehicleWindow.cs
+++ b/source/scripting_v2/GTA/Entities/Vehicles/VehicleWindow.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum VehicleWindow
     {
         FrontLeftWindow,

--- a/source/scripting_v2/GTA/Entities/Vehicles/VehicleWindowTint.cs
+++ b/source/scripting_v2/GTA/Entities/Vehicles/VehicleWindowTint.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum VehicleWindowTint
     {
         None,

--- a/source/scripting_v2/GTA/ExplosionType.cs
+++ b/source/scripting_v2/GTA/ExplosionType.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum ExplosionType
     {
         Grenade,

--- a/source/scripting_v2/GTA/Font.cs
+++ b/source/scripting_v2/GTA/Font.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum Font
     {
         ChaletLondon,

--- a/source/scripting_v2/GTA/ForceType.cs
+++ b/source/scripting_v2/GTA/ForceType.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum ForceType
     {
         MinForce,

--- a/source/scripting_v2/GTA/Game.cs
+++ b/source/scripting_v2/GTA/Game.cs
@@ -11,6 +11,7 @@ using System.Windows.Forms;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public static class Game
     {
         #region Fields

--- a/source/scripting_v2/GTA/GameVersion.cs
+++ b/source/scripting_v2/GTA/GameVersion.cs
@@ -3,6 +3,8 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
     /// <summary>
@@ -16,6 +18,7 @@ namespace GTA
     /// compare <see cref="Game.Version"/> with the internal value of <see cref="VER_1_0_2060_0_STEAM"/>, which is
     /// <c>60</c>.
     /// </remarks>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum GameVersion
     {
         Unknown = 0,

--- a/source/scripting_v2/GTA/GameplayCamera.cs
+++ b/source/scripting_v2/GTA/GameplayCamera.cs
@@ -5,9 +5,11 @@
 
 using GTA.Math;
 using GTA.Native;
+using System;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public static class GameplayCamera
     {
         public static Vector3 Position => Function.Call<Vector3>(Hash.GET_GAMEPLAY_CAM_COORD);

--- a/source/scripting_v2/GTA/Global.cs
+++ b/source/scripting_v2/GTA/Global.cs
@@ -10,6 +10,7 @@ using GTA.Math;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public unsafe struct Global
     {
         private readonly IntPtr _address;

--- a/source/scripting_v2/GTA/GlobalCollection.cs
+++ b/source/scripting_v2/GTA/GlobalCollection.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public class GlobalCollection
     {
         internal GlobalCollection()

--- a/source/scripting_v2/GTA/Handleable.cs
+++ b/source/scripting_v2/GTA/Handleable.cs
@@ -4,9 +4,11 @@
 //
 
 using GTA.Math;
+using System;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public interface ISpatial
     {
         Vector3 Position
@@ -19,6 +21,7 @@ namespace GTA
         }
     }
 
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public interface IHandleable
     {
         int Handle { get; }

--- a/source/scripting_v2/GTA/HudComponent.cs
+++ b/source/scripting_v2/GTA/HudComponent.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum HudComponent
     {
         WantedStars = 1,

--- a/source/scripting_v2/GTA/InputMode.cs
+++ b/source/scripting_v2/GTA/InputMode.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum InputMode
     {
         MouseAndKeyboard,

--- a/source/scripting_v2/GTA/IntersectOptions.cs
+++ b/source/scripting_v2/GTA/IntersectOptions.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum IntersectOptions
     {
         Everything = -1,

--- a/source/scripting_v2/GTA/Language.cs
+++ b/source/scripting_v2/GTA/Language.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum Language
     {
         American,

--- a/source/scripting_v2/GTA/MarkerType.cs
+++ b/source/scripting_v2/GTA/MarkerType.cs
@@ -3,6 +3,8 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
     /// <summary>
@@ -12,6 +14,7 @@ namespace GTA
     /// You can find hardcoded model names that code for marker uses to draw markers, such as "<c>PROP_MK_CONE</c>",
     /// in the exe.
     /// </remarks>
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum MarkerType
     {
         /// <summary>

--- a/source/scripting_v2/GTA/MenuBase.cs
+++ b/source/scripting_v2/GTA/MenuBase.cs
@@ -4,9 +4,11 @@
 //
 
 using System.Drawing;
+using System;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public class MenuBase
     {
         /** Draws the menu */

--- a/source/scripting_v2/GTA/MenuItem.cs
+++ b/source/scripting_v2/GTA/MenuItem.cs
@@ -4,9 +4,11 @@
 //
 
 using System.Drawing;
+using System;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public interface IMenuItem
     {
         /** Called when the MenuItem should be drawn */

--- a/source/scripting_v2/GTA/MenuItemDoubleValueArgs.cs
+++ b/source/scripting_v2/GTA/MenuItemDoubleValueArgs.cs
@@ -7,6 +7,7 @@ using System;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public class MenuItemDoubleValueArgs : EventArgs
     {
         public MenuItemDoubleValueArgs(double value)

--- a/source/scripting_v2/GTA/MenuItemIndexArgs.cs
+++ b/source/scripting_v2/GTA/MenuItemIndexArgs.cs
@@ -7,6 +7,7 @@ using System;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public class MenuItemIndexArgs : EventArgs
     {
         public MenuItemIndexArgs(int index)

--- a/source/scripting_v2/GTA/Notification.cs
+++ b/source/scripting_v2/GTA/Notification.cs
@@ -4,9 +4,11 @@
 //
 
 using GTA.Native;
+using System;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class Notification
     {
         private readonly int _handle;

--- a/source/scripting_v2/GTA/ParachuteTint.cs
+++ b/source/scripting_v2/GTA/ParachuteTint.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum ParachuteTint
     {
         None = -1,

--- a/source/scripting_v2/GTA/Pickup.cs
+++ b/source/scripting_v2/GTA/Pickup.cs
@@ -9,6 +9,7 @@ using System;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class Pickup : IEquatable<Pickup>, IHandleable
     {
         public Pickup(int handle)

--- a/source/scripting_v2/GTA/PickupType.cs
+++ b/source/scripting_v2/GTA/PickupType.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum PickupType : uint
     {
         CustomScript = 738282662u,

--- a/source/scripting_v2/GTA/Player.cs
+++ b/source/scripting_v2/GTA/Player.cs
@@ -10,6 +10,7 @@ using System.Drawing;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class Player : IEquatable<Player>, IHandleable
     {
         #region Fields

--- a/source/scripting_v2/GTA/RadioStation.cs
+++ b/source/scripting_v2/GTA/RadioStation.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum RadioStation
     {
         Unknown = -1,

--- a/source/scripting_v2/GTA/RaycastResult.cs
+++ b/source/scripting_v2/GTA/RaycastResult.cs
@@ -5,9 +5,11 @@
 
 using GTA.Math;
 using GTA.Native;
+using System;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public struct RaycastResult
     {
         internal RaycastResult(int handle)

--- a/source/scripting_v2/GTA/RequireScript.cs
+++ b/source/scripting_v2/GTA/RequireScript.cs
@@ -8,6 +8,7 @@ using System;
 namespace GTA
 {
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class RequireScript : Attribute
     {
         public RequireScript(Type dependency)

--- a/source/scripting_v2/GTA/Rope.cs
+++ b/source/scripting_v2/GTA/Rope.cs
@@ -9,6 +9,7 @@ using System;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class Rope : IEquatable<Rope>, IHandleable
     {
         public Rope(int handle)

--- a/source/scripting_v2/GTA/RopeType.cs
+++ b/source/scripting_v2/GTA/RopeType.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum RopeType
     {
         Normal = 4,

--- a/source/scripting_v2/GTA/Scaleform.cs
+++ b/source/scripting_v2/GTA/Scaleform.cs
@@ -10,6 +10,7 @@ using System.Drawing;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class Scaleform : IDisposable
     {
         private string _scaleformId;

--- a/source/scripting_v2/GTA/ScaleformArgumentTXD.cs
+++ b/source/scripting_v2/GTA/ScaleformArgumentTXD.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ScaleformArgumentTXD
     {
         internal string _txd;

--- a/source/scripting_v2/GTA/Script.cs
+++ b/source/scripting_v2/GTA/Script.cs
@@ -9,6 +9,7 @@ using System.Windows.Forms;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public abstract class Script : IDisposable
     {
         #region Fields

--- a/source/scripting_v2/GTA/ScriptSettings.cs
+++ b/source/scripting_v2/GTA/ScriptSettings.cs
@@ -9,6 +9,7 @@ using System.IO;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class ScriptSettings
     {
         #region Fields

--- a/source/scripting_v2/GTA/SelectedIndexChangedArgs.cs
+++ b/source/scripting_v2/GTA/SelectedIndexChangedArgs.cs
@@ -7,6 +7,7 @@ using System;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public class SelectedIndexChangedArgs : EventArgs
     {
         public SelectedIndexChangedArgs(int selectedIndex)

--- a/source/scripting_v2/GTA/UI.cs
+++ b/source/scripting_v2/GTA/UI.cs
@@ -8,9 +8,11 @@ using GTA.Native;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
+using System;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public static class UI
     {
         // These two definitions need to have 'modopt(System.Runtime.CompilerServices.IsConst)'.

--- a/source/scripting_v2/GTA/UIContainer.cs
+++ b/source/scripting_v2/GTA/UIContainer.cs
@@ -5,9 +5,11 @@
 
 using System.Collections.Generic;
 using System.Drawing;
+using System;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public class UIContainer : UIRectangle
     {
         public UIContainer() : base()

--- a/source/scripting_v2/GTA/UIElement.cs
+++ b/source/scripting_v2/GTA/UIElement.cs
@@ -4,9 +4,11 @@
 //
 
 using System.Drawing;
+using System;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public interface UIElement
     {
         void Draw();

--- a/source/scripting_v2/GTA/UIRectangle.cs
+++ b/source/scripting_v2/GTA/UIRectangle.cs
@@ -5,9 +5,11 @@
 
 using GTA.Native;
 using System.Drawing;
+using System;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public class UIRectangle : UIElement
     {
         public UIRectangle() : this(new Point(), new Size(UI.WIDTH, UI.HEIGHT), Color.Transparent)

--- a/source/scripting_v2/GTA/UISprite.cs
+++ b/source/scripting_v2/GTA/UISprite.cs
@@ -9,6 +9,7 @@ using System.Drawing;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public class UISprite : UIElement, IDisposable
     {
         private readonly string _textureDict;

--- a/source/scripting_v2/GTA/UIText.cs
+++ b/source/scripting_v2/GTA/UIText.cs
@@ -5,9 +5,11 @@
 
 using GTA.Native;
 using System.Drawing;
+using System;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public class UIText : UIElement
     {
         public UIText(string caption, Point position, float scale) : this(caption, position, scale, Color.WhiteSmoke, Font.ChaletLondon, false, false, false)

--- a/source/scripting_v2/GTA/Viewport.cs
+++ b/source/scripting_v2/GTA/Viewport.cs
@@ -5,9 +5,11 @@
 
 using System.Drawing;
 using System.Collections.Generic;
+using System;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class Viewport
     {
         public Viewport()

--- a/source/scripting_v2/GTA/Weapons/Weapon.cs
+++ b/source/scripting_v2/GTA/Weapons/Weapon.cs
@@ -5,9 +5,11 @@
 
 using GTA.Native;
 using System.Linq;
+using System;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class Weapon
     {
         #region Fields

--- a/source/scripting_v2/GTA/Weapons/WeaponAsset.cs
+++ b/source/scripting_v2/GTA/Weapons/WeaponAsset.cs
@@ -8,6 +8,7 @@ using System;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public struct WeaponAsset : IEquatable<WeaponAsset>
     {
         public WeaponAsset(int weaponHash) : this()

--- a/source/scripting_v2/GTA/Weapons/WeaponCollection.cs
+++ b/source/scripting_v2/GTA/Weapons/WeaponCollection.cs
@@ -5,9 +5,11 @@
 
 using GTA.Native;
 using System.Collections.Generic;
+using System;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public sealed class WeaponCollection
     {
         #region Fields

--- a/source/scripting_v2/GTA/Weapons/WeaponGroup.cs
+++ b/source/scripting_v2/GTA/Weapons/WeaponGroup.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum WeaponGroup : uint
     {
         Unarmed = 0xA00FC1E4,

--- a/source/scripting_v2/GTA/Weapons/WeaponTint.cs
+++ b/source/scripting_v2/GTA/Weapons/WeaponTint.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum WeaponTint
     {
         Normal,

--- a/source/scripting_v2/GTA/Weather.cs
+++ b/source/scripting_v2/GTA/Weather.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum Weather
     {
         Unknown = -1,

--- a/source/scripting_v2/GTA/WindowTitle.cs
+++ b/source/scripting_v2/GTA/WindowTitle.cs
@@ -3,8 +3,11 @@
 // License: https://github.com/scripthookvdotnet/scripthookvdotnet#license
 //
 
+using System;
+
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public enum WindowTitle
     {
         CELL_EMAIL_BOD,

--- a/source/scripting_v2/GTA/World.cs
+++ b/source/scripting_v2/GTA/World.cs
@@ -12,6 +12,7 @@ using System.Globalization;
 
 namespace GTA
 {
+    [Obsolete("The v2 API is deprecated, use the v3 API instead.")]
     public static class World
     {
         #region Fields


### PR DESCRIPTION
This PR adds the obsolete attribute to all public declarations of the v2 api excluding enum members.

This was auto generated so I can still change the message if requested, also if adding the tag to all public members is considered unwanted, I can change this to class, struct, and enum definitions only.
