### PR TITLE
feat(api-v3): add getter to `Vehicle.IsHornEnabled`

### DIFF
--- a/source/core/NativeMemory.cs
+++ b/source/core/NativeMemory.cs
@@ -1717,6 +1717,11 @@ namespace SHVDN
 
             public static int FirstVehicleFlagsOffset { get; }
 
+            private static int AudVehicleAudioEntityOffset;
+
+            public static int AudVehicleAudioEntity__IsHornEnabledOffset;
+            public static int AudVehicleAudioEntity__IsHornEnabledBitTest;
+
             static Vehicle()
             {
                 byte* address;
@@ -1996,6 +2001,19 @@ namespace SHVDN
                     ShouldShowOnlyVehicleTiresWithPositiveHealthOffset = *(int*)(address + 2);
                 }
 
+                address = MemScanner.FindPatternBmh("\xCB\x1C\x4A\xC5\x49\x8B\x8D\x00\x00\x00\x00\x45\x33\xC9\x45\x33\xC0", "xxxxxxx????xxxxxx");
+                if (address != null)
+                {
+                    AudVehicleAudioEntityOffset = *(int*)(address + 0x7);
+                }
+
+                address = MemScanner.FindPatternBmh("\x0F\x28\xF9\x0F\x85\xFF\xFF\x00\x00\xF6\xFF\xFF\xFF\x00\x00\xFF\x0F\x84", "xxxxx??xxx???xx?xx");
+                if (address != null)
+                {
+                    AudVehicleAudioEntity__IsHornEnabledOffset = *(int*)(address + 0xB);
+                    AudVehicleAudioEntity__IsHornEnabledBitTest = *(byte*)(address + 0xF);
+                }
+
                 // Vehicle Wheels has the owner vehicle pointer and new wheel functions are used since b1365
                 if (gameVersion >= 40)
                 {
@@ -2146,6 +2164,26 @@ namespace SHVDN
                 return *(byte*)(vehicleModelAddress + ModelSirenIdOffset);
             }
 
+            public static bool IsHornEnabled(int vehicleHandle)
+            {
+                IntPtr address = GetEntityAddress(vehicleHandle);
+
+                if (address == IntPtr.Zero)
+                {
+                    return false;
+                }
+
+                if(AudVehicleAudioEntityOffset == 0 || AudVehicleAudioEntity__IsHornEnabledBitTest == 0 || AudVehicleAudioEntity__IsHornEnabledOffset == 0)
+                {
+                    return false;
+                }
+
+                IntPtr audVehicleAudioEntityAddress = *(IntPtr*)((byte*)address + AudVehicleAudioEntityOffset);
+
+                byte flags = *(byte*)((long)audVehicleAudioEntityAddress + AudVehicleAudioEntity__IsHornEnabledOffset);
+
+                return (flags & AudVehicleAudioEntity__IsHornEnabledBitTest) != 0;
+            }
             #endregion
 
             #region -- Vehicle Wheel Data --

--- a/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs
+++ b/source/scripting_v3/GTA/Entities/Vehicles/Vehicle.cs
@@ -1454,13 +1454,14 @@ namespace GTA
         }
 
         /// <summary>
-        /// Sets a value indicating whether this <see cref="Vehicle"/> has its horn enabled.
+        /// Gets or sets a value indicating whether this <see cref="Vehicle"/> has its horn enabled.
         /// </summary>
         /// <value>
         /// <see langword="true" /> if this <see cref="Vehicle"/> has its horn enabled; otherwise, <see langword="false" />.
         /// </value>
         public bool IsHornEnabled
         {
+            get => SHVDN.NativeMemory.Vehicle.IsHornEnabled(Handle);
             set => Function.Call(Hash.SET_HORN_ENABLED, Handle, value);
         }
 


### PR DESCRIPTION
This PR adds a getter to `IsHornEnabled` of `Vehicle`.

Note:
Both the bitfield offset and the corresponding bit have changed between versions.

Also I'm aware that I will have to resolve some merging conflicts because of the multiple pattern scanning PRs pushed.