### PR TITLE
feat(core): remove `WarnOfDeprecatedScriptsWithTicker` from .ini

### DIFF
--- a/ScriptHookVDotNet.ini
+++ b/ScriptHookVDotNet.ini
@@ -19,11 +19,6 @@ ScriptTimeoutThreshold=5000
 ; as a lot of scripts assume the script location to be "scripts".
 ScriptsLocation="scripts"
 
-; Specifies whether a warning feed post (notification) should be posted when SHVDN finds scripts
-; that is build against a deprecated version of scripting APIs.
-; Acceptable value: "true" or "false" (case-insensitive)
-WarnOfDeprecatedScriptsWithTicker=true
-
 ; Specifies whether the domain of SHVDN should auto load scripts in the scripts folder when the
 ; first game session is starting or SHVDN is reloading (recreating a new domain).
 ; If you encounter some compatibility issues such as nondeterministic game crashes (due to flaws


### PR DESCRIPTION
This is just a small addition to 3d63257 which removed `WarnOfDeprecatedScriptsWithTicker` from code.

Note:
@kagikn I'm not sure which scope to specify here but I think `core` fits the best here.