### PR TITLE
feat(core): add catch exceptions when loading script domain

### DIFF
--- a/source/core/DllMain.cpp
+++ b/source/core/DllMain.cpp
@@ -597,7 +597,16 @@ static void ScriptHookVDotNet_ManagedInit()
     }
 
     // Create a separate script domain
-    domain = SHVDN::ScriptDomain::Load(".", scriptPath);
+    try
+    {
+        domain = SHVDN::ScriptDomain::Load(".", scriptPath);
+    }
+    catch (Exception^ ex)
+    {
+        SHVDN::Log::Message(SHVDN::Log::Level::Error, "Failed to load script domain: ", ex->ToString());
+        return;
+    }
+
     if (domain == nullptr)
         return;
 


### PR DESCRIPTION
This PR adds a try-catch around the loading of the ScriptDomain.
While the internal method also has a try-catch block, it does not cover the entire method body.
This acts as an attempt to find out what is going on with #1805 and #1807.

Both share that their log remains completely empty, as `ScriptHookVDotNet_ManagedInit` follows this sequence of tasks:

- Unload previous domain,
- Clear the log <-- This has to have run 
- Parse Config (exceptions are handled here)
- Load ScriptDomain (previously not fully handled for exceptions)
- Set up TLS functions
- Init NativeMemory


It is most likely that the script domain part causes errors.