### PR TITLE
fix(core): add fallback for invalid scripts path in config

### DIFF
--- a/source/core/DllMain.cpp
+++ b/source/core/DllMain.cpp
@@ -580,7 +580,20 @@ static void ScriptHookVDotNet_ManagedInit()
                 }
             }
             else if (String::Equals(keyStr, "ScriptsLocation", StringComparison::OrdinalIgnoreCase))
-                scriptPath = valueStr->Trim('"');
+            {
+                String^ path = valueStr->Trim('"');
+
+                try
+                {
+                    IO::Path::GetFullPath("./" + path);
+
+                    scriptPath = path;
+                }
+                catch (Exception^ ex)
+                {
+                    SHVDN::Log::Message(SHVDN::Log::Level::Error, "Invalid script path specified in config. Falling back to \"" + scriptPath + "\"");
+                }
+            }
             else if (String::Equals(keyStr, "AutoLoadScripts", StringComparison::OrdinalIgnoreCase))
             {
                 bool outVal;


### PR DESCRIPTION
While working on #1805, I found that any malformed script location from the config could crash the game; this PR validates the path itself without checking for existence. If the location is malformed, it does not update the original value. This is most likely not the cause of #1805.